### PR TITLE
feat: implement YAML config engine (Phase 1 P0)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
         "next": "^15.2.9",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "yaml": "^2.7.0"
+        "yaml": "^2.7.0",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.4",
@@ -8687,6 +8688,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "next": "^15.2.9",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "yaml": "^2.7.0"
+    "yaml": "^2.7.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.4",

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("node:fs");
+
+import { readFileSync, writeFileSync } from "node:fs";
+import {
+  loadConfig,
+  getConfig,
+  writeConfig,
+  invalidateCache,
+} from "../config/loader";
+
+const VALID_YAML = `
+schema_version: 1
+auth:
+  enabled: false
+  session_ttl_hours: 24
+appearance:
+  theme: dark
+layout:
+  columns: 4
+  row_height: 120
+services: []
+widgets: []
+`.trim();
+
+describe("loadConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateCache();
+    vi.mocked(readFileSync).mockReturnValue(VALID_YAML);
+  });
+
+  it("parses a valid settings.yaml", () => {
+    const config = loadConfig();
+    expect(config.schema_version).toBe(1);
+    expect(config.auth.enabled).toBe(false);
+    expect(config.auth.session_ttl_hours).toBe(24);
+    expect(config.appearance.theme).toBe("dark");
+    expect(config.layout.columns).toBe(4);
+    expect(config.layout.row_height).toBe(120);
+    expect(config.services).toEqual([]);
+    expect(config.widgets).toEqual([]);
+  });
+
+  it("applies defaults when optional sections are missing", () => {
+    vi.mocked(readFileSync).mockReturnValue("schema_version: 1");
+    const config = loadConfig();
+    expect(config.auth.enabled).toBe(false);
+    expect(config.auth.session_ttl_hours).toBe(24);
+    expect(config.appearance.theme).toBe("dark");
+    expect(config.layout.columns).toBe(4);
+    expect(config.layout.row_height).toBe(120);
+    expect(config.services).toEqual([]);
+    expect(config.widgets).toEqual([]);
+  });
+
+  it("throws a formatted error with field path for an invalid theme value", () => {
+    vi.mocked(readFileSync).mockReturnValue(
+      "schema_version: 1\nappearance:\n  theme: purple"
+    );
+    expect(() => loadConfig()).toThrow("appearance.theme");
+  });
+
+  it("throws a formatted error with field path for an invalid service URL", () => {
+    vi.mocked(readFileSync).mockReturnValue(
+      "schema_version: 1\nservices:\n  - name: Test\n    url: not-a-url"
+    );
+    expect(() => loadConfig()).toThrow("services");
+  });
+
+  it("error message begins with 'Invalid settings.yaml'", () => {
+    vi.mocked(readFileSync).mockReturnValue(
+      "schema_version: 1\nappearance:\n  theme: purple"
+    );
+    expect(() => loadConfig()).toThrow(/^Invalid settings\.yaml/);
+  });
+});
+
+describe("getConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateCache();
+    vi.mocked(readFileSync).mockReturnValue(VALID_YAML);
+  });
+
+  it("caches the result — file is only read once across multiple calls", () => {
+    loadConfig();
+    getConfig();
+    getConfig();
+    expect(readFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("loads on first call if cache is empty", () => {
+    getConfig();
+    expect(readFileSync).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-reads after invalidateCache()", () => {
+    loadConfig();
+    invalidateCache();
+    vi.clearAllMocks();
+    vi.mocked(readFileSync).mockReturnValue(VALID_YAML);
+    getConfig();
+    expect(readFileSync).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("writeConfig", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    invalidateCache();
+    vi.mocked(readFileSync).mockReturnValue(VALID_YAML);
+    vi.mocked(writeFileSync).mockImplementation(() => undefined);
+  });
+
+  it("writes updated values back to the file", () => {
+    writeConfig({ appearance: { theme: "light" } });
+    expect(writeFileSync).toHaveBeenCalledTimes(1);
+    const written = vi.mocked(writeFileSync).mock.calls[0][1] as string;
+    expect(written).toContain("light");
+  });
+
+  it("preserves YAML comments from the original file", () => {
+    vi.mocked(readFileSync).mockReturnValue(
+      "# Dashboard config\nschema_version: 1\nappearance:\n  theme: dark\n"
+    );
+    writeConfig({ appearance: { theme: "light" } });
+    const written = vi.mocked(writeFileSync).mock.calls[0][1] as string;
+    expect(written).toContain("# Dashboard config");
+    expect(written).toContain("light");
+  });
+
+  it("invalidates cache so next getConfig() re-reads the file", () => {
+    loadConfig();
+    writeConfig({ appearance: { theme: "light" } });
+    vi.clearAllMocks();
+    vi.mocked(readFileSync).mockReturnValue(VALID_YAML);
+    getConfig();
+    expect(readFileSync).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,15 +1,9 @@
-// Config module — Phase 1 (YAML config engine task) will fill this out.
-// Responsibilities:
-//   - Parse settings.yaml (using the `yaml` npm package)
-//   - Validate schema with Zod
-//   - Watch for file changes (dev hot-reload)
-//   - Provide typed access to config values
-//
-// DO NOT use this placeholder directly. It will be replaced.
-
-// Full schema defined in Phase 1 alongside the YAML config engine
-export type KokpitConfig = Record<string, unknown>;
-
-export async function loadConfig(): Promise<KokpitConfig> {
-  throw new Error("Config engine not yet implemented (Phase 1)");
-}
+export {
+  getConfig,
+  loadConfig,
+  writeConfig,
+  getConfigPath,
+  invalidateCache,
+} from "./loader";
+export { KokpitConfigSchema } from "./schema";
+export type { KokpitConfig, Service, Widget } from "./schema";

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,0 +1,51 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { parseDocument } from "yaml";
+import { KokpitConfigSchema, type KokpitConfig } from "./schema";
+
+const CONFIG_PATH =
+  process.env.KOKPIT_CONFIG_PATH ??
+  path.join(process.cwd(), "settings.yaml");
+
+let cachedConfig: KokpitConfig | null = null;
+
+export function getConfigPath(): string {
+  return CONFIG_PATH;
+}
+
+export function loadConfig(): KokpitConfig {
+  const raw = readFileSync(CONFIG_PATH, "utf-8");
+  const parsed = parseDocument(raw).toJS() as unknown;
+  const result = KokpitConfigSchema.safeParse(parsed);
+
+  if (!result.success) {
+    const messages = result.error.issues
+      .map((issue) => `  • ${issue.path.join(".")}: ${issue.message}`)
+      .join("\n");
+    throw new Error(`Invalid settings.yaml:\n${messages}`);
+  }
+
+  cachedConfig = result.data;
+  return cachedConfig;
+}
+
+export function getConfig(): KokpitConfig {
+  if (!cachedConfig) return loadConfig();
+  return cachedConfig;
+}
+
+export function writeConfig(updates: Partial<KokpitConfig>): void {
+  const raw = readFileSync(CONFIG_PATH, "utf-8");
+  const doc = parseDocument(raw);
+
+  for (const [key, value] of Object.entries(updates)) {
+    doc.setIn([key], value);
+  }
+
+  writeFileSync(CONFIG_PATH, doc.toString(), "utf-8");
+  invalidateCache();
+}
+
+export function invalidateCache(): void {
+  cachedConfig = null;
+}

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -1,0 +1,52 @@
+import { z } from "zod";
+
+const ServiceSchema = z.object({
+  name: z.string(),
+  url: z.string().url(),
+  icon: z.string().optional(),
+  description: z.string().optional(),
+  group: z.string().optional(),
+});
+
+const WidgetPositionSchema = z.object({
+  col: z.number().int().positive(),
+  row: z.number().int().positive(),
+  width: z.number().int().positive(),
+  height: z.number().int().positive(),
+});
+
+const WidgetSchema = z.object({
+  type: z.string(),
+  config: z.record(z.string(), z.unknown()).optional(),
+  position: WidgetPositionSchema.optional(),
+});
+
+export const KokpitConfigSchema = z.object({
+  schema_version: z.literal(1),
+  auth: z
+    .object({
+      enabled: z.boolean().default(false),
+      session_ttl_hours: z.number().int().positive().default(24),
+    })
+    .default({ enabled: false, session_ttl_hours: 24 }),
+  appearance: z
+    .object({
+      theme: z
+        .enum(["dark", "light", "oled", "high-contrast"])
+        .default("dark"),
+      custom_css: z.string().optional(),
+    })
+    .default({ theme: "dark" }),
+  layout: z
+    .object({
+      columns: z.number().int().positive().default(4),
+      row_height: z.number().int().positive().default(120),
+    })
+    .default({ columns: 4, row_height: 120 }),
+  services: z.array(ServiceSchema).default([]),
+  widgets: z.array(WidgetSchema).default([]),
+});
+
+export type KokpitConfig = z.infer<typeof KokpitConfigSchema>;
+export type Service = z.infer<typeof ServiceSchema>;
+export type Widget = z.infer<typeof WidgetSchema>;

--- a/src/config/watcher.ts
+++ b/src/config/watcher.ts
@@ -1,0 +1,18 @@
+import { watch, type FSWatcher } from "node:fs";
+import { getConfigPath, invalidateCache } from "./loader";
+
+let watcher: FSWatcher | null = null;
+
+export function startConfigWatcher(): void {
+  if (watcher) return;
+
+  watcher = watch(getConfigPath(), () => {
+    console.log("[kokpit] settings.yaml changed, reloading config...");
+    invalidateCache();
+  });
+}
+
+export function stopConfigWatcher(): void {
+  watcher?.close();
+  watcher = null;
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,10 @@
+export async function register() {
+  // Validate config on startup — crashes loudly if settings.yaml is malformed.
+  const { loadConfig } = await import("./config");
+  loadConfig();
+
+  if (process.env.NODE_ENV === "development") {
+    const { startConfigWatcher } = await import("./config/watcher");
+    startConfigWatcher();
+  }
+}


### PR DESCRIPTION
Replace the config stub with a fully working YAML config engine:
- Zod schema for KokpitConfig (services, widgets, layout, auth, appearance)
- loadConfig() parses settings.yaml and validates with Zod, printing clear field-path error messages on startup if the file is malformed
- getConfig() singleton with module-level caching
- writeConfig() uses yaml.Document AST to write updates while preserving user comments and formatting in settings.yaml
- invalidateCache() for watcher-triggered reloads
- startConfigWatcher() (node:fs.watch) invalidates cache on file change in dev mode — hot-reload without restarting the server
- src/instrumentation.ts validates config at Next.js startup and starts the watcher in development
- 11 unit tests covering parsing, defaults, error formatting, caching, and comment preservation

Config file path defaults to settings.yaml in process.cwd(); override via KOKPIT_CONFIG_PATH env var (needed for Docker volume mounts).