### PR TITLE
fix: resolve webpack node: URI scheme and fs bundling errors

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,17 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Next.js dev",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["run", "dev"],
+      "port": 3000
+    },
+    {
+      "name": "Docker (kokpit-dev)",
+      "runtimeExecutable": "docker",
+      "runtimeArgs": ["compose", "up", "kokpit-dev"],
+      "port": 3000
+    }
+  ]
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,6 +2,7 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "standalone",
+  outputFileTracingRoot: __dirname,
 };
 
 export default nextConfig;

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,5 +1,5 @@
-import { readFileSync, writeFileSync } from "node:fs";
-import path from "node:path";
+import { readFileSync, writeFileSync } from "fs";
+import path from "path";
 import { parseDocument } from "yaml";
 import { KokpitConfigSchema, type KokpitConfig } from "./schema";
 

--- a/src/config/watcher.ts
+++ b/src/config/watcher.ts
@@ -1,4 +1,4 @@
-import { watch, type FSWatcher } from "node:fs";
+import { watch, type FSWatcher } from "fs";
 import { getConfigPath, invalidateCache } from "./loader";
 
 let watcher: FSWatcher | null = null;

--- a/src/instrumentation.node.ts
+++ b/src/instrumentation.node.ts
@@ -1,0 +1,10 @@
+export async function register() {
+  // Validate config on startup — crashes loudly if settings.yaml is malformed.
+  const { loadConfig } = await import("./config");
+  loadConfig();
+
+  if (process.env.NODE_ENV === "development") {
+    const { startConfigWatcher } = await import("./config/watcher");
+    startConfigWatcher();
+  }
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,10 +1,3 @@
-export async function register() {
-  // Validate config on startup — crashes loudly if settings.yaml is malformed.
-  const { loadConfig } = await import("./config");
-  loadConfig();
-
-  if (process.env.NODE_ENV === "development") {
-    const { startConfigWatcher } = await import("./config/watcher");
-    startConfigWatcher();
-  }
-}
+// Node.js-only instrumentation (config loading, file watching) lives in
+// instrumentation.node.ts which Next.js only bundles for the Node.js runtime.
+export async function register() {}


### PR DESCRIPTION
- Replace node:fs/node:path with fs/path in loader.ts and watcher.ts (webpack does not support the node: URI scheme by default)
- Move Node.js-only instrumentation to instrumentation.node.ts so webpack never bundles fs for the edge runtime
- Add outputFileTracingRoot to next.config.ts to silence multiple lockfile workspace root warning