### PR TITLE
feat(radarr): add stats and queue widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,11 @@ Kokpit is a personal dashboard for homelab and self-hosted setups. You define yo
 **Phase 2 — Integrations & Widgets**
 - [x] Widget system architecture
 - [x] Plex integration
-- [ ] Sonarr, Radarr, Prowlarr integrations
-- [ ] qBittorrent, SABnzbd integrations
+- [x] Sonarr integration
+- [x] Radarr integration
+- [x] qBittorrent integration
+- [x] SABnzbd integration
+- [ ] Prowlarr integration
 - [ ] Overseerr / Jellyseerr integration
 - [ ] Immich integration
 - [ ] Unraid, Netdata integrations
@@ -197,6 +200,119 @@ services:
 | `library_music` | Music | Total albums across all music libraries |
 
 The widget only contacts `/status/sessions` or `/library/sections` depending on which fields you configure, so it never makes unnecessary requests.
+
+---
+
+### Sonarr
+
+Two widgets are available for Sonarr: a calendar showing upcoming episodes and a download queue monitor.
+
+**Prerequisites:** An API key from Sonarr → Settings → General → Security.
+
+#### `sonarr-calendar`
+
+Shows upcoming episode air dates for the configured number of days ahead.
+
+```yaml
+services:
+  - name: Sonarr
+    url: http://192.168.1.10:8989
+    icon: sonarr
+    widget:
+      type: sonarr-calendar
+      config:
+        url: http://192.168.1.10:8989
+        api_key: YOUR_API_KEY
+        days: 7
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `url` | Yes | Base URL of your Sonarr instance |
+| `api_key` | Yes | API key from Sonarr → Settings → General |
+| `days` | No | Days ahead to show (1–30, default: 7) |
+
+#### `sonarr-queue`
+
+Shows active downloads with progress bars, status, and ETA.
+
+```yaml
+services:
+  - name: Sonarr
+    url: http://192.168.1.10:8989
+    icon: sonarr
+    widget:
+      type: sonarr-queue
+      config:
+        url: http://192.168.1.10:8989
+        api_key: YOUR_API_KEY
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `url` | Yes | Base URL of your Sonarr instance |
+| `api_key` | Yes | API key from Sonarr → Settings → General |
+
+---
+
+### Radarr
+
+Two widgets are available for Radarr: a stats overview and a download queue monitor.
+
+**Prerequisites:** An API key from Radarr → Settings → General → Security.
+
+#### `radarr-stats`
+
+Displays a six-stat grid showing the state of your movie library.
+
+```yaml
+services:
+  - name: Radarr
+    url: http://192.168.1.10:7878
+    icon: radarr
+    widget:
+      type: radarr-stats
+      config:
+        url: http://192.168.1.10:7878
+        api_key: YOUR_API_KEY
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `url` | Yes | Base URL of your Radarr instance |
+| `api_key` | Yes | API key from Radarr → Settings → General |
+
+**Displayed stats:**
+
+| Stat | Description |
+|------|-------------|
+| Missing | Monitored movies without a file that are already released |
+| Upcoming | Movies in "announced" or "in cinemas" status |
+| Wanted | All monitored movies without a file |
+| Queued | Total items currently in the download queue |
+| Available | Movies with a downloaded file |
+| Total | All movies tracked in Radarr |
+
+#### `radarr-queue`
+
+Shows active movie downloads with progress bars, status, and ETA.
+
+```yaml
+services:
+  - name: Radarr
+    url: http://192.168.1.10:7878
+    icon: radarr
+    widget:
+      type: radarr-queue
+      config:
+        url: http://192.168.1.10:7878
+        api_key: YOUR_API_KEY
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `url` | Yes | Base URL of your Radarr instance |
+| `api_key` | Yes | API key from Radarr → Settings → General |
 
 ---
 

--- a/src/__tests__/integrations/radarr.test.ts
+++ b/src/__tests__/integrations/radarr.test.ts
@@ -1,0 +1,368 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { clearRegistry } from "@/widgets";
+import { fetchStats, fetchQueue } from "@/integrations/radarr/api";
+
+const BASE_CONFIG = {
+  url: "http://radarr.local:7878",
+  api_key: "abc123secret",
+};
+
+// Mock movie data matching Radarr MovieResource shape.
+const MOCK_MOVIES = [
+  // downloaded + monitored (available)
+  { id: 1, hasFile: true, monitored: true, isAvailable: true, status: "released" },
+  // downloaded + monitored (available)
+  { id: 2, hasFile: true, monitored: true, isAvailable: true, status: "released" },
+  // missing: monitored, no file, isAvailable
+  { id: 3, hasFile: false, monitored: true, isAvailable: true, status: "released" },
+  // wanted but not yet available: monitored, no file, not isAvailable
+  { id: 4, hasFile: false, monitored: true, isAvailable: false, status: "announced" },
+  // upcoming (inCinemas)
+  { id: 5, hasFile: false, monitored: true, isAvailable: false, status: "inCinemas" },
+  // unmonitored
+  { id: 6, hasFile: false, monitored: false, isAvailable: true, status: "released" },
+];
+
+const MOCK_QUEUE_TOTAL_RESPONSE = {
+  records: [],
+  totalRecords: 3,
+};
+
+// Mock queue records for fetchQueue tests.
+const MOCK_QUEUE_RESPONSE = {
+  records: [
+    {
+      id: 101,
+      title: "The.Dark.Knight.2008",
+      movie: { title: "The Dark Knight" },
+      status: "downloading",
+      timeleft: "00:12:34",
+      size: 1_000_000_000,
+      sizeleft: 300_000_000,
+      trackedDownloadStatus: "ok",
+    },
+    {
+      id: 102,
+      title: "Inception.2010",
+      movie: { title: "Inception" },
+      status: "queued",
+      size: 900_000_000,
+      sizeleft: 900_000_000,
+      trackedDownloadStatus: "warning",
+    },
+  ],
+  totalRecords: 2,
+};
+
+function makeJsonResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => body,
+  };
+}
+
+function makeErrorResponse(status: number) {
+  return { ok: false, status };
+}
+
+// ---------------------------------------------------------------------------
+// fetchStats
+// ---------------------------------------------------------------------------
+
+describe("fetchStats", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns correct stat counts", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(makeJsonResponse(MOCK_MOVIES))
+      .mockResolvedValueOnce(makeJsonResponse(MOCK_QUEUE_TOTAL_RESPONSE));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await fetchStats(BASE_CONFIG);
+
+    expect(result.total).toBe(6);
+    expect(result.available).toBe(2); // hasFile=true
+    expect(result.missing).toBe(1);   // monitored && !hasFile && isAvailable (id:3)
+    expect(result.wanted).toBe(3);    // monitored && !hasFile (id:3,4,5)
+    expect(result.upcoming).toBe(2);  // status "announced" or "inCinemas" (id:4,5)
+    expect(result.queued).toBe(3);    // from totalRecords
+  });
+
+  it("sends X-Api-Key header to both endpoints", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(makeJsonResponse(MOCK_MOVIES))
+      .mockResolvedValueOnce(makeJsonResponse(MOCK_QUEUE_TOTAL_RESPONSE));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fetchStats(BASE_CONFIG);
+
+    for (const call of mockFetch.mock.calls) {
+      const [, options] = call;
+      expect(options.headers["X-Api-Key"]).toBe("abc123secret");
+      expect(options.headers.Cookie).toBeUndefined();
+    }
+  });
+
+  it("fetches /api/v3/movie and /api/v3/queue", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(makeJsonResponse(MOCK_MOVIES))
+      .mockResolvedValueOnce(makeJsonResponse(MOCK_QUEUE_TOTAL_RESPONSE));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fetchStats(BASE_CONFIG);
+
+    const urls = mockFetch.mock.calls.map((call) => call[0] as string);
+    expect(urls.some((u) => u.includes("/api/v3/movie"))).toBe(true);
+    expect(urls.some((u) => u.includes("/api/v3/queue"))).toBe(true);
+  });
+
+  it("throws on non-2xx response with status in message", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(makeErrorResponse(401))
+    );
+    await expect(fetchStats(BASE_CONFIG)).rejects.toThrow("401");
+  });
+
+  it("forwards AbortSignal", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(makeJsonResponse(MOCK_MOVIES))
+      .mockResolvedValueOnce(makeJsonResponse(MOCK_QUEUE_TOTAL_RESPONSE));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const controller = new AbortController();
+    await fetchStats(BASE_CONFIG, controller.signal);
+
+    for (const call of mockFetch.mock.calls) {
+      const [, options] = call;
+      expect(options.signal).toBe(controller.signal);
+    }
+  });
+
+  it("handles empty movie list", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(makeJsonResponse([]))
+      .mockResolvedValueOnce(makeJsonResponse({ records: [], totalRecords: 0 }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await fetchStats(BASE_CONFIG);
+
+    expect(result.total).toBe(0);
+    expect(result.available).toBe(0);
+    expect(result.missing).toBe(0);
+    expect(result.wanted).toBe(0);
+    expect(result.upcoming).toBe(0);
+    expect(result.queued).toBe(0);
+  });
+
+  it("preserves base path in config.url when resolving API paths", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(makeJsonResponse(MOCK_MOVIES))
+      .mockResolvedValueOnce(makeJsonResponse(MOCK_QUEUE_TOTAL_RESPONSE));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const configWithBasePath = { ...BASE_CONFIG, url: "http://radarr.local:7878/radarr/" };
+    await fetchStats(configWithBasePath);
+
+    const urls = mockFetch.mock.calls.map((call) => call[0] as string);
+    expect(urls.some((u) => u.includes("/radarr/api/v3/movie"))).toBe(true);
+    expect(urls.every((u) => !u.match(/^http:\/\/radarr\.local:7878\/api\//))).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// fetchQueue
+// ---------------------------------------------------------------------------
+
+describe("fetchQueue", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns the records array from wrapped response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeJsonResponse(MOCK_QUEUE_RESPONSE)));
+    const result = await fetchQueue(BASE_CONFIG);
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe(101);
+  });
+
+  it("flattens movie.title to movieTitle", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeJsonResponse(MOCK_QUEUE_RESPONSE)));
+    const result = await fetchQueue(BASE_CONFIG);
+    expect(result[0].movieTitle).toBe("The Dark Knight");
+    expect(result[0]).not.toHaveProperty("movie");
+  });
+
+  it("sends correct path with query params", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(makeJsonResponse(MOCK_QUEUE_RESPONSE));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fetchQueue(BASE_CONFIG);
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("/api/v3/queue");
+    expect(url).toContain("pageSize=25");
+    expect(url).toContain("includeMovie=true");
+    expect(url).toContain("includeUnknownMovieItems=false");
+  });
+
+  it("sends X-Api-Key header", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(makeJsonResponse(MOCK_QUEUE_RESPONSE));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fetchQueue(BASE_CONFIG);
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options.headers["X-Api-Key"]).toBe("abc123secret");
+  });
+
+  it("handles empty records gracefully", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(makeJsonResponse({ records: [], totalRecords: 0 }))
+    );
+    const result = await fetchQueue(BASE_CONFIG);
+    expect(result).toEqual([]);
+  });
+
+  it("throws on non-2xx response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeErrorResponse(500)));
+    await expect(fetchQueue(BASE_CONFIG)).rejects.toThrow("500");
+  });
+
+  it("timeleft field is optional", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeJsonResponse(MOCK_QUEUE_RESPONSE)));
+    const result = await fetchQueue(BASE_CONFIG);
+    // item[0] has timeleft, item[1] does not
+    expect(result[0].timeleft).toBe("00:12:34");
+    expect(result[1].timeleft).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Widget registration — radarr-stats
+// ---------------------------------------------------------------------------
+
+describe("radarr-stats widget registration", () => {
+  beforeEach(() => {
+    clearRegistry();
+    vi.resetModules();
+  });
+
+  it("registers a widget with id 'radarr-stats' on import", async () => {
+    await import("@/integrations/radarr/statsWidget");
+    const { getWidget } = await import("@/widgets");
+    expect(getWidget("radarr-stats")).toBeDefined();
+  });
+
+  it("widget name is 'Radarr Stats'", async () => {
+    await import("@/integrations/radarr/statsWidget");
+    const { getWidget } = await import("@/widgets");
+    expect(getWidget("radarr-stats")?.name).toBe("Radarr Stats");
+  });
+
+  it("refreshInterval is 60000", async () => {
+    await import("@/integrations/radarr/statsWidget");
+    const { getWidget } = await import("@/widgets");
+    expect(getWidget("radarr-stats")?.refreshInterval).toBe(60_000);
+  });
+
+  it("configSchema accepts valid config", async () => {
+    await import("@/integrations/radarr/statsWidget");
+    const { getWidget } = await import("@/widgets");
+    const result = getWidget("radarr-stats")!.configSchema.safeParse({
+      url: "http://192.168.1.10:7878",
+      api_key: "myapikey",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("configSchema rejects invalid URL", async () => {
+    await import("@/integrations/radarr/statsWidget");
+    const { getWidget } = await import("@/widgets");
+    const result = getWidget("radarr-stats")!.configSchema.safeParse({
+      url: "not-a-url",
+      api_key: "myapikey",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("configSchema rejects empty api_key", async () => {
+    await import("@/integrations/radarr/statsWidget");
+    const { getWidget } = await import("@/widgets");
+    const result = getWidget("radarr-stats")!.configSchema.safeParse({
+      url: "http://192.168.1.10:7878",
+      api_key: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("configFields contains url and api_key", async () => {
+    await import("@/integrations/radarr/statsWidget");
+    const { getWidget } = await import("@/widgets");
+    const fields = getWidget("radarr-stats")?.configFields ?? [];
+    const keys = fields.map((f) => f.key);
+    expect(keys).toContain("url");
+    expect(keys).toContain("api_key");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Widget registration — radarr-queue
+// ---------------------------------------------------------------------------
+
+describe("radarr-queue widget registration", () => {
+  beforeEach(() => {
+    clearRegistry();
+    vi.resetModules();
+  });
+
+  it("registers a widget with id 'radarr-queue' on import", async () => {
+    await import("@/integrations/radarr/queueWidget");
+    const { getWidget } = await import("@/widgets");
+    expect(getWidget("radarr-queue")).toBeDefined();
+  });
+
+  it("widget name is 'Radarr Queue'", async () => {
+    await import("@/integrations/radarr/queueWidget");
+    const { getWidget } = await import("@/widgets");
+    expect(getWidget("radarr-queue")?.name).toBe("Radarr Queue");
+  });
+
+  it("refreshInterval is 15000", async () => {
+    await import("@/integrations/radarr/queueWidget");
+    const { getWidget } = await import("@/widgets");
+    expect(getWidget("radarr-queue")?.refreshInterval).toBe(15_000);
+  });
+
+  it("configSchema accepts valid config", async () => {
+    await import("@/integrations/radarr/queueWidget");
+    const { getWidget } = await import("@/widgets");
+    const result = getWidget("radarr-queue")!.configSchema.safeParse({
+      url: "http://192.168.1.10:7878",
+      api_key: "myapikey",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("configFields contains url and api_key", async () => {
+    await import("@/integrations/radarr/queueWidget");
+    const { getWidget } = await import("@/widgets");
+    const fields = getWidget("radarr-queue")?.configFields ?? [];
+    const keys = fields.map((f) => f.key);
+    expect(keys).toContain("url");
+    expect(keys).toContain("api_key");
+  });
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1397,6 +1397,235 @@ body {
   color: #f87171;
 }
 
+/* ── Radarr stats widget ─────────────────────────────────────────────────── */
+
+.radarr-stats-widget {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.radarr-stats-widget__grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+  flex: 1 1 0;
+  align-content: center;
+  padding: 4px;
+}
+
+.radarr-stats-widget__stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 6px 4px;
+  border-radius: 4px;
+  background: var(--color-surface-2);
+  min-width: 0;
+}
+
+.radarr-stats-widget__value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.radarr-stats-widget__label {
+  font-size: 0.65rem;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+}
+
+.radarr-stats-widget__stat--missing .radarr-stats-widget__value {
+  color: #f87171;
+}
+
+.radarr-stats-widget__stat--upcoming .radarr-stats-widget__value {
+  color: var(--color-accent);
+}
+
+.radarr-stats-widget__stat--wanted .radarr-stats-widget__value {
+  color: #fbbf24;
+}
+
+.radarr-stats-widget__stat--queued .radarr-stats-widget__value {
+  color: var(--color-text-muted);
+}
+
+.radarr-stats-widget__stat--available .radarr-stats-widget__value {
+  color: #22c55e;
+}
+
+.radarr-stats-widget__stat--total .radarr-stats-widget__value {
+  color: var(--color-text);
+}
+
+.radarr-stats-widget--empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  gap: 4px;
+}
+
+.radarr-stats-widget__hint {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.radarr-stats-widget__hint--error {
+  color: #f87171;
+}
+
+.radarr-stats-widget__stale-error {
+  font-size: 0.7rem;
+  color: #f87171;
+  text-align: center;
+  padding: 4px 0;
+  flex-shrink: 0;
+}
+
+/* ── Radarr queue widget ─────────────────────────────────────────────────── */
+
+.radarr-queue-widget {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.radarr-queue-widget__header {
+  display: grid;
+  grid-template-columns: 1fr 72px 72px 56px;
+  gap: 6px;
+  padding: 0 4px 4px;
+  border-bottom: 1px solid var(--color-border);
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  flex-shrink: 0;
+}
+
+.radarr-queue-widget__list {
+  flex: 1 1 0;
+  overflow-y: auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.radarr-queue-widget__row {
+  display: grid;
+  grid-template-columns: 1fr 72px 72px 56px;
+  gap: 6px;
+  align-items: center;
+  padding: 5px 4px;
+  border-bottom: 1px solid var(--color-border);
+  min-width: 0;
+}
+
+.radarr-queue-widget__row:last-child {
+  border-bottom: none;
+}
+
+.radarr-queue-widget__name {
+  font-size: 0.8rem;
+  color: var(--color-text);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.radarr-queue-widget__progress-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.radarr-queue-widget__progress-bar {
+  height: 4px;
+  background: var(--color-border);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.radarr-queue-widget__progress-fill {
+  height: 100%;
+  background: var(--color-accent);
+  border-radius: 2px;
+  transition: width 400ms ease;
+}
+
+.radarr-queue-widget__progress-text {
+  font-size: 0.65rem;
+  color: var(--color-text-muted);
+  text-align: right;
+  line-height: 1;
+}
+
+.radarr-queue-widget__status {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: right;
+}
+
+.radarr-queue-widget__status--warning {
+  color: #fbbf24;
+}
+
+.radarr-queue-widget__status--error {
+  color: #f87171;
+}
+
+.radarr-queue-widget__timeleft {
+  font-size: 0.75rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: right;
+}
+
+.radarr-queue-widget__stale-error {
+  font-size: 0.7rem;
+  color: #f87171;
+  text-align: center;
+  padding: 4px 0;
+  flex-shrink: 0;
+}
+
+.radarr-queue-widget--empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  gap: 4px;
+}
+
+.radarr-queue-widget__hint {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.radarr-queue-widget__hint--error {
+  color: #f87171;
+}
+
 /* ── SABnzbd widget ───────────────────────────────────────────────────────── */
 
 .sabnzbd-widget__stat--wide {

--- a/src/integrations/index.ts
+++ b/src/integrations/index.ts
@@ -6,5 +6,7 @@ import "./qbittorrent/torrentsWidget";
 import "./sonarr/calendarWidget";
 import "./sonarr/queueWidget";
 import "./sabnzbd/widget";
+import "./radarr/statsWidget";
+import "./radarr/queueWidget";
 
 export type IntegrationStatus = "ok" | "error" | "unknown";

--- a/src/integrations/radarr/api.ts
+++ b/src/integrations/radarr/api.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { fetchWithApiKey } from "@/integrations/shared/http";
 
 export interface RadarrConfig {
   url: string;
@@ -59,39 +60,17 @@ const RadarrQueueResponseSchema = z.object({
   totalRecords: z.number(),
 });
 
-async function fetchWithAuth(
-  config: RadarrConfig,
-  path: string,
-  signal?: AbortSignal
-): Promise<Response> {
-  // Strip leading slashes from relative paths so new URL resolves relative to
-  // the full config.url (including any base path) rather than the origin.
-  // Absolute URLs (http/https) are passed through unchanged.
-  const relativePath = /^https?:\/\//i.test(path) ? path : path.replace(/^\/+/, "");
-  const url = new URL(relativePath, config.url).toString();
-  const response = await fetch(url, {
-    headers: { "X-Api-Key": config.api_key },
-    signal,
-  });
-  if (!response.ok) {
-    throw new Error(`Radarr responded with ${response.status}`);
-  }
-  return response;
-}
-
 export async function fetchStats(
   config: RadarrConfig,
   signal?: AbortSignal
 ): Promise<RadarrStats> {
   const [moviesResponse, queueResponse] = await Promise.all([
-    fetchWithAuth(config, "/api/v3/movie", signal),
-    fetchWithAuth(config, "/api/v3/queue?pageSize=1", signal),
+    fetchWithApiKey(config, "/api/v3/movie", signal, "Radarr"),
+    fetchWithApiKey(config, "/api/v3/queue?pageSize=1", signal, "Radarr"),
   ]);
 
-  const [moviesData, queueData] = await Promise.all([
-    moviesResponse.json(),
-    queueResponse.json(),
-  ]);
+  const moviesData = await moviesResponse.json();
+  const queueData = await queueResponse.json();
 
   const movies = z.array(MovieResourceSchema).parse(moviesData);
   const { totalRecords } = z
@@ -115,10 +94,11 @@ export async function fetchQueue(
   config: RadarrConfig,
   signal?: AbortSignal
 ): Promise<RadarrQueueItem[]> {
-  const response = await fetchWithAuth(
+  const response = await fetchWithApiKey(
     config,
     "/api/v3/queue?pageSize=25&includeMovie=true&includeUnknownMovieItems=false",
-    signal
+    signal,
+    "Radarr"
   );
   const data = await response.json();
   return RadarrQueueResponseSchema.parse(data).records;

--- a/src/integrations/radarr/api.ts
+++ b/src/integrations/radarr/api.ts
@@ -1,0 +1,125 @@
+import { z } from "zod";
+
+export interface RadarrConfig {
+  url: string;
+  api_key: string;
+}
+
+export const RadarrConfigSchema = z.object({
+  url: z.string().url(),
+  api_key: z.string().min(1),
+});
+
+export interface RadarrStats {
+  total: number;
+  available: number;
+  missing: number;
+  wanted: number;
+  upcoming: number;
+  queued: number;
+}
+
+// Internal schema matching the actual Radarr MovieResource API shape.
+const MovieResourceSchema = z.object({
+  id: z.number(),
+  hasFile: z.boolean(),
+  monitored: z.boolean(),
+  isAvailable: z.boolean(),
+  status: z.string(),
+});
+
+// Internal schema matching the actual Radarr QueueResource API shape.
+const QueueResourceSchema = z.object({
+  id: z.number(),
+  title: z.string(),
+  movie: z.object({ title: z.string() }),
+  status: z.string(),
+  timeleft: z.string().optional(),
+  size: z.number(),
+  sizeleft: z.number(),
+  trackedDownloadStatus: z.string(),
+});
+
+// Widget-facing shape with flat movieTitle extracted from movie.title.
+const RadarrQueueItemSchema = QueueResourceSchema.transform((r) => ({
+  id: r.id,
+  title: r.title,
+  movieTitle: r.movie.title,
+  status: r.status,
+  ...(r.timeleft !== undefined && { timeleft: r.timeleft }),
+  size: r.size,
+  sizeleft: r.sizeleft,
+  trackedDownloadStatus: r.trackedDownloadStatus,
+}));
+
+export type RadarrQueueItem = z.output<typeof RadarrQueueItemSchema>;
+
+const RadarrQueueResponseSchema = z.object({
+  records: z.array(RadarrQueueItemSchema),
+  totalRecords: z.number(),
+});
+
+async function fetchWithAuth(
+  config: RadarrConfig,
+  path: string,
+  signal?: AbortSignal
+): Promise<Response> {
+  // Strip leading slashes from relative paths so new URL resolves relative to
+  // the full config.url (including any base path) rather than the origin.
+  // Absolute URLs (http/https) are passed through unchanged.
+  const relativePath = /^https?:\/\//i.test(path) ? path : path.replace(/^\/+/, "");
+  const url = new URL(relativePath, config.url).toString();
+  const response = await fetch(url, {
+    headers: { "X-Api-Key": config.api_key },
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(`Radarr responded with ${response.status}`);
+  }
+  return response;
+}
+
+export async function fetchStats(
+  config: RadarrConfig,
+  signal?: AbortSignal
+): Promise<RadarrStats> {
+  const [moviesResponse, queueResponse] = await Promise.all([
+    fetchWithAuth(config, "/api/v3/movie", signal),
+    fetchWithAuth(config, "/api/v3/queue?pageSize=1", signal),
+  ]);
+
+  const [moviesData, queueData] = await Promise.all([
+    moviesResponse.json(),
+    queueResponse.json(),
+  ]);
+
+  const movies = z.array(MovieResourceSchema).parse(moviesData);
+  const { totalRecords } = z
+    .object({ totalRecords: z.number() })
+    .parse(queueData);
+
+  return {
+    total: movies.length,
+    available: movies.filter((m) => m.hasFile).length,
+    missing: movies.filter((m) => m.monitored && !m.hasFile && m.isAvailable)
+      .length,
+    wanted: movies.filter((m) => m.monitored && !m.hasFile).length,
+    upcoming: movies.filter(
+      (m) => m.status === "announced" || m.status === "inCinemas"
+    ).length,
+    queued: totalRecords,
+  };
+}
+
+export async function fetchQueue(
+  config: RadarrConfig,
+  signal?: AbortSignal
+): Promise<RadarrQueueItem[]> {
+  const response = await fetchWithAuth(
+    config,
+    "/api/v3/queue?pageSize=25&includeMovie=true&includeUnknownMovieItems=false",
+    signal
+  );
+  const data = await response.json();
+  return RadarrQueueResponseSchema.parse(data).records;
+}

--- a/src/integrations/radarr/queueWidget.tsx
+++ b/src/integrations/radarr/queueWidget.tsx
@@ -1,0 +1,117 @@
+import { registerWidget } from "@/widgets";
+import type { WidgetProps } from "@/widgets";
+import { fetchQueue, RadarrConfigSchema } from "./api";
+import type { RadarrConfig, RadarrQueueItem } from "./api";
+
+function calcProgress(size: number, sizeleft: number): number {
+  if (size === 0) return 0;
+  return Math.min(100, Math.max(0, Math.round((1 - sizeleft / size) * 100)));
+}
+
+export function RadarrQueueWidget({
+  data,
+  loading,
+  error,
+  refresh: _refresh,
+}: WidgetProps<RadarrQueueItem[]>) {
+  if (!data) {
+    return (
+      <div className="radarr-queue-widget radarr-queue-widget--empty">
+        {loading && (
+          <span className="radarr-queue-widget__hint">Loading&hellip;</span>
+        )}
+        {error && (
+          <span className="radarr-queue-widget__hint radarr-queue-widget__hint--error">
+            {error}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  if (data.length === 0) {
+    return (
+      <div className="radarr-queue-widget radarr-queue-widget--empty">
+        <span className="radarr-queue-widget__hint">Queue is empty</span>
+        {error && (
+          <span className="radarr-queue-widget__stale-error" role="alert">
+            {error}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="radarr-queue-widget" aria-label="Radarr queue">
+      <div className="radarr-queue-widget__header">
+        <span>Name</span>
+        <span>Progress</span>
+        <span>Status</span>
+        <span>ETA</span>
+      </div>
+      <div className="radarr-queue-widget__list">
+        {data.map((item) => {
+          const pct = calcProgress(item.size, item.sizeleft);
+          const showStatusBadge =
+            item.trackedDownloadStatus &&
+            item.trackedDownloadStatus.toLowerCase() !== "ok";
+          return (
+            <div key={item.id} className="radarr-queue-widget__row">
+              <span className="radarr-queue-widget__name" title={item.title}>
+                {item.movieTitle}
+              </span>
+              <div className="radarr-queue-widget__progress-cell">
+                <div className="radarr-queue-widget__progress-bar">
+                  <div
+                    className="radarr-queue-widget__progress-fill"
+                    style={{ width: `${pct}%` }}
+                  />
+                </div>
+                <span className="radarr-queue-widget__progress-text">
+                  {pct}%
+                </span>
+              </div>
+              <span
+                className={`radarr-queue-widget__status${showStatusBadge ? ` radarr-queue-widget__status--${item.trackedDownloadStatus.toLowerCase()}` : ""}`}
+              >
+                {item.status}
+              </span>
+              <span className="radarr-queue-widget__timeleft">
+                {item.timeleft ?? "—"}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      {error && (
+        <span className="radarr-queue-widget__stale-error" role="alert">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}
+
+registerWidget<RadarrConfig, RadarrQueueItem[]>({
+  id: "radarr-queue",
+  name: "Radarr Queue",
+  serviceEditorPreset: {
+    defaultName: "Radarr",
+    defaultIconUrl: "https://cdn.simpleicons.org/radarr/ffc230",
+  },
+  configSchema: RadarrConfigSchema,
+  fetchData: fetchQueue,
+  refreshInterval: 15_000,
+  component: RadarrQueueWidget,
+  configFields: [
+    {
+      key: "url",
+      label: "URL",
+      type: "url",
+      required: true,
+      placeholder: "http://192.168.1.x:7878",
+    },
+    { key: "api_key", label: "API Key", type: "password", required: true },
+  ],
+});

--- a/src/integrations/radarr/queueWidget.tsx
+++ b/src/integrations/radarr/queueWidget.tsx
@@ -2,11 +2,7 @@ import { registerWidget } from "@/widgets";
 import type { WidgetProps } from "@/widgets";
 import { fetchQueue, RadarrConfigSchema } from "./api";
 import type { RadarrConfig, RadarrQueueItem } from "./api";
-
-function calcProgress(size: number, sizeleft: number): number {
-  if (size === 0) return 0;
-  return Math.min(100, Math.max(0, Math.round((1 - sizeleft / size) * 100)));
-}
+import { calcProgress } from "@/integrations/shared/queue";
 
 export function RadarrQueueWidget({
   data,

--- a/src/integrations/radarr/statsWidget.tsx
+++ b/src/integrations/radarr/statsWidget.tsx
@@ -1,0 +1,85 @@
+import { registerWidget } from "@/widgets";
+import type { WidgetProps } from "@/widgets";
+import { fetchStats, RadarrConfigSchema } from "./api";
+import type { RadarrConfig, RadarrStats } from "./api";
+
+export function RadarrStatsWidget({
+  data,
+  loading,
+  error,
+  refresh: _refresh,
+}: WidgetProps<RadarrStats>) {
+  if (!data) {
+    return (
+      <div className="radarr-stats-widget radarr-stats-widget--empty">
+        {loading && (
+          <span className="radarr-stats-widget__hint">Loading&hellip;</span>
+        )}
+        {error && (
+          <span className="radarr-stats-widget__hint radarr-stats-widget__hint--error">
+            {error}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="radarr-stats-widget" aria-label="Radarr stats">
+      <div className="radarr-stats-widget__grid">
+        <div className="radarr-stats-widget__stat radarr-stats-widget__stat--missing">
+          <span className="radarr-stats-widget__value">{data.missing}</span>
+          <span className="radarr-stats-widget__label">Missing</span>
+        </div>
+        <div className="radarr-stats-widget__stat radarr-stats-widget__stat--upcoming">
+          <span className="radarr-stats-widget__value">{data.upcoming}</span>
+          <span className="radarr-stats-widget__label">Upcoming</span>
+        </div>
+        <div className="radarr-stats-widget__stat radarr-stats-widget__stat--wanted">
+          <span className="radarr-stats-widget__value">{data.wanted}</span>
+          <span className="radarr-stats-widget__label">Wanted</span>
+        </div>
+        <div className="radarr-stats-widget__stat radarr-stats-widget__stat--queued">
+          <span className="radarr-stats-widget__value">{data.queued}</span>
+          <span className="radarr-stats-widget__label">Queued</span>
+        </div>
+        <div className="radarr-stats-widget__stat radarr-stats-widget__stat--available">
+          <span className="radarr-stats-widget__value">{data.available}</span>
+          <span className="radarr-stats-widget__label">Available</span>
+        </div>
+        <div className="radarr-stats-widget__stat radarr-stats-widget__stat--total">
+          <span className="radarr-stats-widget__value">{data.total}</span>
+          <span className="radarr-stats-widget__label">Total</span>
+        </div>
+      </div>
+      {error && (
+        <span className="radarr-stats-widget__stale-error" role="alert">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}
+
+registerWidget<RadarrConfig, RadarrStats>({
+  id: "radarr-stats",
+  name: "Radarr Stats",
+  serviceEditorPreset: {
+    defaultName: "Radarr",
+    defaultIconUrl: "https://cdn.simpleicons.org/radarr/ffc230",
+  },
+  configSchema: RadarrConfigSchema,
+  fetchData: fetchStats,
+  refreshInterval: 60_000,
+  component: RadarrStatsWidget,
+  configFields: [
+    {
+      key: "url",
+      label: "URL",
+      type: "url",
+      required: true,
+      placeholder: "http://192.168.1.x:7878",
+    },
+    { key: "api_key", label: "API Key", type: "password", required: true },
+  ],
+});

--- a/src/integrations/shared/http.ts
+++ b/src/integrations/shared/http.ts
@@ -1,0 +1,28 @@
+export interface ApiKeyConfig {
+  url: string;
+  api_key: string;
+}
+
+/**
+ * Fetches a URL relative to config.url, injecting an X-Api-Key header.
+ * Strips leading slashes from relative paths so new URL() resolves relative
+ * to the full config.url (including any base path) rather than the origin.
+ * Absolute URLs (http/https) are passed through unchanged.
+ */
+export async function fetchWithApiKey(
+  config: ApiKeyConfig,
+  path: string,
+  signal?: AbortSignal,
+  serviceName = "Service"
+): Promise<Response> {
+  const relativePath = /^https?:\/\//i.test(path) ? path : path.replace(/^\/+/, "");
+  const url = new URL(relativePath, config.url).toString();
+  const response = await fetch(url, {
+    headers: { "X-Api-Key": config.api_key },
+    signal,
+  });
+  if (!response.ok) {
+    throw new Error(`${serviceName} responded with ${response.status}`);
+  }
+  return response;
+}

--- a/src/integrations/shared/queue.ts
+++ b/src/integrations/shared/queue.ts
@@ -1,0 +1,5 @@
+/** Returns download progress as an integer percentage (0–100). */
+export function calcProgress(size: number, sizeleft: number): number {
+  if (size === 0) return 0;
+  return Math.min(100, Math.max(0, Math.round((1 - sizeleft / size) * 100)));
+}

--- a/src/integrations/sonarr/api.ts
+++ b/src/integrations/sonarr/api.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { fetchWithApiKey } from "@/integrations/shared/http";
 
 export interface SonarrConfig {
   url: string;
@@ -68,26 +69,6 @@ const SonarrQueueResponseSchema = z.object({
   records: z.array(SonarrQueueItemSchema),
 });
 
-async function fetchWithAuth(
-  config: SonarrConfig,
-  path: string,
-  signal?: AbortSignal
-): Promise<Response> {
-  // Strip leading slashes from relative paths so new URL resolves relative to
-  // the full config.url (including any base path) rather than the origin.
-  // Absolute URLs (http/https) are passed through unchanged.
-  const relativePath = /^https?:\/\//i.test(path) ? path : path.replace(/^\/+/, "");
-  const url = new URL(relativePath, config.url).toString();
-  const response = await fetch(url, {
-    headers: { "X-Api-Key": config.api_key },
-    signal,
-  });
-  if (!response.ok) {
-    throw new Error(`Sonarr responded with ${response.status}`);
-  }
-  return response;
-}
-
 export async function fetchCalendar(
   config: SonarrConfig,
   signal?: AbortSignal
@@ -98,7 +79,7 @@ export async function fetchCalendar(
   end.setUTCDate(end.getUTCDate() + config.days);
 
   const path = `/api/v3/calendar?start=${start.toISOString()}&end=${end.toISOString()}&includeSeries=true`;
-  const response = await fetchWithAuth(config, path, signal);
+  const response = await fetchWithApiKey(config, path, signal, "Sonarr");
   const data = await response.json();
   return z.array(SonarrEpisodeSchema).parse(data);
 }
@@ -107,10 +88,11 @@ export async function fetchQueue(
   config: SonarrConfig,
   signal?: AbortSignal
 ): Promise<SonarrQueueItem[]> {
-  const response = await fetchWithAuth(
+  const response = await fetchWithApiKey(
     config,
     "/api/v3/queue?pageSize=25&includeSeries=true&includeUnknownSeriesItems=false",
-    signal
+    signal,
+    "Sonarr"
   );
   const data = await response.json();
   return SonarrQueueResponseSchema.parse(data).records;

--- a/src/integrations/sonarr/queueWidget.tsx
+++ b/src/integrations/sonarr/queueWidget.tsx
@@ -2,11 +2,7 @@ import { registerWidget } from "@/widgets";
 import type { WidgetProps } from "@/widgets";
 import { fetchQueue, SonarrConfigSchema } from "./api";
 import type { SonarrConfig, SonarrQueueItem } from "./api";
-
-function calcProgress(size: number, sizeleft: number): number {
-  if (size === 0) return 0;
-  return Math.min(100, Math.max(0, Math.round((1 - sizeleft / size) * 100)));
-}
+import { calcProgress } from "@/integrations/shared/queue";
 
 export function SonarrQueueWidget({
   data,


### PR DESCRIPTION
Implements the P0 Radarr integration from the roadmap with two widgets:

- radarr-stats: displays missing, upcoming, wanted, queued, and available
  movie counts. Fetches /api/v3/movie and /api/v3/queue in parallel and
  computes stats locally.
- radarr-queue: shows download queue with name, progress bar, status, and
  ETA columns. Mirrors the Sonarr queue widget with movie-specific fields.

Both widgets use X-Api-Key auth, support base paths, and follow the same
Zod validation + registerWidget patterns as existing integrations.

26 tests added covering API fetchers and widget registration.

https://claude.ai/code/session_01UNXV5pHUscPGcyeuYbnqGZ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Radarr integration now available with statistics widget displaying movie metrics (total, available, missing, wanted, upcoming, and queued) and queue widget showing download progress and status.

* **Documentation**
  * Expanded README with comprehensive Radarr configuration guide including API key setup and available widgets.
  * Enhanced Sonarr documentation with widget details and YAML configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->