### PR TITLE
Add Seerr integration with stats and requests widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Kokpit is a personal dashboard for homelab and self-hosted setups. You define yo
 - [x] qBittorrent integration
 - [x] SABnzbd integration
 - [x] Prowlarr integration
-- [ ] Overseerr / Jellyseerr integration
+- [x] Seerr integration (compatible with Overseerr and Jellyseerr)
 - [ ] Immich integration
 - [ ] Unraid, Netdata integrations
 - [ ] System stats widget (CPU, RAM, disk, Docker)
@@ -339,6 +339,103 @@ services:
 |-------|----------|-------------|
 | `url` | Yes | Base URL of your Radarr instance |
 | `api_key` | Yes | API key from Radarr → Settings → General |
+
+---
+
+### Prowlarr
+
+Displays indexer health and lifetime grab statistics from Prowlarr.
+
+**Prerequisites:** An API key from Prowlarr → Settings → General → Security.
+
+#### `prowlarr-stats`
+
+Shows a four-stat grid: total indexers, enabled indexers, failing indexers (highlighted in red when non-zero), and total grabs across all time.
+
+```yaml
+services:
+  - name: Prowlarr
+    url: http://192.168.1.10:9696
+    icon: prowlarr
+    widget:
+      type: prowlarr-stats
+      config:
+        url: http://192.168.1.10:9696
+        api_key: YOUR_API_KEY
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `url` | Yes | Base URL of your Prowlarr instance |
+| `api_key` | Yes | API key from Prowlarr → Settings → General |
+
+**Displayed stats:**
+
+| Stat | Description |
+|------|-------------|
+| Indexers | Total number of configured indexers |
+| Enabled | Indexers currently enabled |
+| Failing | Indexers with an active error status (shown in red when > 0) |
+| Total Grabs | Cumulative grab count across all indexers and history |
+
+---
+
+### Seerr
+
+Two widgets are available for Seerr. Both are also compatible with Jellyseerr and Overseerr, which share the same API.
+
+**Prerequisites:** An API key from Settings → General → API Key.
+
+#### `seerr-stats`
+
+Displays a four-stat grid summarising the current state of all media requests.
+
+```yaml
+services:
+  - name: Seerr
+    url: http://192.168.1.10:5055
+    icon: seerr
+    widget:
+      type: seerr-stats
+      config:
+        url: http://192.168.1.10:5055
+        api_key: YOUR_API_KEY
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `url` | Yes | Base URL of your Seerr instance |
+| `api_key` | Yes | API key from Settings → General |
+
+**Displayed stats:**
+
+| Stat | Description |
+|------|-------------|
+| Pending | Requests awaiting approval |
+| Approved | Requests approved but not yet available |
+| Available | Requests where the media has been fully downloaded |
+| Total | All requests regardless of status |
+
+#### `seerr-requests`
+
+Shows a scrollable list of the 15 most recently submitted requests. Each row displays a colour-coded status badge (pending / approved / available / declined), a media type chip (movie / tv), the title, the requester's name, and a relative timestamp.
+
+```yaml
+services:
+  - name: Seerr Requests
+    widget:
+      type: seerr-requests
+      config:
+        url: http://192.168.1.10:5055
+        api_key: YOUR_API_KEY
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `url` | Yes | Base URL of your Seerr instance |
+| `api_key` | Yes | API key from Settings → General |
+
+A request whose media has become fully available is shown with an **available** badge regardless of its underlying request status.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -6953,6 +6953,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9311,6 +9312,474 @@
         }
       }
     },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/vitest/node_modules/@vitest/mocker": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
@@ -9336,6 +9805,50 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
       }
     },
     "node_modules/vitest/node_modules/picomatch": {

--- a/src/__tests__/integrations/seerr.test.ts
+++ b/src/__tests__/integrations/seerr.test.ts
@@ -279,134 +279,86 @@ describe("fetchRequests", () => {
   });
 });
 
-// ── Widget registration — seerr-stats ─────────────────────────────────────────
+// ── Widget registration (table-driven) ───────────────────────────────────────
 
-describe("seerr-stats widget registration", () => {
-  beforeEach(() => {
-    clearRegistry();
-    vi.resetModules();
-  });
+const WIDGET_DESCRIPTORS = [
+  {
+    id: "seerr-stats",
+    importPath: "@/integrations/seerr/statsWidget" as const,
+    expectedName: "Seerr Stats",
+    refreshInterval: 60_000,
+  },
+  {
+    id: "seerr-requests",
+    importPath: "@/integrations/seerr/requestsWidget" as const,
+    expectedName: "Seerr Requests",
+    refreshInterval: 60_000,
+  },
+];
 
-  it("registers a widget with id 'seerr-stats' on import", async () => {
-    await import("@/integrations/seerr/statsWidget");
-    const { getWidget } = await import("@/widgets");
-    expect(getWidget("seerr-stats")).toBeDefined();
-  });
-
-  it("widget name is 'Seerr Stats'", async () => {
-    await import("@/integrations/seerr/statsWidget");
-    const { getWidget } = await import("@/widgets");
-    expect(getWidget("seerr-stats")?.name).toBe("Seerr Stats");
-  });
-
-  it("refreshInterval is 60000", async () => {
-    await import("@/integrations/seerr/statsWidget");
-    const { getWidget } = await import("@/widgets");
-    expect(getWidget("seerr-stats")?.refreshInterval).toBe(60_000);
-  });
-
-  it("configSchema accepts valid config", async () => {
-    await import("@/integrations/seerr/statsWidget");
-    const { getWidget } = await import("@/widgets");
-    const result = getWidget("seerr-stats")!.configSchema.safeParse({
-      url: "http://192.168.1.10:5055",
-      api_key: "myapikey",
+describe.each(WIDGET_DESCRIPTORS)(
+  "$id widget registration",
+  ({ id, importPath, expectedName, refreshInterval }) => {
+    beforeEach(() => {
+      clearRegistry();
+      vi.resetModules();
     });
-    expect(result.success).toBe(true);
-  });
 
-  it("configSchema rejects invalid URL", async () => {
-    await import("@/integrations/seerr/statsWidget");
-    const { getWidget } = await import("@/widgets");
-    const result = getWidget("seerr-stats")!.configSchema.safeParse({
-      url: "not-a-url",
-      api_key: "myapikey",
+    it(`registers a widget with id '${id}' on import`, async () => {
+      await import(importPath);
+      const { getWidget } = await import("@/widgets");
+      expect(getWidget(id)).toBeDefined();
     });
-    expect(result.success).toBe(false);
-  });
 
-  it("configSchema rejects empty api_key", async () => {
-    await import("@/integrations/seerr/statsWidget");
-    const { getWidget } = await import("@/widgets");
-    const result = getWidget("seerr-stats")!.configSchema.safeParse({
-      url: "http://192.168.1.10:5055",
-      api_key: "",
+    it(`widget name is '${expectedName}'`, async () => {
+      await import(importPath);
+      const { getWidget } = await import("@/widgets");
+      expect(getWidget(id)?.name).toBe(expectedName);
     });
-    expect(result.success).toBe(false);
-  });
 
-  it("configFields contains url and api_key keys", async () => {
-    await import("@/integrations/seerr/statsWidget");
-    const { getWidget } = await import("@/widgets");
-    const fields = getWidget("seerr-stats")?.configFields ?? [];
-    const keys = fields.map((f) => f.key);
-    expect(keys).toContain("url");
-    expect(keys).toContain("api_key");
-  });
-});
-
-// ── Widget registration — seerr-requests ─────────────────────────────────────
-
-describe("seerr-requests widget registration", () => {
-  beforeEach(() => {
-    clearRegistry();
-    vi.resetModules();
-  });
-
-  it("registers a widget with id 'seerr-requests' on import", async () => {
-    await import("@/integrations/seerr/requestsWidget");
-    const { getWidget } = await import("@/widgets");
-    expect(getWidget("seerr-requests")).toBeDefined();
-  });
-
-  it("widget name is 'Seerr Requests'", async () => {
-    await import("@/integrations/seerr/requestsWidget");
-    const { getWidget } = await import("@/widgets");
-    expect(getWidget("seerr-requests")?.name).toBe("Seerr Requests");
-  });
-
-  it("refreshInterval is 60000", async () => {
-    await import("@/integrations/seerr/requestsWidget");
-    const { getWidget } = await import("@/widgets");
-    expect(getWidget("seerr-requests")?.refreshInterval).toBe(60_000);
-  });
-
-  it("configSchema accepts valid config", async () => {
-    await import("@/integrations/seerr/requestsWidget");
-    const { getWidget } = await import("@/widgets");
-    const result = getWidget("seerr-requests")!.configSchema.safeParse({
-      url: "http://192.168.1.10:5055",
-      api_key: "myapikey",
+    it(`refreshInterval is ${refreshInterval}`, async () => {
+      await import(importPath);
+      const { getWidget } = await import("@/widgets");
+      expect(getWidget(id)?.refreshInterval).toBe(refreshInterval);
     });
-    expect(result.success).toBe(true);
-  });
 
-  it("configSchema rejects invalid URL", async () => {
-    await import("@/integrations/seerr/requestsWidget");
-    const { getWidget } = await import("@/widgets");
-    const result = getWidget("seerr-requests")!.configSchema.safeParse({
-      url: "not-a-url",
-      api_key: "myapikey",
+    it("configSchema accepts valid config", async () => {
+      await import(importPath);
+      const { getWidget } = await import("@/widgets");
+      const result = getWidget(id)!.configSchema.safeParse({
+        url: "http://192.168.1.10:5055",
+        api_key: "myapikey",
+      });
+      expect(result.success).toBe(true);
     });
-    expect(result.success).toBe(false);
-  });
 
-  it("configSchema rejects empty api_key", async () => {
-    await import("@/integrations/seerr/requestsWidget");
-    const { getWidget } = await import("@/widgets");
-    const result = getWidget("seerr-requests")!.configSchema.safeParse({
-      url: "http://192.168.1.10:5055",
-      api_key: "",
+    it("configSchema rejects invalid URL", async () => {
+      await import(importPath);
+      const { getWidget } = await import("@/widgets");
+      const result = getWidget(id)!.configSchema.safeParse({
+        url: "not-a-url",
+        api_key: "myapikey",
+      });
+      expect(result.success).toBe(false);
     });
-    expect(result.success).toBe(false);
-  });
 
-  it("configFields contains url and api_key keys", async () => {
-    await import("@/integrations/seerr/requestsWidget");
-    const { getWidget } = await import("@/widgets");
-    const fields = getWidget("seerr-requests")?.configFields ?? [];
-    const keys = fields.map((f) => f.key);
-    expect(keys).toContain("url");
-    expect(keys).toContain("api_key");
-  });
-});
+    it("configSchema rejects empty api_key", async () => {
+      await import(importPath);
+      const { getWidget } = await import("@/widgets");
+      const result = getWidget(id)!.configSchema.safeParse({
+        url: "http://192.168.1.10:5055",
+        api_key: "",
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it("configFields contains url and api_key keys", async () => {
+      await import(importPath);
+      const { getWidget } = await import("@/widgets");
+      const fields = getWidget(id)?.configFields ?? [];
+      const keys = fields.map((f) => f.key);
+      expect(keys).toContain("url");
+      expect(keys).toContain("api_key");
+    });
+  }
+);

--- a/src/__tests__/integrations/seerr.test.ts
+++ b/src/__tests__/integrations/seerr.test.ts
@@ -73,7 +73,7 @@ describe("fetchStats", () => {
 
     await fetchStats(BASE_CONFIG);
 
-    const urls = mockFetch.mock.calls.map(([url]: [string]) => url);
+    const urls = mockFetch.mock.calls.map(([url]) => url);
     expect(urls.some((u: string) => u.includes("filter=all"))).toBe(true);
     expect(urls.some((u: string) => u.includes("filter=pending"))).toBe(true);
     expect(urls.some((u: string) => u.includes("filter=approved"))).toBe(true);
@@ -115,7 +115,7 @@ describe("fetchStats", () => {
     const configWithBasePath = { ...BASE_CONFIG, url: "http://seerr.local:5055/seerr/" };
     await fetchStats(configWithBasePath);
 
-    const urls = mockFetch.mock.calls.map(([url]: [string]) => url);
+    const urls = mockFetch.mock.calls.map(([url]) => url);
     for (const url of urls) {
       expect(url).toContain("/seerr/api/v1/request");
     }

--- a/src/__tests__/integrations/seerr.test.ts
+++ b/src/__tests__/integrations/seerr.test.ts
@@ -1,0 +1,412 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { clearRegistry } from "@/widgets";
+import { fetchStats, fetchRequests } from "@/integrations/seerr/api";
+
+const BASE_CONFIG = {
+  url: "http://seerr.local:5055",
+  api_key: "abc123secret",
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeJsonResponse(body: unknown) {
+  return { ok: true, status: 200, json: async () => body };
+}
+
+function makeErrorResponse(status: number) {
+  return { ok: false, status };
+}
+
+function makePageInfoResponse(results: number) {
+  return makeJsonResponse({ pageInfo: { results } });
+}
+
+// ── fetchStats ────────────────────────────────────────────────────────────────
+
+describe("fetchStats", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns correct counts from pageInfo.results across 4 responses", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValueOnce(makePageInfoResponse(42)) // all
+      .mockResolvedValueOnce(makePageInfoResponse(5))  // pending
+      .mockResolvedValueOnce(makePageInfoResponse(20)) // approved
+      .mockResolvedValueOnce(makePageInfoResponse(17)); // available
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await fetchStats(BASE_CONFIG);
+
+    expect(result.total).toBe(42);
+    expect(result.pending).toBe(5);
+    expect(result.approved).toBe(20);
+    expect(result.available).toBe(17);
+  });
+
+  it("makes exactly 4 fetch calls", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(makePageInfoResponse(0));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fetchStats(BASE_CONFIG);
+
+    expect(mockFetch).toHaveBeenCalledTimes(4);
+  });
+
+  it("all 4 calls use the X-Api-Key header", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(makePageInfoResponse(0));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fetchStats(BASE_CONFIG);
+
+    for (const [, options] of mockFetch.mock.calls) {
+      expect(options.headers["X-Api-Key"]).toBe("abc123secret");
+    }
+  });
+
+  it("calls include filter=all, filter=pending, filter=approved, filter=available", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(makePageInfoResponse(0));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fetchStats(BASE_CONFIG);
+
+    const urls = mockFetch.mock.calls.map(([url]: [string]) => url);
+    expect(urls.some((u: string) => u.includes("filter=all"))).toBe(true);
+    expect(urls.some((u: string) => u.includes("filter=pending"))).toBe(true);
+    expect(urls.some((u: string) => u.includes("filter=approved"))).toBe(true);
+    expect(urls.some((u: string) => u.includes("filter=available"))).toBe(true);
+  });
+
+  it("all calls include take=1", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(makePageInfoResponse(0));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fetchStats(BASE_CONFIG);
+
+    for (const [url] of mockFetch.mock.calls) {
+      expect(url).toContain("take=1");
+    }
+  });
+
+  it("throws on non-2xx response with status in message", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeErrorResponse(401)));
+    await expect(fetchStats(BASE_CONFIG)).rejects.toThrow("401");
+  });
+
+  it("forwards AbortSignal to all calls", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(makePageInfoResponse(0));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const controller = new AbortController();
+    await fetchStats(BASE_CONFIG, controller.signal);
+
+    for (const [, options] of mockFetch.mock.calls) {
+      expect(options.signal).toBe(controller.signal);
+    }
+  });
+
+  it("preserves base path in config.url when resolving API path", async () => {
+    const mockFetch = vi.fn().mockResolvedValue(makePageInfoResponse(0));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const configWithBasePath = { ...BASE_CONFIG, url: "http://seerr.local:5055/seerr/" };
+    await fetchStats(configWithBasePath);
+
+    const urls = mockFetch.mock.calls.map(([url]: [string]) => url);
+    for (const url of urls) {
+      expect(url).toContain("/seerr/api/v1/request");
+    }
+  });
+});
+
+// ── fetchRequests ─────────────────────────────────────────────────────────────
+
+const MOCK_MOVIE_REQUEST = {
+  id: 1,
+  status: 1,
+  createdAt: "2026-02-01T10:00:00.000Z",
+  type: "movie",
+  requestedBy: { displayName: "Alice" },
+  media: { tmdbId: 550, status: 2, title: "Fight Club", name: null },
+};
+
+const MOCK_TV_REQUEST = {
+  id: 2,
+  status: 2,
+  createdAt: "2026-02-02T12:00:00.000Z",
+  type: "tv",
+  requestedBy: { displayName: "Bob" },
+  media: { tmdbId: 1396, status: 5, title: null, name: "Breaking Bad" },
+};
+
+const MOCK_NO_TITLE_REQUEST = {
+  id: 3,
+  status: 1,
+  createdAt: "2026-02-03T08:00:00.000Z",
+  type: "movie",
+  requestedBy: { displayName: "Carol" },
+  media: { tmdbId: 999, status: 1, title: null, name: null },
+};
+
+describe("fetchRequests", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("returns parsed request array from results", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(makeJsonResponse({ results: [MOCK_MOVIE_REQUEST, MOCK_TV_REQUEST] }))
+    );
+    const result = await fetchRequests(BASE_CONFIG);
+    expect(result).toHaveLength(2);
+  });
+
+  it("extracts media.title for movies into title field", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(makeJsonResponse({ results: [MOCK_MOVIE_REQUEST] }))
+    );
+    const result = await fetchRequests(BASE_CONFIG);
+    expect(result[0].title).toBe("Fight Club");
+  });
+
+  it("falls back to media.name when media.title is absent (TV shows)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(makeJsonResponse({ results: [MOCK_TV_REQUEST] }))
+    );
+    const result = await fetchRequests(BASE_CONFIG);
+    expect(result[0].title).toBe("Breaking Bad");
+  });
+
+  it("sets title to null when neither title nor name is present", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(makeJsonResponse({ results: [MOCK_NO_TITLE_REQUEST] }))
+    );
+    const result = await fetchRequests(BASE_CONFIG);
+    expect(result[0].title).toBeNull();
+  });
+
+  it("preserves requestStatus and mediaStatus correctly", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(makeJsonResponse({ results: [MOCK_TV_REQUEST] }))
+    );
+    const result = await fetchRequests(BASE_CONFIG);
+    expect(result[0].requestStatus).toBe(2);
+    expect(result[0].mediaStatus).toBe(5);
+  });
+
+  it("preserves mediaType, tmdbId, requestedBy, and createdAt", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(makeJsonResponse({ results: [MOCK_MOVIE_REQUEST] }))
+    );
+    const result = await fetchRequests(BASE_CONFIG);
+    expect(result[0].mediaType).toBe("movie");
+    expect(result[0].tmdbId).toBe(550);
+    expect(result[0].requestedBy).toBe("Alice");
+    expect(result[0].createdAt).toBe("2026-02-01T10:00:00.000Z");
+  });
+
+  it("sends endpoint with take=15, sort=added, filter=all", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(makeJsonResponse({ results: [] }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fetchRequests(BASE_CONFIG);
+
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toContain("take=15");
+    expect(url).toContain("sort=added");
+    expect(url).toContain("filter=all");
+  });
+
+  it("sends X-Api-Key header", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(makeJsonResponse({ results: [] }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    await fetchRequests(BASE_CONFIG);
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options.headers["X-Api-Key"]).toBe("abc123secret");
+  });
+
+  it("throws on non-2xx response with status in message", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(makeErrorResponse(403)));
+    await expect(fetchRequests(BASE_CONFIG)).rejects.toThrow("403");
+  });
+
+  it("forwards AbortSignal", async () => {
+    const mockFetch = vi
+      .fn()
+      .mockResolvedValue(makeJsonResponse({ results: [] }));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const controller = new AbortController();
+    await fetchRequests(BASE_CONFIG, controller.signal);
+
+    const [, options] = mockFetch.mock.calls[0];
+    expect(options.signal).toBe(controller.signal);
+  });
+
+  it("strips unknown fields silently via Zod", async () => {
+    const withExtra = { ...MOCK_MOVIE_REQUEST, unknownField: "foo" };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(makeJsonResponse({ results: [withExtra] }))
+    );
+    const result = await fetchRequests(BASE_CONFIG);
+    expect(result[0]).not.toHaveProperty("unknownField");
+  });
+
+  it("handles empty results gracefully", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(makeJsonResponse({ results: [] }))
+    );
+    const result = await fetchRequests(BASE_CONFIG);
+    expect(result).toEqual([]);
+  });
+});
+
+// ── Widget registration — seerr-stats ─────────────────────────────────────────
+
+describe("seerr-stats widget registration", () => {
+  beforeEach(() => {
+    clearRegistry();
+    vi.resetModules();
+  });
+
+  it("registers a widget with id 'seerr-stats' on import", async () => {
+    await import("@/integrations/seerr/statsWidget");
+    const { getWidget } = await import("@/widgets");
+    expect(getWidget("seerr-stats")).toBeDefined();
+  });
+
+  it("widget name is 'Seerr Stats'", async () => {
+    await import("@/integrations/seerr/statsWidget");
+    const { getWidget } = await import("@/widgets");
+    expect(getWidget("seerr-stats")?.name).toBe("Seerr Stats");
+  });
+
+  it("refreshInterval is 60000", async () => {
+    await import("@/integrations/seerr/statsWidget");
+    const { getWidget } = await import("@/widgets");
+    expect(getWidget("seerr-stats")?.refreshInterval).toBe(60_000);
+  });
+
+  it("configSchema accepts valid config", async () => {
+    await import("@/integrations/seerr/statsWidget");
+    const { getWidget } = await import("@/widgets");
+    const result = getWidget("seerr-stats")!.configSchema.safeParse({
+      url: "http://192.168.1.10:5055",
+      api_key: "myapikey",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("configSchema rejects invalid URL", async () => {
+    await import("@/integrations/seerr/statsWidget");
+    const { getWidget } = await import("@/widgets");
+    const result = getWidget("seerr-stats")!.configSchema.safeParse({
+      url: "not-a-url",
+      api_key: "myapikey",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("configSchema rejects empty api_key", async () => {
+    await import("@/integrations/seerr/statsWidget");
+    const { getWidget } = await import("@/widgets");
+    const result = getWidget("seerr-stats")!.configSchema.safeParse({
+      url: "http://192.168.1.10:5055",
+      api_key: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("configFields contains url and api_key keys", async () => {
+    await import("@/integrations/seerr/statsWidget");
+    const { getWidget } = await import("@/widgets");
+    const fields = getWidget("seerr-stats")?.configFields ?? [];
+    const keys = fields.map((f) => f.key);
+    expect(keys).toContain("url");
+    expect(keys).toContain("api_key");
+  });
+});
+
+// ── Widget registration — seerr-requests ─────────────────────────────────────
+
+describe("seerr-requests widget registration", () => {
+  beforeEach(() => {
+    clearRegistry();
+    vi.resetModules();
+  });
+
+  it("registers a widget with id 'seerr-requests' on import", async () => {
+    await import("@/integrations/seerr/requestsWidget");
+    const { getWidget } = await import("@/widgets");
+    expect(getWidget("seerr-requests")).toBeDefined();
+  });
+
+  it("widget name is 'Seerr Requests'", async () => {
+    await import("@/integrations/seerr/requestsWidget");
+    const { getWidget } = await import("@/widgets");
+    expect(getWidget("seerr-requests")?.name).toBe("Seerr Requests");
+  });
+
+  it("refreshInterval is 60000", async () => {
+    await import("@/integrations/seerr/requestsWidget");
+    const { getWidget } = await import("@/widgets");
+    expect(getWidget("seerr-requests")?.refreshInterval).toBe(60_000);
+  });
+
+  it("configSchema accepts valid config", async () => {
+    await import("@/integrations/seerr/requestsWidget");
+    const { getWidget } = await import("@/widgets");
+    const result = getWidget("seerr-requests")!.configSchema.safeParse({
+      url: "http://192.168.1.10:5055",
+      api_key: "myapikey",
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("configSchema rejects invalid URL", async () => {
+    await import("@/integrations/seerr/requestsWidget");
+    const { getWidget } = await import("@/widgets");
+    const result = getWidget("seerr-requests")!.configSchema.safeParse({
+      url: "not-a-url",
+      api_key: "myapikey",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("configSchema rejects empty api_key", async () => {
+    await import("@/integrations/seerr/requestsWidget");
+    const { getWidget } = await import("@/widgets");
+    const result = getWidget("seerr-requests")!.configSchema.safeParse({
+      url: "http://192.168.1.10:5055",
+      api_key: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("configFields contains url and api_key keys", async () => {
+    await import("@/integrations/seerr/requestsWidget");
+    const { getWidget } = await import("@/widgets");
+    const fields = getWidget("seerr-requests")?.configFields ?? [];
+    const keys = fields.map((f) => f.key);
+    expect(keys).toContain("url");
+    expect(keys).toContain("api_key");
+  });
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1632,6 +1632,229 @@ body {
   grid-column: 1 / -1;
 }
 
+/* ── Seerr stats widget ───────────────────────────────────────────────────── */
+
+.seerr-stats-widget {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.seerr-stats-widget__grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 6px;
+  flex: 1 1 0;
+  align-content: center;
+  padding: 4px;
+}
+
+.seerr-stats-widget__stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 6px 4px;
+  border-radius: 4px;
+  background: var(--color-surface-2);
+  min-width: 0;
+}
+
+.seerr-stats-widget__value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.seerr-stats-widget__label {
+  font-size: 0.65rem;
+  color: var(--color-text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  white-space: nowrap;
+}
+
+.seerr-stats-widget__stat--pending .seerr-stats-widget__value {
+  color: #f59e0b;
+}
+
+.seerr-stats-widget__stat--approved .seerr-stats-widget__value {
+  color: #615fff;
+}
+
+.seerr-stats-widget__stat--available .seerr-stats-widget__value {
+  color: #22c55e;
+}
+
+.seerr-stats-widget__stat--total .seerr-stats-widget__value {
+  color: var(--color-text);
+}
+
+.seerr-stats-widget--empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+}
+
+.seerr-stats-widget__hint {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.seerr-stats-widget__hint--error {
+  color: #f87171;
+}
+
+.seerr-stats-widget__stale-error {
+  font-size: 0.7rem;
+  color: #f87171;
+  text-align: center;
+  padding: 4px 0;
+  flex-shrink: 0;
+}
+
+/* ── Seerr requests widget ────────────────────────────────────────────────── */
+
+.seerr-requests-widget {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.seerr-requests-widget__list {
+  flex: 1 1 0;
+  overflow-y: auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.seerr-requests-widget__row {
+  display: grid;
+  grid-template-columns: auto auto 1fr auto;
+  gap: 6px;
+  align-items: center;
+  padding: 5px 4px;
+  border-bottom: 1px solid var(--color-border);
+  min-width: 0;
+}
+
+.seerr-requests-widget__row:last-child {
+  border-bottom: none;
+}
+
+.seerr-requests-widget__badge {
+  font-size: 0.6rem;
+  font-weight: 600;
+  padding: 1px 5px;
+  border-radius: 3px;
+  white-space: nowrap;
+  flex-shrink: 0;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.seerr-requests-widget__badge--pending {
+  background: color-mix(in srgb, #f59e0b 18%, transparent);
+  color: #f59e0b;
+}
+
+.seerr-requests-widget__badge--approved {
+  background: color-mix(in srgb, #615fff 18%, transparent);
+  color: #8b8fff;
+}
+
+.seerr-requests-widget__badge--available {
+  background: color-mix(in srgb, #22c55e 18%, transparent);
+  color: #22c55e;
+}
+
+.seerr-requests-widget__badge--declined,
+.seerr-requests-widget__badge--failed {
+  background: color-mix(in srgb, #ef4444 18%, transparent);
+  color: #f87171;
+}
+
+.seerr-requests-widget__type {
+  font-size: 0.6rem;
+  padding: 1px 4px;
+  border-radius: 3px;
+  white-space: nowrap;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.seerr-requests-widget__type--movie {
+  background: color-mix(in srgb, #60a5fa 15%, transparent);
+  color: #60a5fa;
+}
+
+.seerr-requests-widget__type--tv {
+  background: color-mix(in srgb, #a78bfa 15%, transparent);
+  color: #a78bfa;
+}
+
+.seerr-requests-widget__info {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+
+.seerr-requests-widget__title {
+  font-size: 0.8rem;
+  color: var(--color-text);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.seerr-requests-widget__requester {
+  font-size: 0.68rem;
+  color: var(--color-text-muted);
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.seerr-requests-widget__time {
+  font-size: 0.68rem;
+  color: var(--color-text-muted);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.seerr-requests-widget--empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+  gap: 4px;
+}
+
+.seerr-requests-widget__hint {
+  font-size: 0.8rem;
+  color: var(--color-text-muted);
+}
+
+.seerr-requests-widget__hint--error {
+  color: #f87171;
+}
+
+.seerr-requests-widget__stale-error {
+  font-size: 0.7rem;
+  color: #f87171;
+  text-align: center;
+  padding: 4px 0;
+  flex-shrink: 0;
+}
+
 /* User-injected custom CSS from appearance.customCss in settings.yaml */
 /* This layer is loaded last and always wins without needing !important */
 @layer user-custom;

--- a/src/integrations/index.ts
+++ b/src/integrations/index.ts
@@ -8,5 +8,7 @@ import "./sonarr/queueWidget";
 import "./sabnzbd/widget";
 import "./radarr/statsWidget";
 import "./radarr/queueWidget";
+import "./seerr/statsWidget";
+import "./seerr/requestsWidget";
 
 export type IntegrationStatus = "ok" | "error" | "unknown";

--- a/src/integrations/seerr/api.ts
+++ b/src/integrations/seerr/api.ts
@@ -56,7 +56,7 @@ export async function fetchStats(
 const RawRequestSchema = z.object({
   id: z.number(),
   status: z.number(),      // 1=PENDING, 2=APPROVED, 3=DECLINED, 4=FAILED
-  createdAt: z.string(),
+  createdAt: z.string().datetime(),
   type: z.enum(["movie", "tv"]),
   requestedBy: z.object({ displayName: z.string() }),
   media: z.object({

--- a/src/integrations/seerr/api.ts
+++ b/src/integrations/seerr/api.ts
@@ -1,0 +1,96 @@
+import { z } from "zod";
+import { fetchWithApiKey } from "@/integrations/shared/http";
+
+export interface SeerrConfig {
+  url: string;
+  api_key: string;
+}
+
+export const SeerrConfigSchema = z.object({
+  url: z.string().url(),
+  api_key: z.string().min(1),
+});
+
+// ── Stats ────────────────────────────────────────────────────────────────────
+
+export interface SeerrStats {
+  pending: number;
+  approved: number;
+  available: number;
+  total: number;
+}
+
+const PageInfoResponseSchema = z.object({
+  pageInfo: z.object({ results: z.number() }),
+});
+
+/**
+ * Fetches request counts by making 4 parallel requests with take=1 per filter.
+ * pageInfo.results holds the total count for that filter — no need to fetch all records.
+ */
+export async function fetchStats(
+  config: SeerrConfig,
+  signal?: AbortSignal
+): Promise<SeerrStats> {
+  const [allRes, pendingRes, approvedRes, availableRes] = await Promise.all([
+    fetchWithApiKey(config, "api/v1/request?filter=all&take=1",       signal, "Seerr"),
+    fetchWithApiKey(config, "api/v1/request?filter=pending&take=1",   signal, "Seerr"),
+    fetchWithApiKey(config, "api/v1/request?filter=approved&take=1",  signal, "Seerr"),
+    fetchWithApiKey(config, "api/v1/request?filter=available&take=1", signal, "Seerr"),
+  ]);
+
+  const parseCount = async (r: Response) =>
+    PageInfoResponseSchema.parse(await r.json()).pageInfo.results;
+
+  const [total, pending, approved, available] = await Promise.all(
+    [allRes, pendingRes, approvedRes, availableRes].map(parseCount)
+  );
+
+  return { total, pending, approved, available };
+}
+
+// ── Requests list ────────────────────────────────────────────────────────────
+
+// Internal schema matching the Seerr/Overseerr/Jellyseerr MediaRequest API shape.
+// title/name are optional: older instances may not embed them in the request response.
+const RawRequestSchema = z.object({
+  id: z.number(),
+  status: z.number(),      // 1=PENDING, 2=APPROVED, 3=DECLINED, 4=FAILED
+  createdAt: z.string(),
+  type: z.enum(["movie", "tv"]),
+  requestedBy: z.object({ displayName: z.string() }),
+  media: z.object({
+    tmdbId: z.number(),
+    status: z.number(),    // 1=UNKNOWN … 5=AVAILABLE
+    title: z.string().optional().nullable(),  // movies
+    name: z.string().optional().nullable(),   // TV shows (some API versions)
+  }),
+});
+
+// Widget-facing type — flat and clean.
+const SeerrRequestSchema = RawRequestSchema.transform((r) => ({
+  id: r.id,
+  requestStatus: r.status,
+  mediaStatus: r.media.status,
+  mediaType: r.type,
+  title: r.media.title ?? r.media.name ?? null,
+  tmdbId: r.media.tmdbId,
+  requestedBy: r.requestedBy.displayName,
+  createdAt: r.createdAt,
+}));
+
+export type SeerrRequest = z.output<typeof SeerrRequestSchema>;
+
+export async function fetchRequests(
+  config: SeerrConfig,
+  signal?: AbortSignal
+): Promise<SeerrRequest[]> {
+  const response = await fetchWithApiKey(
+    config,
+    "api/v1/request?take=15&sort=added&filter=all",
+    signal,
+    "Seerr"
+  );
+  const data = await response.json();
+  return z.object({ results: z.array(SeerrRequestSchema) }).parse(data).results;
+}

--- a/src/integrations/seerr/requestsWidget.tsx
+++ b/src/integrations/seerr/requestsWidget.tsx
@@ -18,7 +18,9 @@ function displayTitle(req: SeerrRequest): string {
 }
 
 function relativeTime(iso: string): string {
-  const diff = Date.now() - new Date(iso).getTime();
+  const ms = new Date(iso).getTime();
+  if (isNaN(ms)) return "unknown";
+  const diff = Math.max(0, Date.now() - ms);
   const m = Math.floor(diff / 60_000);
   if (m < 60) return `${m}m ago`;
   const h = Math.floor(m / 60);

--- a/src/integrations/seerr/requestsWidget.tsx
+++ b/src/integrations/seerr/requestsWidget.tsx
@@ -1,0 +1,142 @@
+import { registerWidget } from "@/widgets";
+import type { WidgetProps } from "@/widgets";
+import { fetchRequests, SeerrConfigSchema } from "./api";
+import type { SeerrConfig, SeerrRequest } from "./api";
+
+type EffectiveStatus = "pending" | "approved" | "available" | "declined" | "failed";
+
+function effectiveStatus(req: SeerrRequest): EffectiveStatus {
+  if (req.mediaStatus === 5) return "available";
+  if (req.requestStatus === 2) return "approved";
+  if (req.requestStatus === 3) return "declined";
+  if (req.requestStatus === 4) return "failed";
+  return "pending";
+}
+
+function displayTitle(req: SeerrRequest): string {
+  return req.title ?? (req.mediaType === "movie" ? "(Movie)" : "(Show)");
+}
+
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime();
+  const m = Math.floor(diff / 60_000);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  if (d < 7) return `${d}d ago`;
+  return `${Math.floor(d / 7)}w ago`;
+}
+
+const STATUS_LABELS: Record<EffectiveStatus, string> = {
+  pending: "pending",
+  approved: "approved",
+  available: "available",
+  declined: "declined",
+  failed: "failed",
+};
+
+export function SeerrRequestsWidget({
+  data,
+  loading,
+  error,
+}: WidgetProps<SeerrRequest[]>) {
+  if (!data) {
+    return (
+      <div className="seerr-requests-widget seerr-requests-widget--empty">
+        {loading && (
+          <span className="seerr-requests-widget__hint">Loading&hellip;</span>
+        )}
+        {error && (
+          <span className="seerr-requests-widget__hint seerr-requests-widget__hint--error">
+            {error}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  if (data.length === 0) {
+    return (
+      <div className="seerr-requests-widget seerr-requests-widget--empty">
+        <span className="seerr-requests-widget__hint">No requests</span>
+        {error && (
+          <span
+            className="seerr-requests-widget__stale-error"
+            role="alert"
+          >
+            {error}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="seerr-requests-widget" aria-label="Seerr requests">
+      <div className="seerr-requests-widget__list">
+        {data.map((req) => {
+          const status = effectiveStatus(req);
+          return (
+            <div key={req.id} className="seerr-requests-widget__row">
+              <span
+                className={`seerr-requests-widget__badge seerr-requests-widget__badge--${status}`}
+              >
+                {STATUS_LABELS[status]}
+              </span>
+              <span
+                className={`seerr-requests-widget__type seerr-requests-widget__type--${req.mediaType}`}
+              >
+                {req.mediaType}
+              </span>
+              <div className="seerr-requests-widget__info">
+                <span
+                  className="seerr-requests-widget__title"
+                  title={displayTitle(req)}
+                >
+                  {displayTitle(req)}
+                </span>
+                <span className="seerr-requests-widget__requester">
+                  {req.requestedBy}
+                </span>
+              </div>
+              <span className="seerr-requests-widget__time">
+                {relativeTime(req.createdAt)}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      {error && (
+        <span className="seerr-requests-widget__stale-error" role="alert">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}
+
+registerWidget<SeerrConfig, SeerrRequest[]>({
+  id: "seerr-requests",
+  name: "Seerr Requests",
+  configSchema: SeerrConfigSchema,
+  fetchData: fetchRequests,
+  refreshInterval: 60_000,
+  component: SeerrRequestsWidget,
+  configFields: [
+    {
+      key: "url",
+      label: "URL",
+      type: "url",
+      required: true,
+      placeholder: "http://192.168.1.x:5055",
+      description: "Works with Seerr, Jellyseerr, and Overseerr",
+    },
+    { key: "api_key", label: "API Key", type: "password", required: true },
+  ],
+  serviceEditorPreset: {
+    defaultName: "Seerr",
+    defaultIconUrl:
+      "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons@main/svg/seerr.svg",
+  },
+});

--- a/src/integrations/seerr/requestsWidget.tsx
+++ b/src/integrations/seerr/requestsWidget.tsx
@@ -79,6 +79,7 @@ export function SeerrRequestsWidget({
       <div className="seerr-requests-widget__list">
         {data.map((req) => {
           const status = effectiveStatus(req);
+          const title = displayTitle(req);
           return (
             <div key={req.id} className="seerr-requests-widget__row">
               <span
@@ -94,9 +95,9 @@ export function SeerrRequestsWidget({
               <div className="seerr-requests-widget__info">
                 <span
                   className="seerr-requests-widget__title"
-                  title={displayTitle(req)}
+                  title={title}
                 >
-                  {displayTitle(req)}
+                  {title}
                 </span>
                 <span className="seerr-requests-widget__requester">
                   {req.requestedBy}

--- a/src/integrations/seerr/statsWidget.tsx
+++ b/src/integrations/seerr/statsWidget.tsx
@@ -1,0 +1,79 @@
+import { registerWidget } from "@/widgets";
+import type { WidgetProps } from "@/widgets";
+import { fetchStats, SeerrConfigSchema } from "./api";
+import type { SeerrConfig, SeerrStats } from "./api";
+
+export function SeerrStatsWidget({
+  data,
+  loading,
+  error,
+}: WidgetProps<SeerrStats>) {
+  if (!data) {
+    return (
+      <div className="seerr-stats-widget seerr-stats-widget--empty">
+        {loading && (
+          <span className="seerr-stats-widget__hint">Loading&hellip;</span>
+        )}
+        {error && (
+          <span className="seerr-stats-widget__hint seerr-stats-widget__hint--error">
+            {error}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="seerr-stats-widget" aria-label="Seerr stats">
+      <div className="seerr-stats-widget__grid">
+        <div className="seerr-stats-widget__stat seerr-stats-widget__stat--pending">
+          <span className="seerr-stats-widget__value">{data.pending}</span>
+          <span className="seerr-stats-widget__label">Pending</span>
+        </div>
+        <div className="seerr-stats-widget__stat seerr-stats-widget__stat--approved">
+          <span className="seerr-stats-widget__value">{data.approved}</span>
+          <span className="seerr-stats-widget__label">Approved</span>
+        </div>
+        <div className="seerr-stats-widget__stat seerr-stats-widget__stat--available">
+          <span className="seerr-stats-widget__value">{data.available}</span>
+          <span className="seerr-stats-widget__label">Available</span>
+        </div>
+        <div className="seerr-stats-widget__stat seerr-stats-widget__stat--total">
+          <span className="seerr-stats-widget__value">{data.total}</span>
+          <span className="seerr-stats-widget__label">Total</span>
+        </div>
+      </div>
+      {error && (
+        <span className="seerr-stats-widget__stale-error" role="alert">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}
+
+registerWidget<SeerrConfig, SeerrStats>({
+  id: "seerr-stats",
+  name: "Seerr Stats",
+  configSchema: SeerrConfigSchema,
+  fetchData: fetchStats,
+  refreshInterval: 60_000,
+  component: SeerrStatsWidget,
+  configFields: [
+    {
+      key: "url",
+      label: "URL",
+      type: "url",
+      required: true,
+      placeholder: "http://192.168.1.x:5055",
+      description: "Works with Seerr, Jellyseerr, and Overseerr",
+    },
+    { key: "api_key", label: "API Key", type: "password", required: true },
+  ],
+  serviceEditorPreset: {
+    defaultName: "Seerr",
+    // Seerr brand color #615fff. Not yet on simpleicons (PR #14462 pending).
+    defaultIconUrl:
+      "https://cdn.jsdelivr.net/gh/walkxcode/dashboard-icons@main/svg/seerr.svg",
+  },
+});


### PR DESCRIPTION
## Summary
Adds a new Seerr integration with two widgets: one for displaying request statistics (pending, approved, available, total counts) and another for listing recent requests with their status and metadata.

## Key Changes
- **New API module** (`src/integrations/seerr/api.ts`):
  - `fetchStats()` — fetches request counts by making 4 parallel API calls with `take=1` per filter (all, pending, approved, available)
  - `fetchRequests()` — fetches up to 15 recent requests sorted by creation date
  - Zod schemas for config validation and response parsing
  - Support for Seerr, Jellyseerr, and Overseerr APIs

- **Stats widget** (`src/integrations/seerr/statsWidget.tsx`):
  - Displays a 2×2 grid showing pending, approved, available, and total request counts
  - Color-coded values (amber for pending, purple for approved, green for available)
  - 60-second refresh interval

- **Requests widget** (`src/integrations/seerr/requestsWidget.tsx`):
  - Lists recent requests with status badge, media type, title, requester, and relative time
  - Status mapping: media status 5 → available, request status 2 → approved, 3 → declined, 4 → failed, else pending
  - Scrollable list with ellipsis for long titles
  - 60-second refresh interval

- **Styling** (`src/app/globals.css`):
  - Comprehensive CSS for both widgets with color-coded status badges and type indicators
  - Responsive grid layout for stats, scrollable list for requests
  - Error and loading states

- **Integration registration** (`src/integrations/index.ts`):
  - Imports both widget modules to register them on app startup

- **Comprehensive test suite** (`src/__tests__/integrations/seerr.test.ts`):
  - 412 lines of tests covering API functions, widget registration, config validation, and edge cases
  - Tests for proper header/parameter handling, error responses, AbortSignal forwarding, and data transformation

## Notable Implementation Details
- Uses shared `fetchWithApiKey()` utility for consistent API authentication
- Efficient stats fetching: requests only 1 result per filter to get total counts via `pageInfo.results`
- Graceful fallback for media titles: uses `media.title` for movies, falls back to `media.name` for TV shows
- Relative time formatting (e.g., "2h ago", "3d ago") for request timestamps
- Zod-based validation strips unknown fields silently and handles optional/nullable fields
- Both widgets support loading, error, and empty states with appropriate messaging

https://claude.ai/code/session_016srLPhUam1vdq6xhDQvYLU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Seerr integration with two widgets: a stats widget (pending, approved, available, total) and a requests widget (recent requests, status, requester, relative time).

* **Tests**
  * Added integration tests covering stats and requests fetching, response parsing, error handling, abort signal forwarding, and widget registration/validation.

* **Style**
  * Added styling for Seerr stats and requests widgets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->