### PR TITLE
fix(docker): bootstrap /data volume and config on first startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,13 +63,14 @@ LABEL org.opencontainers.image.licenses="MIT"
 
 # Non-root user for security
 RUN addgroup --system --gid 1001 nodejs \
- && adduser  --system --uid 1001 nextjs
+ && adduser  --system --uid 1001 nextjs \
+ && apk add --no-cache su-exec
 
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+COPY --chmod=755 docker-entrypoint.sh ./
 
-USER nextjs
 EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
@@ -77,4 +78,4 @@ ENV HOSTNAME="0.0.0.0"
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
   CMD wget -qO- http://localhost:3000/api/health || exit 1
 
-CMD ["node", "server.js"]
+ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -79,3 +79,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
   CMD wget -qO- http://localhost:3000/api/health || exit 1
 
 ENTRYPOINT ["./docker-entrypoint.sh"]
+CMD ["node", "server.js"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Fix ownership of the data volume so the nextjs user can read/write it.
+# Runs as root, then immediately drops privileges via su-exec.
+chown -R nextjs:nodejs /data
+
+exec su-exec nextjs node server.js

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 set -e
 
-# Fix ownership of the data volume so the nextjs user can read/write it.
-# Runs as root, then immediately drops privileges via su-exec.
-chown -R nextjs:nodejs /data
+mkdir -p /data
 
-exec su-exec nextjs node server.js
+if [ "$(stat -c '%U:%G' /data)" != "nextjs:nodejs" ]; then
+  chown -R nextjs:nodejs /data
+fi
+
+exec su-exec nextjs "$@"

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,4 +1,4 @@
-import { readFileSync, writeFileSync } from "fs";
+import { existsSync, readFileSync, writeFileSync } from "fs";
 import path from "path";
 import { parseDocument } from "yaml";
 import { KokpitConfigSchema, type KokpitConfig } from "./schema";
@@ -7,6 +7,8 @@ const CONFIG_PATH =
   process.env.KOKPIT_CONFIG_PATH ??
   path.join(process.cwd(), "settings.yaml");
 
+const DEFAULT_CONFIG = `schema_version: 1\nauth:\n  enabled: true\n  session_ttl_hours: 24\nappearance:\n  theme: dark\nlayout:\n  columns: 4\n  row_height: 120\nservices: []\n`;
+
 let cachedConfig: KokpitConfig | null = null;
 
 export function getConfigPath(): string {
@@ -14,6 +16,9 @@ export function getConfigPath(): string {
 }
 
 export function loadConfig(): KokpitConfig {
+  if (!existsSync(CONFIG_PATH)) {
+    writeFileSync(CONFIG_PATH, DEFAULT_CONFIG, "utf-8");
+  }
   const raw = readFileSync(CONFIG_PATH, "utf-8");
   const parsed = parseDocument(raw).toJS() as unknown;
   const result = KokpitConfigSchema.safeParse(parsed);

--- a/src/config/loader.ts
+++ b/src/config/loader.ts
@@ -1,13 +1,13 @@
-import { existsSync, readFileSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import path from "path";
-import { parseDocument } from "yaml";
+import { parseDocument, stringify } from "yaml";
 import { KokpitConfigSchema, type KokpitConfig } from "./schema";
 
 const CONFIG_PATH =
   process.env.KOKPIT_CONFIG_PATH ??
   path.join(process.cwd(), "settings.yaml");
 
-const DEFAULT_CONFIG = `schema_version: 1\nauth:\n  enabled: true\n  session_ttl_hours: 24\nappearance:\n  theme: dark\nlayout:\n  columns: 4\n  row_height: 120\nservices: []\n`;
+const DEFAULT_CONFIG = stringify(KokpitConfigSchema.parse({ schema_version: 1 }));
 
 let cachedConfig: KokpitConfig | null = null;
 
@@ -17,6 +17,7 @@ export function getConfigPath(): string {
 
 export function loadConfig(): KokpitConfig {
   if (!existsSync(CONFIG_PATH)) {
+    mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
     writeFileSync(CONFIG_PATH, DEFAULT_CONFIG, "utf-8");
   }
   const raw = readFileSync(CONFIG_PATH, "utf-8");


### PR DESCRIPTION
## Summary

- Auto-creates `settings.yaml` with sane defaults if it doesn't exist on first run, fixing the `ENOENT` crash at startup
- Adds `docker-entrypoint.sh` that `chown`s `/data` to the `nextjs` user before launching the app, preventing permission errors on bind-mounted volumes
- Installs `su-exec` in the runner stage for a clean root→unprivileged privilege drop (no root process left running alongside the app)

## Test plan

- [ ] Build image and start container with a fresh empty bind-mount at `/data` — confirm it boots without errors and creates `settings.yaml` and `users.db`
- [ ] Start container with `/data` owned by root — confirm entrypoint fixes ownership and app starts normally
- [ ] Confirm `node server.js` runs as `nextjs` user (not root) after entrypoint exits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration files are now automatically initialised on first application start, eliminating setup errors.

* **Chores**
  * Enhanced container deployment process with improved startup control and privilege management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->