### PR TITLE
fix(auth): force dynamic rendering to prevent static pre-render of auth pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,9 @@ jobs:
       - name: Run E2E tests
         run: npm run test:e2e
 
+      - name: Run auth E2E tests
+        run: npm run test:e2e:auth
+
       - name: Upload Playwright artifacts
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ settings.yaml
 # git worktrees
 .worktrees/
 test-results/
+e2e/fixtures/auth-test-users.db*

--- a/e2e/auth-global-setup.ts
+++ b/e2e/auth-global-setup.ts
@@ -4,11 +4,12 @@ import path from "path";
 const DB_PATH = path.resolve("./e2e/fixtures/auth-test-users.db");
 
 export default function globalSetup() {
-  try {
-    if (fs.existsSync(DB_PATH)) {
-      fs.unlinkSync(DB_PATH);
+  for (const suffix of ["", "-wal", "-shm"]) {
+    const p = DB_PATH + suffix;
+    try {
+      if (fs.existsSync(p)) fs.unlinkSync(p);
+    } catch {
+      console.warn(`[auth-global-setup] Could not delete ${p} — tests may see stale state`);
     }
-  } catch {
-    console.warn("[auth-global-setup] Could not delete auth test DB — tests may see stale state");
   }
 }

--- a/e2e/auth-global-setup.ts
+++ b/e2e/auth-global-setup.ts
@@ -1,0 +1,14 @@
+import fs from "fs";
+import path from "path";
+
+const DB_PATH = path.resolve("./e2e/fixtures/auth-test-users.db");
+
+export default function globalSetup() {
+  try {
+    if (fs.existsSync(DB_PATH)) {
+      fs.unlinkSync(DB_PATH);
+    }
+  } catch {
+    console.warn("[auth-global-setup] Could not delete auth test DB — tests may see stale state");
+  }
+}

--- a/e2e/fixtures/auth-settings.yaml
+++ b/e2e/fixtures/auth-settings.yaml
@@ -1,0 +1,10 @@
+schema_version: 1
+auth:
+  enabled: true
+  session_ttl_hours: 24
+appearance:
+  theme: dark
+layout:
+  columns: 4
+  row_height: 120
+services: []

--- a/e2e/start-prod.sh
+++ b/e2e/start-prod.sh
@@ -1,8 +1,6 @@
 #!/bin/sh
 set -e
 
-npm run build
-
 STANDALONE=$(find .next/standalone -name 'server.js' | grep -v node_modules | head -1)
 if [ -z "$STANDALONE" ]; then
   echo "Error: server.js not found in .next/standalone" >&2

--- a/e2e/start-prod.sh
+++ b/e2e/start-prod.sh
@@ -4,6 +4,10 @@ set -e
 npm run build
 
 STANDALONE=$(find .next/standalone -name 'server.js' | grep -v node_modules | head -1)
+if [ -z "$STANDALONE" ]; then
+  echo "Error: server.js not found in .next/standalone" >&2
+  exit 1
+fi
 STANDALONE_DIR=$(dirname "$STANDALONE")
 
 # Mirror what the Dockerfile does: copy static assets into the standalone dir.

--- a/e2e/start-prod.sh
+++ b/e2e/start-prod.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+npm run build
+
+STANDALONE=$(find .next/standalone -name 'server.js' | grep -v node_modules | head -1)
+STANDALONE_DIR=$(dirname "$STANDALONE")
+
+# Mirror what the Dockerfile does: copy static assets into the standalone dir.
+cp -r .next/static "$STANDALONE_DIR/.next/"
+cp -r public "$STANDALONE_DIR/"
+
+cd "$STANDALONE_DIR"
+exec node server.js

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -73,7 +73,7 @@ test.describe.serial("authentication flow", () => {
     await page.getByPlaceholder("Password").fill(ADMIN.password);
     await page.getByRole("button", { name: "Sign in" }).click();
     await expect(page).toHaveURL("/");
-    await expect(page.locator(".navbar")).toBeVisible();
+    await expect(page.getByRole("navigation")).toBeVisible();
   });
 
   // ── Authenticated-state guards ────────────────────────────────────────────────

--- a/e2e/tests/auth.spec.ts
+++ b/e2e/tests/auth.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect, type Page } from "@playwright/test";
+
+const ADMIN = { username: "testadmin", password: "Str0ngP@ssword1" };
+
+// In production builds, React hydrates after HTML is served. Wait for network
+// idle before interacting with forms so event handlers are attached.
+async function goto(page: Page, url: string) {
+  await page.goto(url);
+  await page.waitForLoadState("networkidle");
+}
+
+// Tests run serially so each builds on the DB state left by the previous one.
+// The global setup wipes the DB before the run, so the sequence always starts
+// from a clean slate: no users → setup → post-setup guards → login → auth state.
+test.describe.serial("authentication flow", () => {
+
+  // ── Before any admin is created ──────────────────────────────────────────────
+
+  test("unauthenticated visit to / redirects to /setup", async ({ page }) => {
+    await goto(page, "/");
+    await expect(page).toHaveURL("/setup");
+  });
+
+  test("visiting /login redirects to /setup when no admin exists", async ({ page }) => {
+    await goto(page, "/login");
+    await expect(page).toHaveURL("/setup");
+  });
+
+  test("/setup shows the account creation form", async ({ page }) => {
+    await goto(page, "/setup");
+    await expect(page.getByRole("heading", { name: "Welcome to Kokpit" })).toBeVisible();
+    await expect(page.getByRole("button", { name: "Create admin account" })).toBeVisible();
+  });
+
+  // ── Setup form ────────────────────────────────────────────────────────────────
+
+  test("setup form creates admin and redirects to /login", async ({ page }) => {
+    await goto(page, "/setup");
+    await page.getByPlaceholder("Username").fill(ADMIN.username);
+    await page.getByPlaceholder("Password (min 8 chars)").fill(ADMIN.password);
+    await page.getByPlaceholder("Confirm password").fill(ADMIN.password);
+    await page.getByRole("button", { name: "Create admin account" }).click();
+    await expect(page).toHaveURL("/login");
+  });
+
+  // ── Post-setup guards (these were broken before the force-dynamic fix) ────────
+
+  test("/setup redirects to /login once an admin exists", async ({ page }) => {
+    await goto(page, "/setup");
+    await expect(page).toHaveURL("/login");
+  });
+
+  test("/login shows the sign-in form and does not loop back to /setup", async ({ page }) => {
+    await goto(page, "/login");
+    await expect(page).toHaveURL("/login");
+    await expect(page.getByRole("button", { name: "Sign in" })).toBeVisible();
+  });
+
+  // ── Login form ────────────────────────────────────────────────────────────────
+
+  test("login with wrong password shows an error and stays on /login", async ({ page }) => {
+    await goto(page, "/login");
+    await page.getByPlaceholder("Username").fill(ADMIN.username);
+    await page.getByPlaceholder("Password").fill("wrongpassword");
+    await page.getByRole("button", { name: "Sign in" }).click();
+    await expect(page.getByText("Invalid credentials")).toBeVisible();
+    await expect(page).toHaveURL("/login");
+  });
+
+  test("login with correct credentials redirects to the dashboard", async ({ page }) => {
+    await goto(page, "/login");
+    await page.getByPlaceholder("Username").fill(ADMIN.username);
+    await page.getByPlaceholder("Password").fill(ADMIN.password);
+    await page.getByRole("button", { name: "Sign in" }).click();
+    await expect(page).toHaveURL("/");
+    await expect(page.locator(".navbar")).toBeVisible();
+  });
+
+  // ── Authenticated-state guards ────────────────────────────────────────────────
+
+  test("visiting /login while authenticated redirects to the dashboard", async ({ page }) => {
+    await goto(page, "/login");
+    await page.getByPlaceholder("Username").fill(ADMIN.username);
+    await page.getByPlaceholder("Password").fill(ADMIN.password);
+    await page.getByRole("button", { name: "Sign in" }).click();
+    await expect(page).toHaveURL("/");
+
+    await goto(page, "/login");
+    await expect(page).toHaveURL("/");
+  });
+
+  test("logout clears the session and redirects to /login", async ({ page }) => {
+    await goto(page, "/login");
+    await page.getByPlaceholder("Username").fill(ADMIN.username);
+    await page.getByPlaceholder("Password").fill(ADMIN.password);
+    await page.getByRole("button", { name: "Sign in" }).click();
+    await expect(page).toHaveURL("/");
+
+    await page.getByRole("button", { name: "Sign out" }).click();
+    await expect(page).toHaveURL("/login");
+  });
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
-    "start:standalone": "node $(find .next/standalone -name 'server.js' | grep -v node_modules | head -1)",
+    "start:standalone": "sh -c 'f=$(find .next/standalone -name server.js | grep -v node_modules | head -1); [ -n \"$f\" ] || { echo \"Error: server.js not found — run npm run build first\" >&2; exit 1; }; node \"$f\"'",
     "test:e2e:auth": "playwright test --config playwright.auth.config.ts",
     "type-check": "tsc --noEmit"
   },

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
+    "start:standalone": "node $(find .next/standalone -name 'server.js' | grep -v node_modules | head -1)",
+    "test:e2e:auth": "playwright test --config playwright.auth.config.ts",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",
     "start:standalone": "sh -c 'f=$(find .next/standalone -name server.js | grep -v node_modules | head -1); [ -n \"$f\" ] || { echo \"Error: server.js not found — run npm run build first\" >&2; exit 1; }; node \"$f\"'",
-    "test:e2e:auth": "playwright test --config playwright.auth.config.ts",
+    "test:e2e:auth": "npm run build && playwright test --config playwright.auth.config.ts",
     "type-check": "tsc --noEmit"
   },
   "dependencies": {

--- a/playwright.auth.config.ts
+++ b/playwright.auth.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   testDir: "./e2e/tests",
   testMatch: "**/auth.spec.ts",
   timeout: 60_000,
-  expect: { timeout: 60_000 },
+  expect: { timeout: 10_000 },
   projects: [
     {
       name: "chromium",
@@ -22,6 +22,6 @@ export default defineConfig({
       PORT: "3001",
     },
     url: "http://localhost:3001",
-    timeout: 180_000,
+    timeout: 300_000,
   },
 });

--- a/playwright.auth.config.ts
+++ b/playwright.auth.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "@playwright/test";
+import path from "path";
+
+export default defineConfig({
+  globalSetup: "./e2e/auth-global-setup.ts",
+  testDir: "./e2e/tests",
+  testMatch: "**/auth.spec.ts",
+  timeout: 60_000,
+  expect: { timeout: 60_000 },
+  use: { baseURL: "http://localhost:3001" },
+  webServer: {
+    command: "sh e2e/start-prod.sh",
+    env: {
+      // Absolute paths so they survive the `cd` into the standalone dir.
+      KOKPIT_DB_PATH: path.resolve("./e2e/fixtures/auth-test-users.db"),
+      KOKPIT_CONFIG_PATH: path.resolve("./e2e/fixtures/auth-settings.yaml"),
+      PORT: "3001",
+    },
+    url: "http://localhost:3001",
+    timeout: 180_000,
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/playwright.auth.config.ts
+++ b/playwright.auth.config.ts
@@ -6,7 +6,6 @@ export default defineConfig({
   testDir: "./e2e/tests",
   testMatch: "**/auth.spec.ts",
   timeout: 60_000,
-  expect: { timeout: 10_000 },
   projects: [
     {
       name: "chromium",
@@ -22,6 +21,5 @@ export default defineConfig({
       PORT: "3001",
     },
     url: "http://localhost:3001",
-    timeout: 300_000,
   },
 });

--- a/playwright.auth.config.ts
+++ b/playwright.auth.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "@playwright/test";
+import { defineConfig, devices } from "@playwright/test";
 import path from "path";
 
 export default defineConfig({
@@ -7,7 +7,12 @@ export default defineConfig({
   testMatch: "**/auth.spec.ts",
   timeout: 60_000,
   expect: { timeout: 60_000 },
-  use: { baseURL: "http://localhost:3001" },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"], baseURL: "http://localhost:3001" },
+    },
+  ],
   webServer: {
     command: "sh e2e/start-prod.sh",
     env: {
@@ -18,6 +23,5 @@ export default defineConfig({
     },
     url: "http://localhost:3001",
     timeout: 180_000,
-    reuseExistingServer: !process.env.CI,
   },
 });

--- a/src/app/(protected)/page.tsx
+++ b/src/app/(protected)/page.tsx
@@ -1,6 +1,8 @@
 import { getConfig } from "@/config";
 import ServiceGrid from "@/components/ServiceGrid";
 
+export const dynamic = 'force-dynamic';
+
 export default async function Home() {
   const { layout } = getConfig();
 

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -1,6 +1,8 @@
 import { getConfig } from "@/config";
 import SettingsPanel from "@/components/SettingsPanel";
 
+export const dynamic = 'force-dynamic';
+
 export default function SettingsPage() {
   const config = getConfig();
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,8 +4,6 @@ import { getConfig } from "@/config";
 import { getConfigPath } from "@/config/loader";
 import { resolveAppearance } from "@/config/theme";
 
-export const dynamic = 'force-dynamic';
-
 export const metadata: Metadata = {
   title: "kokpit",
   description: "Your self-hosted personal dashboard",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,8 @@ import { getConfig } from "@/config";
 import { getConfigPath } from "@/config/loader";
 import { resolveAppearance } from "@/config/theme";
 
+export const dynamic = 'force-dynamic';
+
 export const metadata: Metadata = {
   title: "kokpit",
   description: "Your self-hosted personal dashboard",

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,6 +3,8 @@ import { cookies } from "next/headers";
 import { getAuthUser, countUsers, SESSION_COOKIE_NAME } from "@/auth";
 import LoginForm from "./LoginForm";
 
+export const dynamic = 'force-dynamic';
+
 export default async function LoginPage() {
   if (countUsers() === 0) {
     redirect("/setup");

--- a/src/app/setup/page.tsx
+++ b/src/app/setup/page.tsx
@@ -2,6 +2,8 @@ import { redirect } from "next/navigation";
 import { countUsers } from "@/auth";
 import SetupForm from "./SetupForm";
 
+export const dynamic = 'force-dynamic';
+
 export default async function SetupPage() {
   if (countUsers() > 0) {
     redirect("/login");


### PR DESCRIPTION
## Summary

- Next.js was statically pre-rendering `/setup` and `/login` at build time against an empty DB, caching incorrect redirects that caused a post-setup redirect loop in production
- Added `export const dynamic = 'force-dynamic'` to root `layout.tsx` so all routes re-run server components on every request
- Added a Playwright auth test suite that runs the full setup → login → logout flow against a real production standalone build to catch regressions

## Root Cause

`/setup/page.tsx` has no dynamic APIs — at build time (clean environment, empty DB), `countUsers()=0` so no redirect fires and the form HTML is cached. `/login/page.tsx` calls `redirect("/setup")` before `cookies()` is reached, so Next.js never registers the dynamic API and caches the redirect-to-setup statically. At runtime both pages serve stale build-time output.

## Test plan

- [ ] `npm run test:e2e:auth` passes all 10 serial auth flow tests against a production build
- [ ] After setup, `/setup` redirects to `/login` (not a loop)
- [ ] Login with correct credentials lands on the dashboard
- [ ] Login with wrong credentials shows "Invalid credentials" and stays on `/login`
- [ ] Logout redirects to `/login`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive end-to-end authentication testing suite to validate sign-up, login, and session management flows.
  * Configured testing infrastructure with fixtures and automated database cleanup.

* **Chores**
  * Added npm scripts and utilities to support E2E authentication testing and production server deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->