### PR TITLE
fix(release): route version-bump commit through a PR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -86,20 +87,31 @@ jobs:
         env:
           VERSION: ${{ inputs.version }}
 
-      - name: Commit and push
+      - name: Open and merge version bump PR
+        id: bump
         run: |
+          BUMP_BRANCH="release/v$VERSION"
+          git checkout -b "$BUMP_BRANCH"
           git add package.json package-lock.json
           git commit -m "chore: bump version to $VERSION"
-          git push origin "$BRANCH"
+          git push origin "$BUMP_BRANCH"
+          gh pr create --title "chore: bump version to $VERSION" \
+            --body "Automated version bump for release v$VERSION." \
+            --base "$BRANCH" --head "$BUMP_BRANCH"
+          gh pr merge "$BUMP_BRANCH" --squash --delete-branch
+          git fetch origin "$BRANCH"
+          echo "merge_sha=$(git rev-parse origin/$BRANCH)" >> "$GITHUB_OUTPUT"
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
           BRANCH: ${{ github.ref_name }}
 
       - name: Tag and release
         run: |
-          git tag "v$VERSION"
+          git tag "v$VERSION" "$MERGE_SHA"
           git push origin "v$VERSION"
-          gh release create "v$VERSION" --title "v$VERSION" --generate-notes
+          gh release create "v$VERSION" --title "v$VERSION" --generate-notes --target "$MERGE_SHA"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
+          MERGE_SHA: ${{ steps.bump.outputs.merge_sha }}


### PR DESCRIPTION
## Summary
- The `Create Release` workflow tried to `git push origin main` directly with the version-bump commit, but `main` has a ruleset requiring all changes go through a PR — the push was rejected (`GH013`).
- Updated the release job to push the bump to a `release/vX.Y.Z` branch, open a PR into the triggering branch, and squash-merge it before tagging, so it respects branch protection like any other change.
- Tag and GitHub Release are now created against the merge commit instead of a local, unpushed commit.

## Test plan
- [x] Ran the `Create Release` workflow for `0.2.6` and confirmed the lint/type-check/test/E2E gate passes.
- [x] Confirmed the direct-push failure mode (`GH013` rule violation) and that nothing partial (no tag/release) was left behind.
- [ ] Re-run the `Create Release` workflow after merge to confirm the PR-based bump + tag + release flow completes end-to-end.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PfSvby9HQUqZL5dhPmVmVD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release process so version updates are now merged through a dedicated release branch before tagging.
  * Release tags and GitHub releases now point to the exact merged version, helping make release history clearer and more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->