### PR TITLE
Simplify release workflow, document release process for Claude

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version number without v prefix (e.g., 0.2.6 or 0.3.0-beta.1). A v prefix is added automatically to the git tag.'
+        description: 'Version number without v prefix (e.g., 0.2.6 or 0.3.0-beta.1). Must already match package.json on main — bump it via a merged PR first. A v prefix is added automatically to the git tag.'
         required: true
         type: string
 
@@ -71,47 +71,28 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Configure git
+      - name: Verify package.json version matches input
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-      - name: Bump version
-        run: npm version "$VERSION" --no-git-tag-version
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$PKG_VERSION" != "$VERSION" ]; then
+            echo "Error: package.json on this branch is at $PKG_VERSION, but release was requested for $VERSION."
+            echo "main requires changes via PR (GitHub Actions cannot open/merge its own PRs here), so bump"
+            echo "package.json and package-lock.json on main via a merged PR before running this workflow."
+            exit 1
+          fi
         env:
           VERSION: ${{ inputs.version }}
-
-      - name: Open and merge version bump PR
-        id: bump
-        run: |
-          BUMP_BRANCH="release/v$VERSION"
-          git checkout -b "$BUMP_BRANCH"
-          git add package.json package-lock.json
-          git commit -m "chore: bump version to $VERSION"
-          git push origin "$BUMP_BRANCH"
-          gh pr create --title "chore: bump version to $VERSION" \
-            --body "Automated version bump for release v$VERSION." \
-            --base "$BRANCH" --head "$BUMP_BRANCH"
-          gh pr merge "$BUMP_BRANCH" --squash --delete-branch
-          git fetch origin "$BRANCH"
-          echo "merge_sha=$(git rev-parse origin/$BRANCH)" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ inputs.version }}
-          BRANCH: ${{ github.ref_name }}
 
       - name: Tag and release
         run: |
-          git tag "v$VERSION" "$MERGE_SHA"
+          git tag "v$VERSION"
           git push origin "v$VERSION"
-          gh release create "v$VERSION" --title "v$VERSION" --generate-notes --target "$MERGE_SHA"
+          gh release create "v$VERSION" --title "v$VERSION" --generate-notes
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
-          MERGE_SHA: ${{ steps.bump.outputs.merge_sha }}

--- a/Claude.md
+++ b/Claude.md
@@ -74,6 +74,22 @@ A self-hosted personal dashboard / homepage — a modern alternative to Homepage
 
 ---
 
+## Release Process
+
+`main` has a branch ruleset requiring all changes go through a PR, and GitHub Actions is deliberately **not** permitted to create/approve its own PRs in this repo (a security setting, left off on purpose — enabling it would let any workflow self-merge unreviewed changes). This means the version bump can't happen inside CI; it has to be merged as a normal PR first. When asked to cut a release, do this:
+
+1. **Pick the version** (semver). Check the latest tag/release and the commits since it to decide patch/minor/major.
+2. **Bump the version on `main` via a PR** (Actions can't do this step, so do it directly):
+   - Create a branch off `main`, run `npm version <version> --no-git-tag-version`, commit `package.json` + `package-lock.json`, push.
+   - Open a PR into `main` (`mcp__github__create_pull_request`) and merge it (`mcp__github__merge_pull_request`, squash).
+3. **Trigger the release workflow**: `mcp__github__actions_run_trigger`, method `run_workflow`, `workflow_id: release.yml`, `ref: main`, `inputs: {"version": "<version>"}`. It runs the full test gate (lint, type-check, unit, E2E), checks `package.json` matches the input version, tags `vX.Y.Z`, and creates the GitHub Release.
+4. **Docker publish is automatic**: the published Release triggers `.github/workflows/publish.yml`, which builds and pushes the image to `ghcr.io/pmyszczynski/kokpit`.
+5. **Verify**: check the release workflow run, the new tag/release, and that the publish workflow succeeded (`mcp__github__actions_list`, `mcp__github__list_releases`).
+
+If `release.yml`'s "Verify package.json version matches input" step fails, it means step 2 was skipped or used the wrong version — fix the PR, then re-run.
+
+---
+
 ## Key References
 
 - **Full roadmap & task list:** [`docs/Roadmap.md`](docs/Roadmap.md)


### PR DESCRIPTION
## Summary
- `release.yml`'s "Open and merge version bump PR" step (added in #43) fails: `GitHub Actions is not permitted to create or approve pull requests` in this repo (a deliberate security setting, left off since enabling it lets any workflow self-merge unreviewed changes repo-wide).
- Simplified the release job to no longer attempt the bump/PR itself — it now just verifies `package.json` matches the requested version, tags `vX.Y.Z`, and creates the GitHub Release.
- Documented the release process in `Claude.md` so future sessions know the version bump must be merged into `main` via a normal PR *before* triggering the `Create Release` workflow.

## Test plan
- [x] Confirmed the previous PR-creation step fails with `GraphQL: GitHub Actions is not permitted to create or approve pull requests`.
- [ ] After merge: bump `package.json` to `0.2.6` via a PR, merge it, then trigger `Create Release` with `version: 0.2.6` and confirm the full flow (tests → tag → GitHub Release → Docker publish) completes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PfSvby9HQUqZL5dhPmVmVD)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release creation now validates that the version in the app matches the release input before tagging, helping prevent mismatched releases.
  * GitHub releases are now created from the current commit, simplifying the release flow.

* **Documentation**
  * Added a clearer step-by-step guide for the release process, including how to trigger a release and what to do if version checks fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->