### PR TITLE
chore: bump version to 0.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kokpit",
-  "version": "0.1.0",
+  "version": "0.2.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kokpit",
-      "version": "0.1.0",
+      "version": "0.2.6",
       "dependencies": {
         "@testing-library/dom": "^10.4.1",
         "bcryptjs": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kokpit",
-  "version": "0.1.0",
+  "version": "0.2.6",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Version bump for release v0.2.6, per the process documented in `Claude.md`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PfSvby9HQUqZL5dhPmVmVD)_