### PR TITLE
fix(release): explicitly trigger Docker publish after release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,12 @@ name: Publish Docker Image
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing release tag to publish (e.g., v0.2.6). Needed because releases created by GITHUB_TOKEN (our Create Release workflow) do not auto-trigger this workflow — GitHub suppresses events authored by GITHUB_TOKEN to prevent recursive runs.'
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -21,6 +27,21 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Resolve release info
+        id: release_info
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            IS_PRERELEASE=$(gh release view "$TAG" --json isPrerelease -q .isPrerelease)
+          else
+            IS_PRERELEASE="${{ github.event.release.prerelease }}"
+          fi
+          echo "prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -41,7 +62,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=ref,event=tag
-            type=raw,value=latest,enable=${{ !github.event.release.prerelease }}
+            type=raw,value=latest,enable=${{ steps.release_info.outputs.prerelease != 'true' }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,6 +71,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -93,6 +94,16 @@ jobs:
           git tag "v$VERSION"
           git push origin "v$VERSION"
           gh release create "v$VERSION" --title "v$VERSION" --generate-notes
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+
+      - name: Trigger Docker publish
+        run: |
+          # The release we just created was authored by GITHUB_TOKEN, so GitHub
+          # suppresses the "release published" event that would normally trigger
+          # publish.yml (loop prevention). Dispatch it explicitly instead.
+          gh workflow run publish.yml -f "tag=v$VERSION"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}

--- a/Claude.md
+++ b/Claude.md
@@ -83,8 +83,8 @@ A self-hosted personal dashboard / homepage — a modern alternative to Homepage
    - Create a branch off `main`, run `npm version <version> --no-git-tag-version`, commit `package.json` + `package-lock.json`, push.
    - Open a PR into `main` (`mcp__github__create_pull_request`) and merge it (`mcp__github__merge_pull_request`, squash).
 3. **Trigger the release workflow**: `mcp__github__actions_run_trigger`, method `run_workflow`, `workflow_id: release.yml`, `ref: main`, `inputs: {"version": "<version>"}`. It runs the full test gate (lint, type-check, unit, E2E), checks `package.json` matches the input version, tags `vX.Y.Z`, and creates the GitHub Release.
-4. **Docker publish is automatic**: the published Release triggers `.github/workflows/publish.yml`, which builds and pushes the image to `ghcr.io/pmyszczynski/kokpit`.
-5. **Verify**: check the release workflow run, the new tag/release, and that the publish workflow succeeded (`mcp__github__actions_list`, `mcp__github__list_releases`).
+4. **Docker publish**: `release.yml`'s last step explicitly dispatches `.github/workflows/publish.yml` (`gh workflow run publish.yml -f tag=vX.Y.Z`) rather than relying on the `release: published` event — GitHub suppresses events authored by `GITHUB_TOKEN` to prevent recursive workflow runs, so the release `release.yml` creates would never auto-trigger `publish.yml` otherwise. (Releases made by an actual human via the GitHub UI still trigger it normally through the `release` event.)
+5. **Verify**: check the release workflow run, the new tag/release, and that the publish workflow run for the new tag succeeded (`mcp__github__actions_list`, `mcp__github__list_releases`).
 
 If `release.yml`'s "Verify package.json version matches input" step fails, it means step 2 was skipped or used the wrong version — fix the PR, then re-run.
 


### PR DESCRIPTION
## Summary
- The `v0.2.6` release created by `release.yml` didn't trigger `publish.yml` — its `release: published` trigger never fired because the release was authored by `GITHUB_TOKEN`, and GitHub suppresses events created by `GITHUB_TOKEN` to prevent recursive workflow runs.
- `release.yml` now explicitly dispatches `publish.yml` (`gh workflow run publish.yml -f tag=vX.Y.Z`) as its last step, instead of relying on the event.
- `publish.yml` gained a `workflow_dispatch` trigger with a `tag` input, and resolves the prerelease flag via `gh release view` when dispatched manually (since `github.event.release` isn't populated for `workflow_dispatch`). Releases published by an actual human via the GitHub UI still trigger it the original way through the `release` event.
- Documented this in `Claude.md`'s release process.

## Test plan
- [x] Confirmed no `publish.yml` run exists for `v0.2.6` after the release.yml run that created it.
- [ ] After merge: manually dispatch `publish.yml` with `tag: v0.2.6` to finish publishing the image for the already-created v0.2.6 release, and confirm the image appears in GHCR.
- [ ] Confirm next release run's "Trigger Docker publish" step succeeds end-to-end automatically.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PfSvby9HQUqZL5dhPmVmVD)_