### PR TITLE
Add plan: optional widget config + test connection button

### DIFF
--- a/docs/plans/2026-07-12-optional-widget-and-test-connection.md
+++ b/docs/plans/2026-07-12-optional-widget-and-test-connection.md
@@ -1,0 +1,137 @@
+# Optional widget config + "Test connection" button
+
+**Date:** 2026-07-12
+**Status:** Planned
+
+## Problem
+
+Adding a service through the UI currently forces an all-or-nothing choice:
+
+1. Picking an integration tile type (e.g. "Plex") in `ServiceForm` marks the
+   widget's required config fields (`url`, `token`, …) as HTML-`required`, so
+   the form cannot be submitted without full widget credentials. You can't
+   just add "Plex" with a name + URL and configure the widget later.
+2. On save the form always writes `widget: { type, config }`. On the
+   dashboard, any `service.widget` mounts `WidgetRenderer`, which renders an
+   error box when the config is empty or invalid — instead of a plain tile.
+3. There is no way to verify widget credentials from the add/edit form; you
+   have to save and watch the dashboard tile fail.
+
+## Decisions (confirmed with owner)
+
+- **YAML shape:** a service with an integration selected but no widget config
+  keeps the marker: `widget: { type: plex }` (no `config` key). Re-opening the
+  edit form shows Plex still selected; the schema already allows this
+  (`config` is optional in `ServiceWidgetSchema`) — no migration needed.
+- **Rendering rule:** *any* widget config that fails the widget's
+  `configSchema` (empty, partial, or typo'd) renders the service as a plain
+  tile — silent degradation, no error box. An **unknown widget type** keeps
+  the current "Unknown widget type" error, since that signals a YAML typo of
+  `type` itself, not a missing config.
+- **Test button:** covers the widget connection only (no generic URL ping in
+  the form).
+
+## Changes
+
+### 1. Dashboard: render plain tile when widget config doesn't validate
+
+`src/components/ServiceGrid.tsx` (server component):
+
+- Import `@/integrations` so the widget registry is populated server-side.
+- For each service with a `widget`, resolve `getWidget(widget.type)`:
+  - Type unknown → pass the widget through unchanged (error box preserved).
+  - Type known → run `configSchema.safeParse(widget.config ?? {})`. On
+    failure, pass **no widget** to `ServiceTile` → plain tile.
+- Pass a **sanitized widget prop** to the client: `{ type,
+  refresh_interval_ms }` only. Today `ServiceGrid` serializes the full
+  `widget.config` (including tokens) into the RSC payload sent to the
+  browser; the widget data API already looks config up server-side by service
+  name, so the client never needs it. This closes that leak as part of the
+  same change.
+
+`src/components/ServiceTile.tsx`: narrow the `widget` prop type to the
+sanitized shape (`{ type: string; refresh_interval_ms?: number }`). No
+behavioral change otherwise.
+
+### 2. ServiceForm: widget config becomes optional
+
+`src/components/ServiceForm.tsx`:
+
+- Drop the HTML `required` attribute from widget config fields. Keep the `*`
+  marker but reword the widget section with a hint: *"Leave empty to add a
+  plain link tile — you can configure the widget later."*
+- On submit with a tile type selected, always emit `widget: { type }`;
+  attach `config` only when it contains at least one non-empty value.
+  Strip empty strings / empty arrays from `widgetConfig` first, so fields
+  that were touched and cleared don't count as "configured".
+- Live status line in the widget section (client-side `safeParse` against
+  the registry's `configSchema`, which is already imported client-side):
+  *"Widget active"* vs *"Widget disabled — tile will render as a plain link
+  until required fields are filled"*. This keeps the silent dashboard
+  degradation from being surprising.
+- Same treatment applies to orphan widgets (types without an editor preset):
+  they already save whatever raw config exists; no `required` change needed
+  there since their fields were never enforced.
+
+### 3. `POST /api/widget/test` — test connection endpoint
+
+New route `src/app/api/widget/test/route.ts`:
+
+- Body: `{ type: string, config: unknown }` — the config comes from the form
+  as currently typed (it may not be saved yet, so the existing
+  lookup-by-service-name GET route can't be reused).
+- **Auth required.** Extract the `checkAuth()` helper currently private to
+  `src/app/api/settings/route.ts` into a shared module (e.g.
+  `src/app/api/_auth.ts`) and use it here; the settings route adopts the
+  shared helper. This endpoint triggers server-side fetches to
+  user-supplied URLs with user-supplied credentials, so it must not be
+  callable unauthenticated.
+- Flow mirrors the GET route: resolve widget (404 if unknown) →
+  `configSchema.safeParse` (400 with joined issue messages) → run
+  `widget.fetchData(parsed.data, signal)` under an `AbortController` with the
+  same 5 s timeout → `{ ok: true }` on success, `{ ok: false, error }` with
+  504 (timeout) / 500 (fetch failure) otherwise. No widget data is returned —
+  the form only needs pass/fail + message.
+
+### 4. ServiceForm: Test connection button
+
+- A "Test connection" button inside the widget section, next to the config
+  fields. Disabled while a test is in flight or when the current config fails
+  client-side `safeParse` (no point sending a config we know is incomplete).
+- On click: `POST /api/widget/test` with the current `{ type, config }`
+  (works for both preset tile types and orphan widgets, which keep raw
+  config client-side).
+- Inline result states: idle → testing (spinner/label) → success ("Connection
+  OK ✓") or error (server's error message). Any config field change resets
+  the result to idle so a stale "OK" never lingers over edited credentials.
+
+## Tests
+
+- `src/__tests__/components/ServiceForm.test.tsx`
+  - Selecting an integration and saving with empty widget fields succeeds;
+    `onSave` receives `widget: { type }` with no `config`.
+  - Empty-string values are stripped (config with only `""` values → no
+    `config` key).
+  - Filling required fields still produces `widget: { type, config }`.
+  - Test button: disabled with incomplete config; success and error paths
+    with mocked `fetch`; result resets when a config field changes.
+- `src/__tests__/components/ServiceGrid.test.tsx` (or `ServiceTile.test.tsx`)
+  - Widget with valid config → widget rendered.
+  - Widget with missing/partial/invalid config → plain tile, no
+    `.service-tile__widget`.
+  - Unknown widget type → error box preserved.
+  - Sanitized prop: rendered output/props contain no credential values.
+- `src/__tests__/api/widget-test.test.ts` (new)
+  - 401 when auth enabled and no session; 404 unknown type; 400 invalid
+    config; 200 `{ ok: true }` on success; 504 on timeout; 500 with message
+    on fetch failure.
+- E2E (`e2e/tests`): extend the service-management spec — add a service with
+  an integration selected but no widget config, assert it appears as a plain
+  tile, then edit it to add config and assert the widget section appears.
+
+## Out of scope / follow-ups
+
+- `GET /api/widget` currently has no auth check (dashboard pages are
+  protected, the API route is not). Worth a separate hardening pass together
+  with `GET /api/ping` (SSRF surface). Noted here so it isn't forgotten; the
+  new test endpoint ships auth-protected from day one.

--- a/e2e/tests/plex-widget.spec.ts
+++ b/e2e/tests/plex-widget.spec.ts
@@ -142,3 +142,69 @@ test("settings form saves Plex widget config and renders the tile", async ({
   const tile = page.locator(".service-tile").filter({ hasText: "My Plex" });
   await expect(tile.locator(".plex-widget")).toBeVisible({ timeout: 15_000 });
 });
+
+// ── Test 5 ───────────────────────────────────────────────────────────────────
+
+test("integration tile saved without widget config renders as a plain tile", async ({
+  page,
+}) => {
+  await page.goto("/settings");
+  await page.click("button.settings-tab:has-text('Services')");
+  await page.click("button:has-text('+ Add Service')");
+
+  // Pick Plex but leave the widget config completely empty.
+  await page.selectOption("#sf-tile-type", "plex");
+  await page.fill("#sf-name", "Plex Later");
+  await expect(page.getByText(/widget not configured/i)).toBeVisible();
+
+  await page.getByRole("button", { name: "Save" }).click();
+  await expect(page.locator("dialog.service-form-dialog")).toBeHidden();
+
+  await page.goto("/");
+  const tile = page.locator(".service-tile").filter({ hasText: "Plex Later" });
+  await expect(tile).toBeVisible();
+  await expect(tile.locator(".service-tile__widget")).toHaveCount(0);
+  await expect(tile.locator(".widget-error")).toHaveCount(0);
+
+  // Re-opening the editor remembers the Plex tile type.
+  await page.goto("/settings");
+  await page.click("button.settings-tab:has-text('Services')");
+  await page.click(
+    ".service-table tr:has-text('Plex Later') button:has-text('Edit')"
+  );
+  await expect(page.locator("#sf-tile-type")).toHaveValue("plex");
+});
+
+// ── Test 6 ───────────────────────────────────────────────────────────────────
+
+test("Test connection button reports success and failure", async ({
+  page,
+  request,
+}) => {
+  await page.goto("/settings");
+  await page.click("button.settings-tab:has-text('Services')");
+  await page.click("button:has-text('+ Add Service')");
+  await page.selectOption("#sf-tile-type", "plex");
+
+  // Disabled until the required widget fields are filled.
+  const testBtn = page.getByRole("button", { name: "Test connection" });
+  await expect(testBtn).toBeDisabled();
+
+  await page.fill("#sf-widget-url", MOCK);
+  await page.fill("#sf-widget-token", "test-token");
+  await expect(testBtn).toBeEnabled();
+
+  await testBtn.click();
+  await expect(page.getByText("Connection OK")).toBeVisible({ timeout: 15_000 });
+
+  // Flip the mock into an error state — the retest surfaces the failure.
+  await request.post(`${MOCK}/__control`, {
+    data: { ...DEFAULT_MOCK_STATE, error: 503 },
+  });
+  await page.fill("#sf-widget-token", "test-token-2");
+  await expect(page.getByText("Connection OK")).toBeHidden();
+  await testBtn.click();
+  await expect(page.getByText(/Plex responded with 503/)).toBeVisible({
+    timeout: 15_000,
+  });
+});

--- a/src/__tests__/api/health.test.ts
+++ b/src/__tests__/api/health.test.ts
@@ -1,0 +1,14 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { GET } from "../../app/api/health/route";
+
+describe("GET /api/health", () => {
+  it("returns 200 with status, version, and timestamp", async () => {
+    const res = await GET();
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.status).toBe("ok");
+    expect(typeof json.version).toBe("string");
+    expect(new Date(json.timestamp).getTime()).not.toBeNaN();
+  });
+});

--- a/src/__tests__/api/widget-test.test.ts
+++ b/src/__tests__/api/widget-test.test.ts
@@ -21,6 +21,16 @@ vi.mock("next/headers", () => ({
 process.env.KOKPIT_AUTH_DISABLED = "true";
 
 import { existsSync, readFileSync } from "node:fs";
+import "@/integrations";
+import { getAllWidgets } from "@/widgets";
+
+// Every registered widget type, with what its schema says about an empty
+// config. Collected once at module load; the tests re-import the route (and
+// a fresh registry) after vi.resetModules(), but the ids are stable.
+const allWidgets = getAllWidgets().map((w) => ({
+  id: w.id,
+  emptyConfigValid: w.configSchema.safeParse({}).success,
+}));
 
 const BASE_YAML = `
 schema_version: 1
@@ -86,6 +96,25 @@ describe("POST /api/widget/test", () => {
     expect(res.status).toBe(404);
     expect((await res.json()).error).toMatch(/unknown widget type/i);
   });
+
+  it.each(allWidgets)(
+    "$id: rejects an empty config per its schema without fetching",
+    async ({ id, emptyConfigValid }) => {
+      const fetchMock = vi.fn().mockRejectedValue(new Error("network down"));
+      vi.stubGlobal("fetch", fetchMock);
+      const { POST } = await import("../../app/api/widget/test/route");
+      const res = await POST(post({ type: id, config: {} }));
+      if (emptyConfigValid) {
+        // Schema accepts an empty config — the endpoint attempts the fetch.
+        expect(res.status).toBe(500);
+        expect(fetchMock).toHaveBeenCalled();
+      } else {
+        expect(res.status).toBe(400);
+        expect((await res.json()).error).toMatch(/invalid widget config/i);
+        expect(fetchMock).not.toHaveBeenCalled();
+      }
+    }
+  );
 
   it("returns 400 with issue details when the config fails the widget schema", async () => {
     const { POST } = await import("../../app/api/widget/test/route");

--- a/src/__tests__/api/widget-test.test.ts
+++ b/src/__tests__/api/widget-test.test.ts
@@ -177,6 +177,27 @@ describe("POST /api/widget/test", () => {
     expect((await res.json()).error).toMatch(/timed out/i);
   });
 
+  it("returns 504 even when the widget ignores its abort signal", async () => {
+    vi.useFakeTimers();
+    // A fetch that never settles, abort or not — the hard timeout race is
+    // the only thing that can end this request.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(() => new Promise(() => {}))
+    );
+    const { POST } = await import("../../app/api/widget/test/route");
+    const resPromise = POST(
+      post({
+        type: "plex",
+        config: { url: "http://plex.test:32400", token: "t" },
+      })
+    );
+    await vi.advanceTimersByTimeAsync(5001);
+    const res = await resPromise;
+    expect(res.status).toBe(504);
+    expect((await res.json()).error).toMatch(/timed out/i);
+  });
+
   it("returns 500 with the error message when the widget fetch fails", async () => {
     vi.stubGlobal(
       "fetch",

--- a/src/__tests__/api/widget-test.test.ts
+++ b/src/__tests__/api/widget-test.test.ts
@@ -65,6 +65,7 @@ beforeEach(() => {
 afterEach(() => {
   vi.unstubAllGlobals();
   vi.unstubAllEnvs();
+  vi.useRealTimers();
 });
 
 describe("POST /api/widget/test", () => {
@@ -146,6 +147,34 @@ describe("POST /api/widget/test", () => {
     expect(res.status).toBe(200);
     const json = await res.json();
     expect(json).toEqual({ ok: true });
+  });
+
+  it("returns 504 when the connection test exceeds the 5s timeout", async () => {
+    vi.useFakeTimers();
+    // A fetch that never settles until its signal aborts — the route's
+    // AbortController is the only thing that can end this request.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(
+        (_url: string, opts?: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            opts?.signal?.addEventListener("abort", () =>
+              reject(new Error("aborted"))
+            );
+          })
+      )
+    );
+    const { POST } = await import("../../app/api/widget/test/route");
+    const resPromise = POST(
+      post({
+        type: "plex",
+        config: { url: "http://plex.test:32400", token: "t" },
+      })
+    );
+    await vi.advanceTimersByTimeAsync(5001);
+    const res = await resPromise;
+    expect(res.status).toBe(504);
+    expect((await res.json()).error).toMatch(/timed out/i);
   });
 
   it("returns 500 with the error message when the widget fetch fails", async () => {

--- a/src/__tests__/api/widget-test.test.ts
+++ b/src/__tests__/api/widget-test.test.ts
@@ -1,0 +1,139 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("node:fs", () => {
+  const readFileSync = vi.fn();
+  const writeFileSync = vi.fn();
+  const existsSync = vi.fn().mockReturnValue(true);
+  const mkdirSync = vi.fn();
+  return {
+    default: { readFileSync, writeFileSync, existsSync, mkdirSync },
+    readFileSync,
+    writeFileSync,
+    existsSync,
+    mkdirSync,
+  };
+});
+vi.mock("next/headers", () => ({
+  cookies: vi.fn().mockResolvedValue({ get: () => undefined }),
+}));
+
+process.env.KOKPIT_AUTH_DISABLED = "true";
+
+import { existsSync, readFileSync } from "node:fs";
+
+const BASE_YAML = `
+schema_version: 1
+auth:
+  enabled: false
+  session_ttl_hours: 24
+appearance:
+  theme: dark
+layout:
+  columns: 4
+  row_height: 120
+services: []
+`.trim();
+
+const AUTH_YAML = BASE_YAML.replace("enabled: false", "enabled: true");
+
+function post(body: unknown) {
+  return new Request("http://localhost/api/widget/test", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  vi.mocked(existsSync).mockReturnValue(true);
+  vi.mocked(readFileSync).mockReturnValue(BASE_YAML);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe("POST /api/widget/test", () => {
+  it("returns 401 when auth is enabled and no session cookie is present", async () => {
+    vi.stubEnv("KOKPIT_AUTH_DISABLED", "false");
+    vi.mocked(readFileSync).mockReturnValue(AUTH_YAML);
+    const { POST } = await import("../../app/api/widget/test/route");
+    const res = await POST(post({ type: "plex", config: {} }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 for malformed JSON", async () => {
+    const { POST } = await import("../../app/api/widget/test/route");
+    const res = await POST(post("not json"));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/invalid json/i);
+  });
+
+  it("returns 400 when type is missing", async () => {
+    const { POST } = await import("../../app/api/widget/test/route");
+    const res = await POST(post({ config: {} }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/missing type/i);
+  });
+
+  it("returns 404 for an unknown widget type", async () => {
+    const { POST } = await import("../../app/api/widget/test/route");
+    const res = await POST(post({ type: "does-not-exist", config: {} }));
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toMatch(/unknown widget type/i);
+  });
+
+  it("returns 400 with issue details when the config fails the widget schema", async () => {
+    const { POST } = await import("../../app/api/widget/test/route");
+    const res = await POST(post({ type: "plex", config: {} }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.ok).toBe(false);
+    expect(json.error).toMatch(/invalid widget config/i);
+    expect(json.error).toMatch(/url/);
+    expect(json.error).toMatch(/token/);
+  });
+
+  it("returns { ok: true } when the widget fetch succeeds", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ MediaContainer: { size: 2, Metadata: [] } }),
+      } as Response)
+    );
+    const { POST } = await import("../../app/api/widget/test/route");
+    const res = await POST(
+      post({
+        type: "plex",
+        config: { url: "http://plex.test:32400", token: "t" },
+      })
+    );
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ ok: true });
+  });
+
+  it("returns 500 with the error message when the widget fetch fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 503 } as Response)
+    );
+    const { POST } = await import("../../app/api/widget/test/route");
+    const res = await POST(
+      post({
+        type: "plex",
+        config: { url: "http://plex.test:32400", token: "t" },
+      })
+    );
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.ok).toBe(false);
+    expect(json.error).toMatch(/503/);
+  });
+});

--- a/src/__tests__/api/widget.test.ts
+++ b/src/__tests__/api/widget.test.ts
@@ -130,6 +130,22 @@ describe("GET /api/widget", () => {
     expect((await res.json()).error).toMatch(/502/);
   });
 
+  it("returns 504 even when the widget ignores its abort signal", async () => {
+    vi.useFakeTimers();
+    // A fetch that never settles, abort or not — the hard timeout race is
+    // the only thing that can end this request.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(() => new Promise(() => {}))
+    );
+    const { GET } = await import("../../app/api/widget/route");
+    const resPromise = GET(get({ type: "plex", service: "Plex" }));
+    await vi.advanceTimersByTimeAsync(5001);
+    const res = await resPromise;
+    expect(res.status).toBe(504);
+    expect((await res.json()).error).toMatch(/timed out/i);
+  });
+
   it("returns 504 when the widget fetch exceeds the 5s timeout", async () => {
     vi.useFakeTimers();
     // A fetch that never settles until its signal aborts — the route's

--- a/src/__tests__/api/widget.test.ts
+++ b/src/__tests__/api/widget.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("node:fs", () => {
+  const readFileSync = vi.fn();
+  const writeFileSync = vi.fn();
+  const existsSync = vi.fn().mockReturnValue(true);
+  const mkdirSync = vi.fn();
+  return {
+    default: { readFileSync, writeFileSync, existsSync, mkdirSync },
+    readFileSync,
+    writeFileSync,
+    existsSync,
+    mkdirSync,
+  };
+});
+
+import { existsSync, readFileSync } from "node:fs";
+
+// Fixture services: one valid Plex widget, one with an incomplete config,
+// and one with a widget type that isn't registered.
+const SERVICES_YAML = `
+schema_version: 1
+auth:
+  enabled: false
+  session_ttl_hours: 24
+appearance:
+  theme: dark
+layout:
+  columns: 4
+  row_height: 120
+services:
+  - name: Plex
+    url: http://plex.local
+    widget:
+      type: plex
+      config:
+        url: http://plex.test:32400
+        token: t
+  - name: Broken Plex
+    widget:
+      type: plex
+      config:
+        url: http://plex.test:32400
+  - name: Mystery
+    widget:
+      type: not-a-real-widget
+`.trim();
+
+function get(params: Record<string, string>) {
+  const qs = new URLSearchParams(params).toString();
+  return new Request(`http://localhost/api/widget?${qs}`);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  vi.mocked(existsSync).mockReturnValue(true);
+  vi.mocked(readFileSync).mockReturnValue(SERVICES_YAML);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+describe("GET /api/widget", () => {
+  it("returns 400 when the type parameter is missing", async () => {
+    const { GET } = await import("../../app/api/widget/route");
+    const res = await GET(get({ service: "Plex" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/missing type/i);
+  });
+
+  it("returns 400 when the service parameter is missing", async () => {
+    const { GET } = await import("../../app/api/widget/route");
+    const res = await GET(get({ type: "plex" }));
+    expect(res.status).toBe(400);
+    expect((await res.json()).error).toMatch(/missing service/i);
+  });
+
+  it("returns 404 for an unknown widget type", async () => {
+    const { GET } = await import("../../app/api/widget/route");
+    const res = await GET(get({ type: "not-a-real-widget", service: "Mystery" }));
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toMatch(/unknown widget type/i);
+  });
+
+  it("returns 404 when the service does not exist in settings", async () => {
+    const { GET } = await import("../../app/api/widget/route");
+    const res = await GET(get({ type: "plex", service: "Nope" }));
+    expect(res.status).toBe(404);
+    expect((await res.json()).error).toMatch(/service not found/i);
+  });
+
+  it("returns 400 when the stored config fails the widget schema", async () => {
+    const { GET } = await import("../../app/api/widget/route");
+    const res = await GET(get({ type: "plex", service: "Broken Plex" }));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/invalid widget config/i);
+    expect(json.error).toMatch(/token/);
+  });
+
+  it("returns { ok: true, data } when the widget fetch succeeds", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: () =>
+          Promise.resolve({ MediaContainer: { size: 3, Metadata: [{}, {}, {}] } }),
+      } as Response)
+    );
+    const { GET } = await import("../../app/api/widget/route");
+    const res = await GET(get({ type: "plex", service: "Plex" }));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json.ok).toBe(true);
+    expect(json.data.streams).toBe(3);
+  });
+
+  it("returns 500 with the error message when the widget fetch fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false, status: 502 } as Response)
+    );
+    const { GET } = await import("../../app/api/widget/route");
+    const res = await GET(get({ type: "plex", service: "Plex" }));
+    expect(res.status).toBe(500);
+    expect((await res.json()).error).toMatch(/502/);
+  });
+
+  it("returns 504 when the widget fetch exceeds the 5s timeout", async () => {
+    vi.useFakeTimers();
+    // A fetch that never settles until its signal aborts — the route's
+    // AbortController is the only thing that can end this request.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(
+        (_url: string, opts?: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            opts?.signal?.addEventListener("abort", () =>
+              reject(new Error("aborted"))
+            );
+          })
+      )
+    );
+    const { GET } = await import("../../app/api/widget/route");
+    const resPromise = GET(get({ type: "plex", service: "Plex" }));
+    await vi.advanceTimersByTimeAsync(5001);
+    const res = await resPromise;
+    expect(res.status).toBe(504);
+    expect((await res.json()).error).toMatch(/timed out/i);
+  });
+});

--- a/src/__tests__/components/ServiceForm.test.tsx
+++ b/src/__tests__/components/ServiceForm.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import ServiceForm from "@/components/ServiceForm";
 
 beforeEach(() => {
@@ -220,6 +220,152 @@ describe("ServiceForm – tile type", () => {
         },
       })
     );
+  });
+});
+
+describe("ServiceForm – optional widget config", () => {
+  it("saves widget with type only when the config fields are left empty", () => {
+    const onSave = vi.fn();
+    render(
+      <ServiceForm service={null} existingGroups={[]} onSave={onSave} onClose={noop} />
+    );
+    fireEvent.change(screen.getByLabelText("Tile type"), {
+      target: { value: "plex" },
+    });
+    fireEvent.click(screen.getByText("Save"));
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const saved = onSave.mock.calls[0][0];
+    expect(saved.widget.type).toBe("plex");
+    expect(saved.widget.config).toBeUndefined();
+  });
+
+  it("treats config fields that were filled and cleared as unconfigured", () => {
+    const onSave = vi.fn();
+    render(
+      <ServiceForm service={null} existingGroups={[]} onSave={onSave} onClose={noop} />
+    );
+    fireEvent.change(screen.getByLabelText("Tile type"), {
+      target: { value: "plex" },
+    });
+    const urlInput = screen.getByLabelText(/Server URL/);
+    fireEvent.change(urlInput, { target: { value: "http://plex.local:32400" } });
+    fireEvent.change(urlInput, { target: { value: "" } });
+    fireEvent.click(screen.getByText("Save"));
+    const saved = onSave.mock.calls[0][0];
+    expect(saved.widget.type).toBe("plex");
+    expect(saved.widget.config).toBeUndefined();
+  });
+
+  it("shows the not-configured status until required fields are filled", () => {
+    render(
+      <ServiceForm service={null} existingGroups={[]} onSave={noop} onClose={noop} />
+    );
+    fireEvent.change(screen.getByLabelText("Tile type"), {
+      target: { value: "plex" },
+    });
+    expect(screen.getByText(/widget not configured/i)).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText(/Server URL/), {
+      target: { value: "http://plex.local:32400" },
+    });
+    fireEvent.change(screen.getByLabelText(/^Token/), {
+      target: { value: "t" },
+    });
+    expect(screen.getByText(/widget configured/i)).toBeInTheDocument();
+    expect(screen.queryByText(/widget not configured/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("ServiceForm – test connection", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function setupPlexForm() {
+    render(
+      <ServiceForm service={null} existingGroups={[]} onSave={noop} onClose={noop} />
+    );
+    fireEvent.change(screen.getByLabelText("Tile type"), {
+      target: { value: "plex" },
+    });
+  }
+
+  function fillPlexConfig() {
+    fireEvent.change(screen.getByLabelText(/Server URL/), {
+      target: { value: "http://plex.local:32400" },
+    });
+    fireEvent.change(screen.getByLabelText(/^Token/), {
+      target: { value: "secret" },
+    });
+  }
+
+  it("is disabled while the config does not validate", () => {
+    setupPlexForm();
+    expect(screen.getByText("Test connection")).toBeDisabled();
+    fillPlexConfig();
+    expect(screen.getByText("Test connection")).toBeEnabled();
+  });
+
+  it("posts the current type and config and shows success", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ ok: true }),
+    } as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    setupPlexForm();
+    fillPlexConfig();
+    fireEvent.click(screen.getByText("Test connection"));
+
+    await waitFor(() =>
+      expect(screen.getByText("Connection OK")).toBeInTheDocument()
+    );
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/widget/test",
+      expect.objectContaining({ method: "POST" })
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body).toEqual({
+      type: "plex",
+      config: { url: "http://plex.local:32400", token: "secret" },
+    });
+  });
+
+  it("shows the server error message when the test fails", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        json: () => Promise.resolve({ ok: false, error: "Plex responded with 503" }),
+      } as Response)
+    );
+
+    setupPlexForm();
+    fillPlexConfig();
+    fireEvent.click(screen.getByText("Test connection"));
+
+    await waitFor(() =>
+      expect(screen.getByText("Plex responded with 503")).toBeInTheDocument()
+    );
+  });
+
+  it("resets the test result when a config field changes", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        json: () => Promise.resolve({ ok: true }),
+      } as Response)
+    );
+
+    setupPlexForm();
+    fillPlexConfig();
+    fireEvent.click(screen.getByText("Test connection"));
+    await waitFor(() =>
+      expect(screen.getByText("Connection OK")).toBeInTheDocument()
+    );
+
+    fireEvent.change(screen.getByLabelText(/^Token/), {
+      target: { value: "different" },
+    });
+    expect(screen.queryByText("Connection OK")).not.toBeInTheDocument();
   });
 });
 

--- a/src/__tests__/components/ServiceForm.test.tsx
+++ b/src/__tests__/components/ServiceForm.test.tsx
@@ -1,6 +1,16 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import ServiceForm from "@/components/ServiceForm";
+import "@/integrations";
+import { getWidgetsWithServiceEditorPreset } from "@/widgets";
+
+// Every selectable tile type, with what its schema says about an empty
+// config. Derived from the registry so new integrations are covered
+// automatically.
+const allPresetTiles = getWidgetsWithServiceEditorPreset().map((w) => ({
+  id: w.id,
+  emptyConfigValid: w.configSchema.safeParse({}).success,
+}));
 
 beforeEach(() => {
   // jsdom does not implement dialog methods; close() must dispatch the
@@ -224,20 +234,42 @@ describe("ServiceForm – tile type", () => {
 });
 
 describe("ServiceForm – optional widget config", () => {
-  it("saves widget with type only when the config fields are left empty", () => {
-    const onSave = vi.fn();
-    render(
-      <ServiceForm service={null} existingGroups={[]} onSave={onSave} onClose={noop} />
-    );
-    fireEvent.change(screen.getByLabelText("Tile type"), {
-      target: { value: "plex" },
-    });
-    fireEvent.click(screen.getByText("Save"));
-    expect(onSave).toHaveBeenCalledTimes(1);
-    const saved = onSave.mock.calls[0][0];
-    expect(saved.widget.type).toBe("plex");
-    expect(saved.widget.config).toBeUndefined();
-  });
+  it.each(allPresetTiles)(
+    "$id: saves widget with type only when the config fields are left empty",
+    ({ id }) => {
+      const onSave = vi.fn();
+      render(
+        <ServiceForm service={null} existingGroups={[]} onSave={onSave} onClose={noop} />
+      );
+      fireEvent.change(screen.getByLabelText("Tile type"), {
+        target: { value: id },
+      });
+      fireEvent.click(screen.getByText("Save"));
+      expect(onSave).toHaveBeenCalledTimes(1);
+      const saved = onSave.mock.calls[0][0];
+      expect(saved.widget.type).toBe(id);
+      expect(saved.widget.config).toBeUndefined();
+    }
+  );
+
+  it.each(allPresetTiles)(
+    "$id: status line and test button reflect the empty-config state",
+    ({ id, emptyConfigValid }) => {
+      render(
+        <ServiceForm service={null} existingGroups={[]} onSave={noop} onClose={noop} />
+      );
+      fireEvent.change(screen.getByLabelText("Tile type"), {
+        target: { value: id },
+      });
+      if (emptyConfigValid) {
+        expect(screen.getByText(/widget configured/i)).toBeInTheDocument();
+        expect(screen.getByText("Test connection")).toBeEnabled();
+      } else {
+        expect(screen.getByText(/widget not configured/i)).toBeInTheDocument();
+        expect(screen.getByText("Test connection")).toBeDisabled();
+      }
+    }
+  );
 
   it("treats config fields that were filled and cleared as unconfigured", () => {
     const onSave = vi.fn();

--- a/src/__tests__/components/ServiceGrid.test.tsx
+++ b/src/__tests__/components/ServiceGrid.test.tsx
@@ -9,6 +9,16 @@ vi.mock("@/config", () => ({
 }));
 
 import ServiceGrid from "@/components/ServiceGrid";
+import "@/integrations";
+import { getAllWidgets } from "@/widgets";
+
+// Every registered widget type, with what its schema says about an empty
+// config. Derived from the registry so new integrations are covered
+// automatically.
+const allTiles = getAllWidgets().map((w) => ({
+  id: w.id,
+  emptyConfigValid: w.configSchema.safeParse({}).success,
+}));
 
 function makeService(overrides: Partial<Service> & { name: string }): Service {
   return { ...overrides };
@@ -108,24 +118,33 @@ describe("ServiceGrid", () => {
     ).not.toBeNull();
   });
 
-  it("renders a plain tile when the widget has no config", async () => {
-    getConfig.mockReturnValue({
-      services: [
-        makeService({
-          name: "Plex",
-          url: "http://plex.local",
-          widget: { type: "plex" },
-        }),
-      ],
-    });
-    let container!: HTMLElement;
-    await act(async () => {
-      ({ container } = render(<ServiceGrid />));
-    });
-    expect(screen.getByText("Plex")).toBeInTheDocument();
-    expect(container.querySelector(".service-tile__widget")).toBeNull();
-    expect(container.querySelector(".widget-error")).toBeNull();
-  });
+  it.each(allTiles)(
+    "$id: renders per its schema when the widget has no config",
+    async ({ id, emptyConfigValid }) => {
+      getConfig.mockReturnValue({
+        services: [
+          makeService({
+            name: "Svc",
+            url: "http://svc.local",
+            widget: { type: id },
+          }),
+        ],
+      });
+      let container!: HTMLElement;
+      await act(async () => {
+        ({ container } = render(<ServiceGrid />));
+      });
+      expect(screen.getByText("Svc")).toBeInTheDocument();
+      if (emptyConfigValid) {
+        // Schema accepts an empty config — the widget renders.
+        expect(container.querySelector(".service-tile__widget")).not.toBeNull();
+      } else {
+        // Unconfigured widget — plain link tile, no error box.
+        expect(container.querySelector(".service-tile__widget")).toBeNull();
+        expect(container.querySelector(".widget-error")).toBeNull();
+      }
+    }
+  );
 
   it("renders a plain tile when the widget config is partial/invalid", async () => {
     getConfig.mockReturnValue({

--- a/src/__tests__/components/ServiceGrid.test.tsx
+++ b/src/__tests__/components/ServiceGrid.test.tsx
@@ -86,6 +86,86 @@ describe("ServiceGrid", () => {
     expect(zetaGroup.textContent).toContain("Sonarr");
   });
 
+  it("renders the widget when its config passes the widget schema", async () => {
+    getConfig.mockReturnValue({
+      services: [
+        makeService({
+          name: "Plex",
+          url: "http://plex.local",
+          widget: {
+            type: "plex",
+            config: { url: "http://plex.local:32400", token: "t" },
+          },
+        }),
+      ],
+    });
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<ServiceGrid />));
+    });
+    expect(
+      container.querySelector('.service-tile__widget[data-widget-type="plex"]')
+    ).not.toBeNull();
+  });
+
+  it("renders a plain tile when the widget has no config", async () => {
+    getConfig.mockReturnValue({
+      services: [
+        makeService({
+          name: "Plex",
+          url: "http://plex.local",
+          widget: { type: "plex" },
+        }),
+      ],
+    });
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<ServiceGrid />));
+    });
+    expect(screen.getByText("Plex")).toBeInTheDocument();
+    expect(container.querySelector(".service-tile__widget")).toBeNull();
+    expect(container.querySelector(".widget-error")).toBeNull();
+  });
+
+  it("renders a plain tile when the widget config is partial/invalid", async () => {
+    getConfig.mockReturnValue({
+      services: [
+        makeService({
+          name: "Plex",
+          url: "http://plex.local",
+          widget: {
+            type: "plex",
+            config: { url: "http://plex.local:32400" }, // token missing
+          },
+        }),
+      ],
+    });
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<ServiceGrid />));
+    });
+    expect(screen.getByText("Plex")).toBeInTheDocument();
+    expect(container.querySelector(".service-tile__widget")).toBeNull();
+    expect(container.querySelector(".widget-error")).toBeNull();
+  });
+
+  it("keeps the error box for an unknown widget type", async () => {
+    getConfig.mockReturnValue({
+      services: [
+        makeService({
+          name: "Mystery",
+          widget: { type: "not-a-real-widget" },
+        }),
+      ],
+    });
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(<ServiceGrid />));
+    });
+    expect(container.querySelector(".widget-error")).not.toBeNull();
+    expect(screen.getByText(/unknown widget type/i)).toBeInTheDocument();
+  });
+
   it("renders both grouped and ungrouped services together", async () => {
     getConfig.mockReturnValue({
       services: [

--- a/src/__tests__/integrations/NetdataFetchData.test.ts
+++ b/src/__tests__/integrations/NetdataFetchData.test.ts
@@ -1,0 +1,293 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import "@/integrations";
+import { getWidget } from "@/widgets";
+
+// The netdata fetch*Data functions are module-private and only reachable
+// through the widget registry, so these tests drive them the same way the
+// widget API route does: getWidget(id).fetchData(config).
+//
+// fetchAllMetrics caches per url+token for 9s (module-level), so every test
+// uses a distinct URL to stay independent.
+
+type Charts = Record<
+  string,
+  { units?: string; dimensions: Record<string, { value: number | null }> }
+>;
+
+interface HistoryPayload {
+  dimension_names: string[];
+  data: Array<[number, ...number[]]>;
+}
+
+function stubNetdataFetch({
+  charts,
+  history,
+  failHistory = false,
+}: {
+  charts: Charts;
+  history?: HistoryPayload;
+  failHistory?: boolean;
+}) {
+  const fetchMock = vi.fn().mockImplementation((url: string) => {
+    if (url.includes("allmetrics")) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ charts }),
+      } as Response);
+    }
+    if (failHistory) {
+      return Promise.resolve({ ok: false, status: 500 } as Response);
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve(history ?? { dimension_names: [], data: [] }),
+    } as Response);
+  });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+function fetchData(
+  id: string,
+  config: Record<string, unknown>
+): Promise<Record<string, unknown>> {
+  const def = getWidget(id);
+  if (!def) throw new Error(`widget "${id}" not registered`);
+  return def.fetchData(config) as Promise<Record<string, unknown>>;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("netdata-cpu fetchData", () => {
+  it("computes usage from idle and maps history rows to 100 - idle", async () => {
+    stubNetdataFetch({
+      charts: { "system.cpu": { dimensions: { idle: { value: 60 } } } },
+      history: {
+        dimension_names: ["idle"],
+        data: [
+          [1, 80],
+          [2, 90],
+        ],
+      },
+    });
+    const data = await fetchData("netdata-cpu", { url: "http://nd-cpu.test" });
+    expect(data).toEqual({ current: 40, history: [20, 10] });
+  });
+
+  it("falls back to empty history when the history request fails", async () => {
+    stubNetdataFetch({
+      charts: { "system.cpu": { dimensions: { idle: { value: 75 } } } },
+      failHistory: true,
+    });
+    const data = await fetchData("netdata-cpu", {
+      url: "http://nd-cpu-nohist.test",
+    });
+    expect(data).toEqual({ current: 25, history: [] });
+  });
+});
+
+describe("netdata-ram fetchData", () => {
+  const MiB = 1024 * 1024;
+
+  it("converts MiB dimensions to bytes and sums history components", async () => {
+    stubNetdataFetch({
+      charts: {
+        "system.ram": {
+          dimensions: {
+            free: { value: 1024 },
+            used: { value: 2048 },
+            cached: { value: 512 },
+            buffers: { value: 512 },
+          },
+        },
+      },
+      history: {
+        dimension_names: ["used", "cached", "buffers"],
+        data: [[1, 100, 50, 50]],
+      },
+    });
+    const data = await fetchData("netdata-ram", { url: "http://nd-ram.test" });
+    expect(data).toEqual({
+      usedBytes: 3072 * MiB,
+      totalBytes: 4096 * MiB,
+      history: [200 * MiB],
+    });
+  });
+});
+
+describe("netdata-net fetchData", () => {
+  it("converts kilobits/s to bytes/s for current values and history", async () => {
+    stubNetdataFetch({
+      charts: {
+        "system.net": {
+          dimensions: { received: { value: -800 }, sent: { value: 80 } },
+        },
+      },
+      history: {
+        dimension_names: ["received", "sent"],
+        data: [[1, -16, 8]],
+      },
+    });
+    const data = await fetchData("netdata-net", { url: "http://nd-net.test" });
+    expect(data).toEqual({
+      inBps: 100_000,
+      outBps: 10_000,
+      inHistory: [2000],
+      outHistory: [1000],
+    });
+  });
+
+  it("returns empty histories when the history chart lacks the dimensions", async () => {
+    stubNetdataFetch({
+      charts: {
+        "system.net": {
+          dimensions: { received: { value: 8 }, sent: { value: 8 } },
+        },
+      },
+      history: { dimension_names: ["other"], data: [[1, 5]] },
+    });
+    const data = await fetchData("netdata-net", {
+      url: "http://nd-net-nodims.test",
+    });
+    expect(data.inHistory).toEqual([]);
+    expect(data.outHistory).toEqual([]);
+  });
+});
+
+describe("netdata-disk-io fetchData", () => {
+  it("converts KiB/s to bytes/s for current values and history", async () => {
+    stubNetdataFetch({
+      charts: {
+        "system.io": {
+          dimensions: { in: { value: 100 }, out: { value: -50 } },
+        },
+      },
+      history: {
+        dimension_names: ["in", "out"],
+        data: [[1, 10, -20]],
+      },
+    });
+    const data = await fetchData("netdata-disk-io", {
+      url: "http://nd-io.test",
+    });
+    expect(data).toEqual({
+      readBps: 100 * 1024,
+      writeBps: 50 * 1024,
+      readHistory: [10 * 1024],
+      writeHistory: [20 * 1024],
+    });
+  });
+});
+
+describe("netdata-disk-space fetchData", () => {
+  const GiB = 1024 ** 3;
+
+  it("reads the default disk_space._ chart in GiB", async () => {
+    stubNetdataFetch({
+      charts: {
+        "disk_space._": {
+          dimensions: {
+            avail: { value: 100 },
+            used: { value: 300 },
+            reserved_for_root: { value: 12 },
+          },
+        },
+      },
+    });
+    const data = await fetchData("netdata-disk-space", {
+      url: "http://nd-disk.test",
+    });
+    expect(data).toEqual({ usedBytes: 300 * GiB, totalBytes: 412 * GiB });
+  });
+
+  it("honors a custom chart_id", async () => {
+    stubNetdataFetch({
+      charts: {
+        "disk_space./mnt": {
+          dimensions: {
+            avail: { value: 10 },
+            used: { value: 30 },
+            reserved_for_root: { value: 0 },
+          },
+        },
+      },
+    });
+    const data = await fetchData("netdata-disk-space", {
+      url: "http://nd-disk-mnt.test",
+      chart_id: "disk_space./mnt",
+    });
+    expect(data).toEqual({ usedBytes: 30 * GiB, totalBytes: 40 * GiB });
+  });
+});
+
+describe("netdata-load fetchData", () => {
+  it("returns the 1m/5m/15m load averages", async () => {
+    stubNetdataFetch({
+      charts: {
+        "system.load": {
+          dimensions: {
+            load1: { value: 1.5 },
+            load5: { value: 1.0 },
+            load15: { value: 0.5 },
+          },
+        },
+      },
+    });
+    const data = await fetchData("netdata-load", { url: "http://nd-load.test" });
+    expect(data).toEqual({ one: 1.5, five: 1.0, fifteen: 0.5 });
+  });
+});
+
+describe("netdata-sensor fetchData", () => {
+  it("averages the chart dimensions and derives the default label", async () => {
+    stubNetdataFetch({
+      charts: {
+        "sensors.cpu_temp": {
+          units: "Celsius",
+          dimensions: { a: { value: 50 }, b: { value: 60 } },
+        },
+      },
+      history: {
+        dimension_names: ["a", "b"],
+        data: [[1, 40, 60]],
+      },
+    });
+    const data = await fetchData("netdata-sensor", {
+      url: "http://nd-sensor.test",
+      chart_id: "sensors.cpu_temp",
+    });
+    expect(data).toEqual({
+      value: 55,
+      units: "Celsius",
+      history: [50],
+      label: "cpu_temp",
+    });
+  });
+
+  it("prefers an explicit label over the chart id", async () => {
+    stubNetdataFetch({
+      charts: {
+        "sensors.fan": { units: "RPM", dimensions: { a: { value: 1200 } } },
+      },
+    });
+    const data = await fetchData("netdata-sensor", {
+      url: "http://nd-sensor-label.test",
+      chart_id: "sensors.fan",
+      label: "Case Fan",
+    });
+    expect(data.label).toBe("Case Fan");
+  });
+
+  it("throws a helpful error when the chart does not exist", async () => {
+    stubNetdataFetch({ charts: {} });
+    await expect(
+      fetchData("netdata-sensor", {
+        url: "http://nd-sensor-missing.test",
+        chart_id: "sensors.none",
+      })
+    ).rejects.toThrow(/sensors\.none.*not found/);
+  });
+});

--- a/src/app/api/_auth.ts
+++ b/src/app/api/_auth.ts
@@ -1,0 +1,16 @@
+import { cookies } from "next/headers";
+import { getAuthUser, SESSION_COOKIE_NAME } from "@/auth";
+import { getConfig } from "@/config";
+
+/** True when the request carries a valid session, or when auth is disabled. */
+export async function checkAuth(): Promise<boolean> {
+  const config = getConfig();
+  const authEnabled =
+    config.auth.enabled && process.env.KOKPIT_AUTH_DISABLED !== "true";
+  if (!authEnabled) return true;
+
+  const cookieStore = await cookies();
+  const token = cookieStore.get(SESSION_COOKIE_NAME)?.value;
+  const user = await getAuthUser(token);
+  return !!user;
+}

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,20 +1,7 @@
-import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { getAuthUser, SESSION_COOKIE_NAME } from "@/auth";
 import { getConfig, writeConfig } from "@/config";
-
-async function checkAuth(): Promise<boolean> {
-  const config = getConfig();
-  const authEnabled =
-    config.auth.enabled && process.env.KOKPIT_AUTH_DISABLED !== "true";
-  if (!authEnabled) return true;
-
-  const cookieStore = await cookies();
-  const token = cookieStore.get(SESSION_COOKIE_NAME)?.value;
-  const user = await getAuthUser(token);
-  return !!user;
-}
+import { checkAuth } from "../_auth";
 
 const PatchBodySchema = z.object({
   appearance: z

--- a/src/app/api/widget/_timeout.ts
+++ b/src/app/api/widget/_timeout.ts
@@ -1,0 +1,40 @@
+export const WIDGET_FETCH_TIMEOUT_MS = 5000;
+
+export class WidgetFetchTimeoutError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WidgetFetchTimeoutError";
+  }
+}
+
+/**
+ * Runs a widget fetch under a hard timeout. The AbortSignal asks the widget
+ * to cancel cooperatively, but the race guarantees the caller gets a
+ * WidgetFetchTimeoutError even when the widget ignores its signal — an
+ * abort alone would leave the request hanging on a non-cooperative fetch.
+ */
+export async function fetchWithHardTimeout<T>(
+  run: (signal: AbortSignal) => Promise<T>,
+  timeoutMessage: string,
+  timeoutMs: number = WIDGET_FETCH_TIMEOUT_MS
+): Promise<T> {
+  const ac = new AbortController();
+  const task = run(ac.signal);
+  // If the timeout wins the race, a later cooperative rejection from the
+  // abandoned task would otherwise surface as an unhandled rejection.
+  task.catch(() => {});
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      task,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(() => {
+          ac.abort(new Error(timeoutMessage));
+          reject(new WidgetFetchTimeoutError(timeoutMessage));
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/app/api/widget/route.ts
+++ b/src/app/api/widget/route.ts
@@ -2,6 +2,7 @@ import "@/integrations";
 import { NextResponse } from "next/server";
 import { getConfig } from "@/config";
 import { getWidget } from "@/widgets";
+import { fetchWithHardTimeout, WidgetFetchTimeoutError } from "./_timeout";
 
 export async function GET(request: Request) {
   const { searchParams } = new URL(request.url);
@@ -44,21 +45,19 @@ export async function GET(request: Request) {
     );
   }
 
-  // Use an AbortController so the timeout actually cancels the widget's fetch, not just the race.
-  const ac = new AbortController();
-  const timer = setTimeout(() => ac.abort(new Error("Widget fetch timed out")), 5000);
   try {
-    const data = await widget.fetchData(parsed.data, ac.signal);
+    const data = await fetchWithHardTimeout(
+      (signal) => widget.fetchData(parsed.data, signal),
+      "Widget fetch timed out"
+    );
     return NextResponse.json({ ok: true, data });
   } catch (err) {
-    if (ac.signal.aborted) {
-      return NextResponse.json({ ok: false, error: "Widget fetch timed out" }, { status: 504 });
+    if (err instanceof WidgetFetchTimeoutError) {
+      return NextResponse.json({ ok: false, error: err.message }, { status: 504 });
     }
     return NextResponse.json(
       { ok: false, error: err instanceof Error ? err.message : "Widget fetch failed" },
       { status: 500 }
     );
-  } finally {
-    clearTimeout(timer);
   }
 }

--- a/src/app/api/widget/test/route.ts
+++ b/src/app/api/widget/test/route.ts
@@ -1,0 +1,68 @@
+import "@/integrations";
+import { NextResponse } from "next/server";
+import { getWidget } from "@/widgets";
+import { checkAuth } from "../../_auth";
+
+// Tests a widget connection with config straight from the (possibly unsaved)
+// service form. Unlike GET /api/widget, the config arrives in the body instead
+// of being looked up in settings.yaml — the service may not exist yet. This
+// endpoint triggers server-side requests to caller-supplied URLs, so it is
+// strictly auth-gated.
+export async function POST(request: Request) {
+  if (!(await checkAuth())) {
+    return NextResponse.json({ ok: false, error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ ok: false, error: "Invalid JSON" }, { status: 400 });
+  }
+
+  const { type, config } = (body ?? {}) as { type?: unknown; config?: unknown };
+  if (typeof type !== "string" || type === "") {
+    return NextResponse.json({ ok: false, error: "Missing type" }, { status: 400 });
+  }
+
+  const widget = getWidget(type);
+  if (!widget) {
+    return NextResponse.json(
+      { ok: false, error: `Unknown widget type: "${type}"` },
+      { status: 404 }
+    );
+  }
+
+  const parsed = widget.configSchema.safeParse(config ?? {});
+  if (!parsed.success) {
+    const messages = parsed.error.issues
+      .map((issue) => `${issue.path.join(".")}: ${issue.message}`)
+      .join(", ");
+    return NextResponse.json(
+      { ok: false, error: `Invalid widget config: ${messages}` },
+      { status: 400 }
+    );
+  }
+
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(new Error("Connection test timed out")), 5000);
+  try {
+    // Only pass/fail matters here — discard the data so credentials-derived
+    // payloads never round-trip through the form.
+    await widget.fetchData(parsed.data, ac.signal);
+    return NextResponse.json({ ok: true });
+  } catch (err) {
+    if (ac.signal.aborted) {
+      return NextResponse.json(
+        { ok: false, error: "Connection test timed out" },
+        { status: 504 }
+      );
+    }
+    return NextResponse.json(
+      { ok: false, error: err instanceof Error ? err.message : "Connection test failed" },
+      { status: 500 }
+    );
+  } finally {
+    clearTimeout(timer);
+  }
+}

--- a/src/app/api/widget/test/route.ts
+++ b/src/app/api/widget/test/route.ts
@@ -2,6 +2,7 @@ import "@/integrations";
 import { NextResponse } from "next/server";
 import { getWidget } from "@/widgets";
 import { checkAuth } from "../../_auth";
+import { fetchWithHardTimeout, WidgetFetchTimeoutError } from "../_timeout";
 
 // Tests a widget connection with config straight from the (possibly unsaved)
 // service form. Unlike GET /api/widget, the config arrives in the body instead
@@ -44,25 +45,21 @@ export async function POST(request: Request) {
     );
   }
 
-  const ac = new AbortController();
-  const timer = setTimeout(() => ac.abort(new Error("Connection test timed out")), 5000);
   try {
     // Only pass/fail matters here — discard the data so credentials-derived
     // payloads never round-trip through the form.
-    await widget.fetchData(parsed.data, ac.signal);
+    await fetchWithHardTimeout(
+      (signal) => widget.fetchData(parsed.data, signal),
+      "Connection test timed out"
+    );
     return NextResponse.json({ ok: true });
   } catch (err) {
-    if (ac.signal.aborted) {
-      return NextResponse.json(
-        { ok: false, error: "Connection test timed out" },
-        { status: 504 }
-      );
+    if (err instanceof WidgetFetchTimeoutError) {
+      return NextResponse.json({ ok: false, error: err.message }, { status: 504 });
     }
     return NextResponse.json(
       { ok: false, error: err instanceof Error ? err.message : "Connection test failed" },
       { status: 500 }
     );
-  } finally {
-    clearTimeout(timer);
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -782,6 +782,28 @@ body {
   background: var(--color-surface-2);
 }
 
+.service-form__widget-status--active {
+  color: #22c55e;
+}
+
+.service-form__test-row {
+  align-items: center;
+  display: flex;
+  gap: 0.75rem;
+}
+
+.service-form__test-result {
+  font-size: 0.8rem;
+}
+
+.service-form__test-result--success {
+  color: #22c55e;
+}
+
+.service-form__test-result--error {
+  color: var(--color-error);
+}
+
 .service-form__actions {
   display: flex;
   justify-content: flex-end;

--- a/src/components/ServiceForm.tsx
+++ b/src/components/ServiceForm.tsx
@@ -70,6 +70,30 @@ function initFromService(service: Service | null): {
   };
 }
 
+/**
+ * Drops entries that don't count as "configured": empty strings, empty
+ * arrays, null/undefined. A widget config that cleans down to {} means the
+ * user left the widget unconfigured and the tile renders as a plain link.
+ */
+function cleanWidgetConfig(
+  config: Record<string, unknown>
+): Record<string, unknown> {
+  const cleaned: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(config)) {
+    if (value === undefined || value === null) continue;
+    if (typeof value === "string" && value.trim() === "") continue;
+    if (Array.isArray(value) && value.length === 0) continue;
+    cleaned[key] = value;
+  }
+  return cleaned;
+}
+
+type TestStatus =
+  | { state: "idle" }
+  | { state: "testing" }
+  | { state: "success" }
+  | { state: "error"; message: string };
+
 function GroupCombobox({
   value,
   onChange,
@@ -195,7 +219,6 @@ function WidgetConfigFields({
                 onChange(field.key, field.type === "number" ? (raw === "" ? undefined : Number(raw)) : raw);
               }}
               placeholder={field.placeholder}
-              required={field.required}
             />
             {field.description && (
               <p className="settings-form-hint">{field.description}</p>
@@ -227,6 +250,7 @@ export default function ServiceForm({
   const [orphanWidget, setOrphanWidget] = useState<ServiceWidget | null>(initial.orphanWidget);
   const [widgetConfig, setWidgetConfig] = useState<Record<string, unknown>>(initial.widgetConfig);
   const [refreshInterval, setRefreshInterval] = useState<string>(initial.refreshInterval);
+  const [testStatus, setTestStatus] = useState<TestStatus>({ state: "idle" });
 
   const presetWidgets = getWidgetsWithServiceEditorPreset();
 
@@ -239,8 +263,22 @@ export default function ServiceForm({
 
   const showWidgetSection = tileType !== "" || orphanWidget !== null;
 
+  const activeWidgetType =
+    tileType !== "" ? tileType : orphanWidget?.type ?? null;
+  const activeCleanedConfig = cleanWidgetConfig(
+    tileType !== ""
+      ? widgetConfig
+      : ((orphanWidget?.config as Record<string, unknown>) ?? {})
+  );
+  // Mirrors the dashboard's rule: the widget renders only when its config
+  // passes the schema. Unknown types can't be validated client-side.
+  const widgetConfigValid = selectedWidgetDef
+    ? selectedWidgetDef.configSchema.safeParse(activeCleanedConfig).success
+    : null;
+
   function handleWidgetConfigChange(key: string, value: unknown) {
     setWidgetConfig((prev) => ({ ...prev, [key]: value }));
+    setTestStatus({ state: "idle" });
   }
 
   function handleOrphanWidgetConfigChange(key: string, value: unknown) {
@@ -249,9 +287,11 @@ export default function ServiceForm({
       const cfg = { ...((prev.config as Record<string, unknown>) ?? {}), [key]: value };
       return { ...prev, config: cfg };
     });
+    setTestStatus({ state: "idle" });
   }
 
   function handleTileTypeChange(newTile: string) {
+    setTestStatus({ state: "idle" });
     if (newTile === "") {
       if (tileType !== "") {
         setOrphanWidget(null);
@@ -269,6 +309,35 @@ export default function ServiceForm({
     if (def?.serviceEditorPreset) {
       setName(def.serviceEditorPreset.defaultName);
       setIcon(def.serviceEditorPreset.defaultIconUrl);
+    }
+  }
+
+  async function handleTestConnection() {
+    if (!activeWidgetType) return;
+    setTestStatus({ state: "testing" });
+    try {
+      const res = await fetch("/api/widget/test", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          type: activeWidgetType,
+          config: activeCleanedConfig,
+        }),
+      });
+      const json = (await res.json()) as { ok: boolean; error?: string };
+      if (json.ok) {
+        setTestStatus({ state: "success" });
+      } else {
+        setTestStatus({
+          state: "error",
+          message: json.error ?? "Connection test failed",
+        });
+      }
+    } catch (err) {
+      setTestStatus({
+        state: "error",
+        message: err instanceof Error ? err.message : "Connection test failed",
+      });
     }
   }
 
@@ -294,10 +363,10 @@ export default function ServiceForm({
 
     let widget: ServiceWidget | undefined;
     if (tileType !== "") {
+      const cfg = cleanWidgetConfig(widgetConfig);
       widget = {
         type: tileType,
-        config:
-          Object.keys(widgetConfig).length > 0 ? widgetConfig : undefined,
+        config: Object.keys(cfg).length > 0 ? cfg : undefined,
         refresh_interval_ms:
           refreshInterval !== "" ? Number(refreshInterval) : undefined,
       };
@@ -439,6 +508,13 @@ export default function ServiceForm({
               <span>Widget</span>
             </div>
 
+            {tileType !== "" && (
+              <p className="settings-form-hint">
+                Optional — leave these fields empty to add a plain link tile.
+                You can configure the widget later.
+              </p>
+            )}
+
             {selectedWidgetDef?.configFields &&
               selectedWidgetDef.configFields.length > 0 && (
                 <WidgetConfigFields
@@ -490,6 +566,48 @@ export default function ServiceForm({
                 min={5000}
                 step={1000}
               />
+            </div>
+
+            {selectedWidgetDef && (
+              <p
+                role="status"
+                className={`settings-form-hint service-form__widget-status service-form__widget-status--${
+                  widgetConfigValid ? "active" : "inactive"
+                }`}
+              >
+                {widgetConfigValid
+                  ? "Widget configured — it will render on the dashboard tile."
+                  : "Widget not configured — the tile will render as a plain link until the required fields are filled."}
+              </p>
+            )}
+
+            <div className="service-form__test-row">
+              <button
+                type="button"
+                className="settings-btn"
+                onClick={handleTestConnection}
+                disabled={
+                  testStatus.state === "testing" || widgetConfigValid === false
+                }
+              >
+                {testStatus.state === "testing" ? "Testing…" : "Test connection"}
+              </button>
+              {testStatus.state === "success" && (
+                <span
+                  className="service-form__test-result service-form__test-result--success"
+                  role="status"
+                >
+                  Connection OK
+                </span>
+              )}
+              {testStatus.state === "error" && (
+                <span
+                  className="service-form__test-result service-form__test-result--error"
+                  role="alert"
+                >
+                  {testStatus.message}
+                </span>
+              )}
             </div>
           </>
         )}

--- a/src/components/ServiceGrid.tsx
+++ b/src/components/ServiceGrid.tsx
@@ -1,6 +1,28 @@
+// Populate the widget registry server-side so widget configs can be
+// validated before deciding whether a tile renders its widget.
+import "@/integrations";
 import { getConfig } from "@/config";
-import { Service } from "@/config/schema";
-import ServiceTile from "./ServiceTile";
+import { Service, ServiceWidget } from "@/config/schema";
+import { getWidget } from "@/widgets";
+import ServiceTile, { TileWidget } from "./ServiceTile";
+
+// Decide what the client tile gets to see of a service's widget:
+// - no widget → nothing
+// - unknown type → sanitized pass-through, so the renderer surfaces the typo
+// - known type with valid config → sanitized widget
+// - known type with missing/invalid config → nothing (plain link tile)
+// Config (credentials) never leaves the server either way.
+function resolveTileWidget(widget?: ServiceWidget): TileWidget | undefined {
+  if (!widget) return undefined;
+  const def = getWidget(widget.type);
+  if (def && !def.configSchema.safeParse(widget.config ?? {}).success) {
+    return undefined;
+  }
+  return {
+    type: widget.type,
+    refresh_interval_ms: widget.refresh_interval_ms,
+  };
+}
 
 function groupServices(services: Service[]): {
   ungrouped: Service[];
@@ -49,7 +71,7 @@ export default function ServiceGrid() {
                 url={service.url}
                 icon={service.icon}
                 description={service.description}
-                widget={service.widget}
+                widget={resolveTileWidget(service.widget)}
                 position={service.position}
               />
             ))}
@@ -65,7 +87,7 @@ export default function ServiceGrid() {
               url={service.url}
               icon={service.icon}
               description={service.description}
-              widget={service.widget}
+              widget={resolveTileWidget(service.widget)}
               position={service.position}
             />
           ))}

--- a/src/components/ServiceTile.tsx
+++ b/src/components/ServiceTile.tsx
@@ -1,15 +1,22 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type { ServiceWidget, WidgetPosition } from "@/config/schema";
+import type { WidgetPosition } from "@/config/schema";
 import { WidgetRenderer } from "./WidgetRenderer";
+
+// Client-safe slice of ServiceWidget: the config (credentials) stays on the
+// server — the widget data API looks it up in settings.yaml by service name.
+export interface TileWidget {
+  type: string;
+  refresh_interval_ms?: number;
+}
 
 interface ServiceTileProps {
   name: string;
   url?: string;
   icon?: string;
   description?: string;
-  widget?: ServiceWidget;
+  widget?: TileWidget;
   position?: WidgetPosition;
 }
 


### PR DESCRIPTION
Plan for decoupling widget configuration from service creation (plain
tile until widget config validates) and adding a Test connection button
to the service add/edit form.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012XiEvKqxHkcHBejHToMWAf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Widget configuration is now optional when creating or editing services.
  - Services without valid widget settings render as plain tiles.
  - Added **Test connection** in the service form with live success/error and timeout feedback.
  - Widget status now reflects whether required settings are configured.

- **Bug Fixes**
  - Prevented misleading widget error displays when stored widget config is missing or invalid.
  - Improved clarity for widget connection failures.

- **Security**
  - Sensitive widget credentials/config are no longer exposed to the client.
  - Authentication is enforced consistently for protected widget/setting actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->