### PR TITLE
chore: bump version to 0.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kokpit",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kokpit",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@testing-library/dom": "^10.4.1",
         "bcryptjs": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kokpit",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "engines": {
     "node": ">=22.19.0"


### PR DESCRIPTION
## Summary
- Bumps `package.json`/`package-lock.json` version to `0.3.1`, ahead of releasing #57 (server-side icon detection for the service editor).

## Test plan
- [x] Version-only change; no behavior to test directly.


---
_Generated by [Claude Code](https://claude.ai/code/session_01ExjmqSGjwmU4HtHytYUafL)_