### PR TITLE
Fix mobile horizontal-overflow scrolling

### DIFF
--- a/e2e/tests/mobile-layout.spec.ts
+++ b/e2e/tests/mobile-layout.spec.ts
@@ -103,14 +103,17 @@ for (const viewport of VIEWPORTS) {
     test.use({ viewport: { width: viewport.width, height: viewport.height } });
 
     test.beforeEach(async ({ request }) => {
-      await request.post(`${MOCK}/__control`, { data: DEFAULT_MOCK_STATE });
-      await request.patch("/api/settings", {
+      const mockRes = await request.post(`${MOCK}/__control`, { data: DEFAULT_MOCK_STATE });
+      expect(mockRes.ok(), `Mock control endpoint failed: ${mockRes.status()}`).toBeTruthy();
+
+      const settingsRes = await request.patch("/api/settings", {
         data: {
           layout: { columns: 4, row_height: 120 }, // no mobile override -> reproduces default RC2
           appearance: { theme: "dark", custom_css: undefined },
           services: MOBILE_FIXTURE_SERVICES,
         },
       });
+      expect(settingsRes.ok(), `Settings patch failed: ${settingsRes.status()}`).toBeTruthy();
     });
 
     test("dashboard has no horizontal overflow", async ({ page }) => {

--- a/e2e/tests/mobile-layout.spec.ts
+++ b/e2e/tests/mobile-layout.spec.ts
@@ -1,0 +1,233 @@
+import { test, expect, type Page } from "@playwright/test";
+import { DEFAULT_MOCK_STATE } from "../helpers/mock-plex-server";
+
+const MOCK = "http://localhost:32400";
+
+/**
+ * Mobile horizontal-overflow regression tests.
+ *
+ * Reproduces the bug documented in docs/plans/mobile-experience-plan.md: on
+ * narrow viewports the dashboard (and, at 375px, the settings tab bar)
+ * scrolls horizontally. The overflow is contained inside `.shell-main`
+ * (which becomes an implicit `overflow-x: auto` scroll container per the
+ * CSS overflow spec once `overflow-y: auto` is set) rather than the
+ * document, so `document.documentElement.scrollWidth` alone does NOT catch
+ * it — these tests measure `.shell-main` directly and sweep every element
+ * under `.shell` for a bounding box that extends past the viewport.
+ *
+ * We deliberately use manual `{ width, height }` viewports via
+ * `test.use({ viewport })` rather than Playwright's `devices[...]` presets
+ * (e.g. `devices['iPhone SE']` / `devices['iPhone 12']`) — we only need the
+ * CSS width to trigger the relevant media queries, not touch/UA emulation,
+ * and manual sizes keep the measurements deterministic.
+ */
+
+const VIEWPORTS = [
+  { name: "375x667 (iPhone SE)", width: 375, height: 667 },
+  { name: "390x844 (iPhone 12/13/14)", width: 390, height: 844 },
+];
+
+// Plain link tiles (no widgets) so the test needs no mock widget data and is
+// deterministic. No mobile column override is configured, so the dashboard
+// grid inherits the desktop column count (RC2) -- and the last service has a
+// long unbreakable name/description token to exercise the grid-shrinking fix
+// (RC3). This mirrors a representative real-world config, not a contrived one.
+const MOBILE_FIXTURE_SERVICES = [
+  { name: "Sonarr", url: "http://localhost:8001" },
+  { name: "Radarr", url: "http://localhost:8002" },
+  { name: "Prowlarr", url: "http://localhost:8003" },
+  { name: "qBittorrent", url: "http://localhost:8004" },
+  { name: "SABnzbd", url: "http://localhost:8005" },
+  { name: "Immich", url: "http://localhost:8006" },
+  {
+    name: "A-Very-Long-Unbreakable-Service-Name-That-Cannot-Wrap",
+    url: "http://localhost:8007",
+    description: "contains superlongunbreakablewordthatwillnotwrapatalleverokay token",
+  },
+];
+
+/**
+ * Measures real horizontal overflow even when an inner scroll container
+ * (`.shell-main`) hides it from `document.documentElement.scrollWidth`.
+ * See the file-level comment / docs/plans/mobile-experience-plan.md Section 1
+ * ("The measurement trap") for why the document-level check alone is
+ * insufficient.
+ */
+async function assertNoHorizontalOverflow(page: Page) {
+  const r = await page.evaluate(() => {
+    const iw = window.innerWidth;
+    const sm = document.querySelector(".shell-main");
+    // Per-element sweep under .shell: nothing may extend past the right edge.
+    let worstRight = 0;
+    let worstSel = "";
+    document.querySelectorAll(".shell *").forEach((el) => {
+      const rect = el.getBoundingClientRect();
+      if (rect.width === 0 && rect.height === 0) return; // skip hidden
+      if (rect.right > worstRight) {
+        worstRight = rect.right;
+        worstSel =
+          el.tagName.toLowerCase() +
+          "." +
+          (typeof el.className === "string" ? el.className.split(" ")[0] : "");
+      }
+    });
+    return {
+      innerWidth: iw,
+      docScrollWidth: document.documentElement.scrollWidth,
+      shellMain: sm ? { c: sm.clientWidth, s: sm.scrollWidth } : null,
+      worstRight: Math.round(worstRight),
+      worstSel,
+    };
+  });
+
+  // (a) document-level (cheap; necessary but NOT sufficient on its own --
+  // `.shell-main`'s implicit horizontal scroll container hides overflow from
+  // the document, so this alone would false-negative on the real bug).
+  expect(r.docScrollWidth, `document.documentElement.scrollWidth (${r.docScrollWidth}) exceeds innerWidth (${r.innerWidth})`)
+    .toBeLessThanOrEqual(r.innerWidth + 1);
+  // (b) PRIMARY: the scroll container must not scroll horizontally.
+  expect(r.shellMain, ".shell-main not found on page").not.toBeNull();
+  expect(
+    r.shellMain!.s,
+    `.shell-main scrollWidth (${r.shellMain!.s}) exceeds clientWidth (${r.shellMain!.c})`
+  ).toBeLessThanOrEqual(r.shellMain!.c + 1);
+  // (c) THOROUGH: no element inside .shell extends past the viewport.
+  expect(
+    r.worstRight,
+    `element ${r.worstSel} extends to right=${r.worstRight}, past innerWidth=${r.innerWidth}`
+  ).toBeLessThanOrEqual(r.innerWidth + 1);
+}
+
+for (const viewport of VIEWPORTS) {
+  test.describe(`mobile layout @ ${viewport.name}`, () => {
+    test.use({ viewport: { width: viewport.width, height: viewport.height } });
+
+    test.beforeEach(async ({ request }) => {
+      await request.post(`${MOCK}/__control`, { data: DEFAULT_MOCK_STATE });
+      await request.patch("/api/settings", {
+        data: {
+          layout: { columns: 4, row_height: 120 }, // no mobile override -> reproduces default RC2
+          appearance: { theme: "dark", custom_css: undefined },
+          services: MOBILE_FIXTURE_SERVICES,
+        },
+      });
+    });
+
+    test("dashboard has no horizontal overflow", async ({ page }) => {
+      await page.goto("/");
+      await expect(page.locator(".service-tile").first()).toBeVisible();
+
+      await assertNoHorizontalOverflow(page);
+    });
+
+    test("settings page has no horizontal overflow", async ({ page }) => {
+      await page.goto("/settings");
+      await expect(page.locator(".settings-tabs")).toBeVisible();
+
+      await assertNoHorizontalOverflow(page);
+    });
+
+    test("settings tabs are all reachable", async ({ page }) => {
+      await page.goto("/settings");
+      await expect(page.locator(".settings-tabs")).toBeVisible();
+
+      const innerWidth = viewport.width;
+      const tabs = page.locator(".settings-tab");
+      const count = await tabs.count();
+      expect(count).toBeGreaterThan(0);
+
+      for (let i = 0; i < count; i++) {
+        const tab = tabs.nth(i);
+        const box = await tab.boundingBox();
+        expect(box, `tab ${i} has no bounding box`).not.toBeNull();
+        expect(
+          box!.x + box!.width,
+          `settings-tab[${i}] right edge (${box!.x + box!.width}) exceeds innerWidth (${innerWidth})`
+        ).toBeLessThanOrEqual(innerWidth + 1);
+      }
+
+      // Clicking a non-default tab still switches the visible section.
+      await page.click("button.settings-tab:has-text('Layout')");
+      await expect(page.locator(".settings-section__title")).toHaveText("Layout");
+    });
+
+    test("auth form is usable on mobile", async ({ page }) => {
+      // /login redirects to /setup when no admin exists in the e2e server;
+      // /setup renders the same .auth-card styling, so it's a valid stand-in
+      // for exercising the auth-card layout on mobile. (See docs/plans/
+      // mobile-experience-plan.md Section 5 for why /login itself is out of
+      // scope for this default, auth-disabled harness.)
+      await page.goto("/setup");
+
+      const authCard = page.locator(".auth-card");
+      await expect(authCard).toBeVisible();
+
+      const innerWidth = viewport.width;
+      const cardBox = await authCard.boundingBox();
+      expect(cardBox).not.toBeNull();
+      expect(
+        cardBox!.x + cardBox!.width,
+        `.auth-card right edge (${cardBox!.x + cardBox!.width}) exceeds innerWidth (${innerWidth})`
+      ).toBeLessThanOrEqual(innerWidth + 1);
+
+      const firstInput = page.locator("input").first();
+      await expect(firstInput).toBeVisible();
+      const inputBox = await firstInput.boundingBox();
+      expect(inputBox).not.toBeNull();
+      expect(
+        inputBox!.width,
+        `first input width (${inputBox!.width}) exceeds innerWidth (${innerWidth})`
+      ).toBeLessThanOrEqual(innerWidth);
+    });
+
+    test("dashboard tiles are visible and tappable", async ({ page }) => {
+      await page.goto("/");
+      await expect(page.locator(".service-tile").first()).toBeVisible();
+
+      const tiles = page.locator(".service-tile");
+      const count = await tiles.count();
+      expect(count).toBeGreaterThan(0);
+
+      const sampleSize = Math.min(count, 3);
+      for (let i = 0; i < sampleSize; i++) {
+        const tile = tiles.nth(i);
+        await expect(tile).toBeVisible();
+        await expect(tile).toHaveAttribute("href", /.+/);
+
+        const box = await tile.boundingBox();
+        expect(box, `tile ${i} has no bounding box`).not.toBeNull();
+        expect(
+          box!.height,
+          `tile ${i} height (${box!.height}) is below the 40px tap-target minimum`
+        ).toBeGreaterThanOrEqual(40);
+      }
+    });
+
+    test("main content scrolls vertically only", async ({ page }) => {
+      await page.goto("/");
+      await expect(page.locator(".service-tile").first()).toBeVisible();
+
+      const r = await page.evaluate(() => {
+        const sm = document.querySelector(".shell-main");
+        if (!sm) return null;
+        return {
+          scrollWidth: sm.scrollWidth,
+          clientWidth: sm.clientWidth,
+          scrollHeight: sm.scrollHeight,
+          clientHeight: sm.clientHeight,
+        };
+      });
+
+      expect(r, ".shell-main not found on page").not.toBeNull();
+      // Vertical overflow/scrolling is expected and fine.
+      expect(r!.scrollHeight).toBeGreaterThanOrEqual(0);
+      // Horizontal overflow/scrolling is NOT fine -- this is the same
+      // primary check as assertNoHorizontalOverflow's (b), kept explicit
+      // here as documentation of intent for this specific scenario.
+      expect(
+        r!.scrollWidth,
+        `.shell-main scrollWidth (${r!.scrollWidth}) exceeds clientWidth (${r!.clientWidth}) -- horizontal scroll detected`
+      ).toBeLessThanOrEqual(r!.clientWidth + 1);
+    });
+  });
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -89,6 +89,17 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+/* Global backstop (defense-in-depth, RC1): belt-and-suspenders against any
+   future horizontal overflow source. The app has no `position: sticky`
+   descendants (navbar is a grid row; dialogs use the top layer; the
+   group-combobox dropdown is `position: absolute`), so this is low-risk.
+   The real guardrail is the per-element overflow sweep in
+   e2e/tests/mobile-layout.spec.ts, not this rule. */
+html,
+body {
+  overflow-x: hidden;
+}
+
 /* === FORM ELEMENT BASELINE ===
    Gives every raw <input>/<select>/<textarea>/<button> a themed look even
    before any component-specific class is applied, so forms never fall back
@@ -176,6 +187,14 @@ button {
 
 .shell-main {
   padding: var(--gap);
+  /* Backstop (RC1): without an explicit overflow-x, the CSS overflow spec
+     computes it to `auto` because overflow-y is non-visible, turning this
+     into a silent horizontal scroll container that hides real overflow from
+     document.documentElement.scrollWidth. Fix A removes the overflow source;
+     this just guards against any future regression by clipping instead of
+     scrolling sideways. It does not affect scrollWidth, so overflow is still
+     detectable by tests. */
+  overflow-x: hidden;
   overflow-y: auto;
 }
 
@@ -222,19 +241,19 @@ button {
 /* Outer grid: stacked full-width sections only (no fixed row height — avoids stretching group headers). */
 .dashboard-grid {
   display: grid;
-  grid-template-columns: repeat(var(--layout-columns-desktop, 4), 1fr);
+  grid-template-columns: repeat(var(--layout-columns-desktop, 4), minmax(0, 1fr));
   gap: var(--gap);
 }
 
 @media (max-width: 768px) {
   .dashboard-grid {
-    grid-template-columns: repeat(var(--layout-columns-tablet, var(--layout-columns-desktop, 2)), 1fr);
+    grid-template-columns: repeat(var(--layout-columns-tablet, var(--layout-columns-desktop, 2)), minmax(0, 1fr));
   }
 }
 
 @media (max-width: 480px) {
   .dashboard-grid {
-    grid-template-columns: repeat(var(--layout-columns-mobile, var(--layout-columns-desktop, 1)), 1fr);
+    grid-template-columns: repeat(var(--layout-columns-mobile, var(--layout-columns-desktop, 1)), minmax(0, 1fr));
   }
 }
 
@@ -242,22 +261,31 @@ button {
 .dashboard-tile-grid {
   display: grid;
   grid-column: 1 / -1;
-  grid-template-columns: repeat(var(--layout-columns-desktop, 4), 1fr);
+  grid-template-columns: repeat(var(--layout-columns-desktop, 4), minmax(0, 1fr));
   grid-auto-rows: var(--layout-row-height-desktop, 120px);
   gap: var(--gap);
 }
 
 @media (max-width: 768px) {
   .dashboard-tile-grid {
-    grid-template-columns: repeat(var(--layout-columns-tablet, var(--layout-columns-desktop, 2)), 1fr);
+    grid-template-columns: repeat(var(--layout-columns-tablet, var(--layout-columns-desktop, 2)), minmax(0, 1fr));
     grid-auto-rows: var(--layout-row-height-tablet, var(--layout-row-height-desktop, 120px));
   }
 }
 
 @media (max-width: 480px) {
   .dashboard-tile-grid {
-    grid-template-columns: repeat(var(--layout-columns-mobile, var(--layout-columns-desktop, 1)), 1fr);
+    grid-template-columns: repeat(var(--layout-columns-mobile, var(--layout-columns-desktop, 1)), minmax(0, 1fr));
     grid-auto-rows: var(--layout-row-height-mobile, var(--layout-row-height-desktop, 120px));
+  }
+
+  /* RC4 (defensive): neutralize desktop-absolute inline grid-column/grid-row
+     positions (ServiceTile.tsx `position` prop) so tiles flow normally on
+     phones instead of retaining desktop coordinates that don't make sense
+     in a 1-2 column layout. Inline styles require !important to override. */
+  .dashboard-tile-grid > .service-tile {
+    grid-column: auto !important;
+    grid-row: auto !important;
   }
 }
 
@@ -275,6 +303,7 @@ button {
   color: var(--color-text);
   transition: background 150ms ease, border-color 150ms ease;
   cursor: pointer;
+  min-width: 0; /* grid item: allow shrinking below content width (RC3) */
 }
 
 .service-tile:hover {
@@ -306,12 +335,16 @@ button {
 .service-tile__name {
   font-weight: 600;
   font-size: 0.95rem;
+  min-width: 0;
+  overflow-wrap: anywhere; /* long unbreakable tokens wrap instead of forcing width (RC3) */
 }
 
 .service-tile__description {
   font-size: 0.8rem;
   color: var(--color-text-muted);
   line-height: 1.3;
+  min-width: 0;
+  overflow-wrap: anywhere; /* long unbreakable tokens wrap instead of forcing width (RC3) */
 }
 
 .service-tile__widget {
@@ -437,6 +470,7 @@ button {
 /* === SETTINGS TABS === */
 .settings-tabs {
   display: flex;
+  flex-wrap: wrap; /* RC5: wrap onto a second row instead of overflowing on narrow phones */
   gap: 4px;
   border-bottom: 1px solid var(--color-border);
   padding-bottom: 0;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -282,10 +282,18 @@ button {
   /* RC4 (defensive): neutralize desktop-absolute inline grid-column/grid-row
      positions (ServiceTile.tsx `position` prop) so tiles flow normally on
      phones instead of retaining desktop coordinates that don't make sense
-     in a 1-2 column layout. Inline styles require !important to override. */
+     in a 1-2 column layout. Inline styles require !important to override.
+     - grid-column is fully reset (start position AND span): a configured
+       column span can exceed the mobile column count, which would create
+       an oversized implicit track and reintroduce horizontal overflow.
+     - grid-row only has its start position reset via the longhand below;
+       the row span (height) from the inline style is intentionally left
+       in place, since a taller row never causes horizontal overflow and
+       dropping it would needlessly shrink/clip widgets configured to need
+       extra vertical space. */
   .dashboard-tile-grid > .service-tile {
     grid-column: auto !important;
-    grid-row: auto !important;
+    grid-row-start: auto !important;
   }
 }
 


### PR DESCRIPTION
## Summary
- On narrow viewports (~375–430px) the dashboard scrolled left/right instead of staying constrained to the screen width. Root cause: grid tracks used bare `1fr` (`minmax(auto,1fr)`), so a track could never shrink below its content's min-content width, and tiles/text had no `min-width`/wrap fallback — a long service name or the default 4-column mobile grid would force the layout wider than the viewport. This was hidden from a naive `document.scrollWidth` check because `.shell-main`'s `overflow-y: auto` implicitly computed `overflow-x: auto` too, turning it into an invisible sideways scroller.
- Fixed in `src/app/globals.css`: `1fr` → `minmax(0, 1fr)` on dashboard grid tracks (base + tablet/mobile media queries), `min-width: 0` on tiles and tile text, `overflow-wrap: anywhere` for unbreakable strings, `overflow-x: hidden` backstops on `.shell-main` and `html`/`body`, `flex-wrap` on the settings tab bar, and a mobile override neutralizing desktop-absolute inline tile positions.
- Added `e2e/tests/mobile-layout.spec.ts`: 12 Playwright tests at 375×667 and 390×844 viewports covering the dashboard, settings, and auth pages — asserting no horizontal overflow (via `.shell-main` scrollWidth and a per-element bounding-box sweep, not just `document.scrollWidth`), settings-tab reachability, and tap-target sizing.

## Test plan
- [x] `npx playwright test e2e/tests/mobile-layout.spec.ts` — 12/12 passing (was 6/12 before the fix, proving the tests catch the real bug)
- [x] Full e2e suite — 28/28 passing (mobile-layout, plex-widget, visual regression), zero visual-snapshot diffs
- [x] Unit tests — 910/910 passing
- [x] `npm run type-check` — clean
- [x] `npm run lint` — clean (2 pre-existing warnings in unrelated files)


---
_Generated by [Claude Code](https://claude.ai/code/session_01GYrSWaGxHwe1NKq8NVuyMB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile layouts to prevent unwanted horizontal scrolling.
  * Improved dashboard tile responsiveness and prevented long text from overflowing.
  * Ensured settings tabs wrap correctly on smaller screens.
  * Improved mobile usability of authentication cards and dashboard tiles.

* **Tests**
  * Added mobile regression coverage for layout overflow, navigation, scrolling, and tile accessibility across multiple viewport sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->