### PR TITLE
Add icon library fallback matching for unreachable service URLs

### DIFF
--- a/src/__tests__/components/ServiceForm.test.tsx
+++ b/src/__tests__/components/ServiceForm.test.tsx
@@ -203,7 +203,33 @@ describe("ServiceForm – icon detection", () => {
       expect.objectContaining({ method: "POST" })
     );
     const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
-    expect(body).toEqual({ url: "http://jellyfin.local" });
+    expect(body).toEqual({ url: "http://jellyfin.local", name: "" });
+  });
+
+  it("sends the service name alongside the URL for name-based fallback matching", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ icon: null, source: null }),
+    } as Response);
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(
+      <ServiceForm service={null} existingGroups={[]} onSave={noop} onClose={noop} />
+    );
+    fireEvent.change(screen.getByLabelText("Name *"), {
+      target: { value: "Arcane" },
+    });
+    fireEvent.change(screen.getByLabelText("URL"), {
+      target: { value: "http://towarcloud.worm-marlin.ts.net:3552" },
+    });
+    fireEvent.click(screen.getByText("Detect icon"));
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalled());
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body).toEqual({
+      url: "http://towarcloud.worm-marlin.ts.net:3552",
+      name: "Arcane",
+    });
   });
 
   it("shows a hint when no icon is found", async () => {

--- a/src/__tests__/components/ServiceForm.test.tsx
+++ b/src/__tests__/components/ServiceForm.test.tsx
@@ -331,6 +331,43 @@ describe("ServiceForm – icon detection", () => {
       "http://manually-typed.example/icon.png"
     );
   });
+
+  it("ignores a stale detect response once the user has since edited the name", async () => {
+    let resolveFetch!: (value: Response) => void;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(
+        () => new Promise<Response>((resolve) => { resolveFetch = resolve; })
+      )
+    );
+
+    render(
+      <ServiceForm service={null} existingGroups={[]} onSave={noop} onClose={noop} />
+    );
+    fireEvent.change(screen.getByLabelText("Name *"), {
+      target: { value: "Arcane" },
+    });
+    fireEvent.change(screen.getByLabelText("URL"), {
+      target: { value: "http://towarcloud.worm-marlin.ts.net:3552" },
+    });
+
+    // Detect request starts (matching "Arcane") and is left pending.
+    fireEvent.click(screen.getByText("Detect icon"));
+
+    // The user edits the name before the request resolves — a response
+    // matched against the old name must not land.
+    fireEvent.change(screen.getByLabelText("Name *"), {
+      target: { value: "Something Else" },
+    });
+
+    resolveFetch({
+      ok: true,
+      json: () => Promise.resolve({ icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/arcane.svg", source: "dashboard-icons" }),
+    } as Response);
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(screen.getByLabelText("Icon URL")).toHaveValue("");
+  });
 });
 
 describe("ServiceForm – tile type", () => {

--- a/src/__tests__/lib/iconDetect.test.ts
+++ b/src/__tests__/lib/iconDetect.test.ts
@@ -20,6 +20,12 @@ vi.mock("undici", () => ({
   },
 }));
 
+const matchIconLibrariesMock = vi.fn();
+vi.mock("@/lib/iconLibraries", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/iconLibraries")>();
+  return { ...actual, matchIconLibraries: (...args: [string]) => matchIconLibrariesMock(...args) };
+});
+
 import { detectServiceIcon } from "@/lib/iconDetect";
 
 const PUBLIC_IP = "93.184.216.34"; // example.com's real public address
@@ -60,10 +66,15 @@ function resolvesTo(ip: string, family: 4 | 6 = 4) {
 beforeEach(() => {
   dnsLookupMock.mockReset();
   undiciFetchMock.mockReset();
+  matchIconLibrariesMock.mockReset();
   // Default: every hostname resolves to an ordinary public address, so
   // tests that don't care about DNS/blocking behavior don't need to set it
   // up themselves.
   dnsLookupMock.mockResolvedValue(resolvesTo(PUBLIC_IP));
+  // Default: no icon-library match, so tests that only care about the
+  // page/favicon tiers don't need to reason about library-matching too —
+  // that has its own dedicated test file (iconLibraries.test.ts).
+  matchIconLibrariesMock.mockResolvedValue(null);
 });
 
 afterEach(() => {
@@ -158,27 +169,93 @@ describe("detectServiceIcon", () => {
   it("does not accept a favicon.ico response with a non-image content-type", async () => {
     undiciFetchMock
       .mockResolvedValueOnce(htmlResponse("<html><head></head></html>"))
-      .mockResolvedValueOnce(plainResponse(200, { "content-type": "text/html" }))
-      .mockResolvedValueOnce(plainResponse(404));
+      .mockResolvedValueOnce(plainResponse(200, { "content-type": "text/html" }));
     const result = await detectServiceIcon("http://example.com");
     expect(result).toEqual({ icon: null, source: null });
-  });
-
-  it("falls back to a Simple Icons slug guess when nothing else matches", async () => {
-    undiciFetchMock
-      .mockResolvedValueOnce(htmlResponse("<html><head></head></html>"))
-      .mockResolvedValueOnce(plainResponse(404))
-      .mockResolvedValueOnce(plainResponse(200));
-    const result = await detectServiceIcon("http://app.plex.tv");
-    expect(result).toEqual({
-      icon: "https://cdn.simpleicons.org/plex",
-      source: "simple-icons",
-    });
   });
 
   it("returns null when every strategy fails", async () => {
     undiciFetchMock.mockRejectedValue(new Error("network down"));
     const result = await detectServiceIcon("http://example.com");
+    expect(result).toEqual({ icon: null, source: null });
+  });
+});
+
+describe("detectServiceIcon - name and hostname-guess fallback tiers", () => {
+  function nothingViaPageOrFavicon() {
+    undiciFetchMock
+      .mockResolvedValueOnce(htmlResponse("<html><head></head></html>"))
+      .mockResolvedValueOnce(plainResponse(404));
+  }
+
+  it("matches the given service name against the icon libraries when page/favicon fail", async () => {
+    nothingViaPageOrFavicon();
+    matchIconLibrariesMock.mockImplementation(async (candidate: string) =>
+      candidate === "Arcane"
+        ? { url: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/arcane.svg", source: "dashboard-icons" }
+        : null
+    );
+    const result = await detectServiceIcon("http://towarcloud.worm-marlin.ts.net:3552", "Arcane");
+    expect(result).toEqual({
+      icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/arcane.svg",
+      source: "dashboard-icons",
+    });
+    expect(matchIconLibrariesMock).toHaveBeenCalledWith("Arcane");
+  });
+
+  it("does not attempt a name match when no name is given", async () => {
+    nothingViaPageOrFavicon();
+    const result = await detectServiceIcon("http://example.com");
+    expect(result).toEqual({ icon: null, source: null });
+    // Only the hostname-guess call ("example"), never an empty/undefined name.
+    expect(matchIconLibrariesMock).toHaveBeenCalledTimes(1);
+    expect(matchIconLibrariesMock).toHaveBeenCalledWith("example");
+  });
+
+  it("does not attempt a name match when the name is blank", async () => {
+    nothingViaPageOrFavicon();
+    const result = await detectServiceIcon("http://example.com", "   ");
+    expect(result).toEqual({ icon: null, source: null });
+    expect(matchIconLibrariesMock).toHaveBeenCalledTimes(1);
+    expect(matchIconLibrariesMock).toHaveBeenCalledWith("example");
+  });
+
+  it("falls back to a hostname-derived guess when the name doesn't match anything", async () => {
+    nothingViaPageOrFavicon();
+    matchIconLibrariesMock.mockImplementation(async (candidate: string) =>
+      candidate === "sonarr"
+        ? { url: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/sonarr.svg", source: "dashboard-icons" }
+        : null
+    );
+    const result = await detectServiceIcon("http://sonarr.example.com", "My Media Downloader");
+    expect(result).toEqual({
+      icon: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/sonarr.svg",
+      source: "dashboard-icons",
+    });
+    expect(matchIconLibrariesMock).toHaveBeenNthCalledWith(1, "My Media Downloader");
+    expect(matchIconLibrariesMock).toHaveBeenNthCalledWith(2, "sonarr");
+  });
+
+  it("prefers a name match over a hostname-guess match when both would resolve", async () => {
+    nothingViaPageOrFavicon();
+    matchIconLibrariesMock.mockImplementation(async (candidate: string) => {
+      if (candidate === "Arcane") {
+        return { url: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/arcane.svg", source: "dashboard-icons" };
+      }
+      if (candidate === "towarcloud") {
+        return { url: "https://cdn.simpleicons.org/towarcloud", source: "simple-icons" };
+      }
+      return null;
+    });
+    const result = await detectServiceIcon("http://towarcloud.worm-marlin.ts.net:3552", "Arcane");
+    expect(result.source).toBe("dashboard-icons");
+    // The name match wins before the hostname-guess tier is ever tried.
+    expect(matchIconLibrariesMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns null when neither the name nor the hostname guess match", async () => {
+    nothingViaPageOrFavicon();
+    const result = await detectServiceIcon("http://towarcloud.worm-marlin.ts.net:3552", "Something Unmatched");
     expect(result).toEqual({ icon: null, source: null });
   });
 });

--- a/src/__tests__/lib/iconLibraries.test.ts
+++ b/src/__tests__/lib/iconLibraries.test.ts
@@ -33,6 +33,9 @@ const SAMPLE_DASHBOARD_ICONS = {
 const SAMPLE_SIMPLE_ICONS = [
   { title: "Docker", aliases: undefined },
   { title: ".ENV", aliases: { aka: ["Dotenv"] } },
+  // A real Simple Icons disambiguation case: the auto-slugified title would
+  // collide with something else, so the data declares an explicit slug.
+  { title: "Graphite", slug: "graphite_editor", aliases: undefined },
 ];
 
 function mockDashboardIconsFetch(data = SAMPLE_DASHBOARD_ICONS) {
@@ -216,5 +219,58 @@ describe("matchIconLibraries", () => {
     const { matchIconLibraries } = await freshModule();
     const result = await matchIconLibraries("Arcane");
     expect(result).toBeNull();
+  });
+
+  it("uses a Simple Icons entry's explicit slug instead of the title-derived one", async () => {
+    mockDashboardIconsFetch();
+    const { matchIconLibraries } = await freshModule();
+    const result = await matchIconLibraries("Graphite");
+    // Not "graphite" -- the naive title-derived slug -- since the data
+    // declares an explicit "graphite_editor" to disambiguate.
+    expect(result).toEqual({
+      url: "https://cdn.simpleicons.org/graphite_editor",
+      source: "simple-icons",
+    });
+  });
+
+  it("also matches a Simple Icons candidate on its explicit slug directly", async () => {
+    mockDashboardIconsFetch();
+    const { matchIconLibraries } = await freshModule();
+    const result = await matchIconLibraries("graphite_editor");
+    expect(result).toEqual({
+      url: "https://cdn.simpleicons.org/graphite_editor",
+      source: "simple-icons",
+    });
+  });
+
+  it("backs off after a failed index load instead of retrying immediately", async () => {
+    vi.useFakeTimers();
+    try {
+      ssrfSafeFetchMock.mockImplementation(async (url: string) => {
+        if (url === DASHBOARD_ICONS_URL) return plainResponse(500);
+        if (url === SIMPLE_ICONS_URL) return jsonResponse(SAMPLE_SIMPLE_ICONS);
+        return plainResponse(200);
+      });
+      const { matchIconLibraries } = await freshModule();
+
+      await matchIconLibraries("Arcane");
+      await matchIconLibraries("sonarr");
+      const dashboardCallsBeforeBackoff = ssrfSafeFetchMock.mock.calls.filter(
+        ([url]) => url === DASHBOARD_ICONS_URL
+      );
+      // One failed attempt, not one per candidate -- the second call should
+      // have backed off rather than retrying the CDN immediately.
+      expect(dashboardCallsBeforeBackoff).toHaveLength(1);
+
+      vi.setSystemTime(Date.now() + 61_000);
+      await matchIconLibraries("filebrowser");
+      const dashboardCallsAfterBackoff = ssrfSafeFetchMock.mock.calls.filter(
+        ([url]) => url === DASHBOARD_ICONS_URL
+      );
+      // Once the backoff window passes, a retry is attempted again.
+      expect(dashboardCallsAfterBackoff).toHaveLength(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/__tests__/lib/iconLibraries.test.ts
+++ b/src/__tests__/lib/iconLibraries.test.ts
@@ -1,0 +1,220 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const ssrfSafeFetchMock = vi.fn();
+vi.mock("@/lib/ssrfGuard", () => ({
+  ssrfSafeFetch: (...args: unknown[]) => ssrfSafeFetchMock(...args),
+}));
+
+function jsonResponse(data: unknown, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    body: undefined,
+    json: () => Promise.resolve(data),
+  };
+}
+
+function plainResponse(status: number) {
+  return { ok: status >= 200 && status < 300, status, body: undefined };
+}
+
+const DASHBOARD_ICONS_URL = "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/metadata.json";
+const SIMPLE_ICONS_URL =
+  "https://cdn.jsdelivr.net/gh/simple-icons/simple-icons@develop/data/simple-icons.json";
+
+const SAMPLE_DASHBOARD_ICONS = {
+  arcane: { base: "svg", aliases: [] },
+  filebrowser: { base: "svg", aliases: [] },
+  "nginx-proxy-manager": { base: "svg", aliases: ["Reverse Proxy UI"] },
+  sonarr: { base: "png", aliases: [] },
+};
+
+const SAMPLE_SIMPLE_ICONS = [
+  { title: "Docker", aliases: undefined },
+  { title: ".ENV", aliases: { aka: ["Dotenv"] } },
+];
+
+function mockDashboardIconsFetch(data = SAMPLE_DASHBOARD_ICONS) {
+  ssrfSafeFetchMock.mockImplementation(async (url: string) => {
+    if (url === DASHBOARD_ICONS_URL) return jsonResponse(data);
+    if (url === SIMPLE_ICONS_URL) return jsonResponse(SAMPLE_SIMPLE_ICONS);
+    return plainResponse(200);
+  });
+}
+
+// Each test gets its own fresh module instance -- the index cache lives at
+// module scope with a 24h TTL, so reusing one import across tests would let
+// an earlier test's successful fetch silently mask a later test's mocked
+// failure/response.
+async function freshModule() {
+  vi.resetModules();
+  return import("@/lib/iconLibraries");
+}
+
+beforeEach(() => {
+  ssrfSafeFetchMock.mockReset();
+});
+
+describe("guessNamesFromHostname", () => {
+  it("guesses the leftmost label first (reverse-proxy subdomain-per-app convention)", async () => {
+    const { guessNamesFromHostname } = await freshModule();
+    expect(guessNamesFromHostname("sonarr.example.com")).toEqual(["sonarr", "example"]);
+  });
+
+  it("also offers the pre-TLD label as a second guess (public SaaS brand domain convention)", async () => {
+    const { guessNamesFromHostname } = await freshModule();
+    expect(guessNamesFromHostname("app.plex.tv")).toEqual(["app", "plex"]);
+  });
+
+  it("excludes a leading www from the leftmost guess", async () => {
+    const { guessNamesFromHostname } = await freshModule();
+    expect(guessNamesFromHostname("www.example.com")).toEqual(["example"]);
+  });
+
+  it("dedupes when both conventions land on the same label", async () => {
+    const { guessNamesFromHostname } = await freshModule();
+    expect(guessNamesFromHostname("example.com")).toEqual(["example"]);
+  });
+
+  it("doesn't produce a name related to the app for a Tailscale-style hostname", async () => {
+    // This is the real motivating case: neither guess is "arcane" here,
+    // which is expected -- hostname-guessing can't solve this, that's what
+    // name-based matching is for. Just confirming it degrades sensibly
+    // rather than crashing or guessing something wild.
+    const { guessNamesFromHostname } = await freshModule();
+    expect(guessNamesFromHostname("towarcloud.worm-marlin.ts.net")).toEqual([
+      "towarcloud",
+      "ts",
+    ]);
+  });
+
+  it("returns no guesses for a single-label hostname", async () => {
+    const { guessNamesFromHostname } = await freshModule();
+    expect(guessNamesFromHostname("localhost")).toEqual([]);
+  });
+});
+
+describe("matchIconLibraries", () => {
+  it("returns null for an empty or whitespace-only candidate", async () => {
+    const { matchIconLibraries } = await freshModule();
+    expect(await matchIconLibraries("")).toBeNull();
+    expect(await matchIconLibraries("   ")).toBeNull();
+    expect(ssrfSafeFetchMock).not.toHaveBeenCalled();
+  });
+
+  it("matches a dashboard-icons canonical slug directly", async () => {
+    mockDashboardIconsFetch();
+    const { matchIconLibraries } = await freshModule();
+    const result = await matchIconLibraries("Arcane");
+    expect(result).toEqual({
+      url: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/arcane.svg",
+      source: "dashboard-icons",
+    });
+  });
+
+  it("matches regardless of spacing/hyphenation differences from the real slug", async () => {
+    mockDashboardIconsFetch();
+    const { matchIconLibraries } = await freshModule();
+    // The real dashboard-icons slug is "filebrowser" (no hyphen) -- a naive
+    // hyphenated guess from "File Browser" would miss it; normalized
+    // matching should not.
+    const result = await matchIconLibraries("File Browser");
+    expect(result).toEqual({
+      url: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/filebrowser.svg",
+      source: "dashboard-icons",
+    });
+  });
+
+  it("matches a dashboard-icons alias", async () => {
+    mockDashboardIconsFetch();
+    const { matchIconLibraries } = await freshModule();
+    const result = await matchIconLibraries("Reverse Proxy UI");
+    expect(result).toEqual({
+      url: "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/svg/nginx-proxy-manager.svg",
+      source: "dashboard-icons",
+    });
+  });
+
+  it("uses each entry's own declared format extension", async () => {
+    mockDashboardIconsFetch();
+    const { matchIconLibraries } = await freshModule();
+    const result = await matchIconLibraries("sonarr");
+    expect(result?.url).toBe(
+      "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/png/sonarr.png"
+    );
+  });
+
+  it("does not verify a dashboard-icons match with an extra network call", async () => {
+    mockDashboardIconsFetch();
+    const { matchIconLibraries } = await freshModule();
+    await matchIconLibraries("Arcane");
+    // Exactly one call: the metadata.json fetch. The published index is
+    // trusted directly, unlike the best-effort Simple Icons slug guess.
+    expect(ssrfSafeFetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to Simple Icons when dashboard-icons has no match", async () => {
+    mockDashboardIconsFetch();
+    const { matchIconLibraries } = await freshModule();
+    const result = await matchIconLibraries("Docker");
+    expect(result).toEqual({ url: "https://cdn.simpleicons.org/docker", source: "simple-icons" });
+  });
+
+  it("matches a Simple Icons alias (aka)", async () => {
+    mockDashboardIconsFetch();
+    const { matchIconLibraries } = await freshModule();
+    const result = await matchIconLibraries("Dotenv");
+    expect(result).toEqual({ url: "https://cdn.simpleicons.org/env", source: "simple-icons" });
+  });
+
+  it("verifies the Simple Icons candidate before returning it, and rejects it if it 404s", async () => {
+    ssrfSafeFetchMock.mockImplementation(async (url: string, opts: { method: string }) => {
+      if (url === DASHBOARD_ICONS_URL) return jsonResponse(SAMPLE_DASHBOARD_ICONS);
+      if (url === SIMPLE_ICONS_URL) return jsonResponse(SAMPLE_SIMPLE_ICONS);
+      if (opts.method === "HEAD") return plainResponse(404);
+      return plainResponse(200);
+    });
+    const { matchIconLibraries } = await freshModule();
+    const result = await matchIconLibraries("Docker");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when nothing matches in either library", async () => {
+    mockDashboardIconsFetch();
+    const { matchIconLibraries } = await freshModule();
+    const result = await matchIconLibraries("Something Totally Unknown");
+    expect(result).toBeNull();
+  });
+
+  it("caches the fetched indices across multiple calls", async () => {
+    mockDashboardIconsFetch();
+    const { matchIconLibraries } = await freshModule();
+    await matchIconLibraries("Arcane");
+    await matchIconLibraries("sonarr");
+    await matchIconLibraries("filebrowser");
+    // One fetch per index, ever, not once per call.
+    const dashboardCalls = ssrfSafeFetchMock.mock.calls.filter(
+      ([url]) => url === DASHBOARD_ICONS_URL
+    );
+    expect(dashboardCalls).toHaveLength(1);
+  });
+
+  it("degrades to Simple Icons (and eventually null) when the dashboard-icons fetch fails", async () => {
+    ssrfSafeFetchMock.mockImplementation(async (url: string) => {
+      if (url === DASHBOARD_ICONS_URL) return plainResponse(500);
+      if (url === SIMPLE_ICONS_URL) return jsonResponse(SAMPLE_SIMPLE_ICONS);
+      return plainResponse(200);
+    });
+    const { matchIconLibraries } = await freshModule();
+    const result = await matchIconLibraries("Docker");
+    expect(result).toEqual({ url: "https://cdn.simpleicons.org/docker", source: "simple-icons" });
+  });
+
+  it("returns null (not a throw) when both index fetches fail", async () => {
+    ssrfSafeFetchMock.mockRejectedValue(new Error("network down"));
+    const { matchIconLibraries } = await freshModule();
+    const result = await matchIconLibraries("Arcane");
+    expect(result).toBeNull();
+  });
+});

--- a/src/app/api/icon/detect/route.ts
+++ b/src/app/api/icon/detect/route.ts
@@ -34,7 +34,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
   }
 
-  const { url: raw } = (body ?? {}) as { url?: unknown };
+  const { url: raw, name } = (body ?? {}) as { url?: unknown; name?: unknown };
   if (typeof raw !== "string" || raw === "") {
     return NextResponse.json({ error: "Missing url" }, { status: 400 });
   }
@@ -48,6 +48,6 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Invalid url" }, { status: 400 });
   }
 
-  const result = await detectServiceIcon(raw);
+  const result = await detectServiceIcon(raw, typeof name === "string" ? name : undefined);
   return NextResponse.json(result);
 }

--- a/src/components/ServiceForm.tsx
+++ b/src/components/ServiceForm.tsx
@@ -525,6 +525,7 @@ export default function ServiceForm({
               onChange={(e) => {
                 setName(e.target.value);
                 setNameError(null);
+                iconDetectRequestId.current++;
               }}
               required
               placeholder="Jellyfin"

--- a/src/components/ServiceForm.tsx
+++ b/src/components/ServiceForm.tsx
@@ -394,7 +394,7 @@ export default function ServiceForm({
       const res = await fetch("/api/icon/detect", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ url: trimmedUrl }),
+        body: JSON.stringify({ url: trimmedUrl, name: name.trim() }),
       });
       if (iconDetectRequestId.current !== requestId) return;
       if (!res.ok) {

--- a/src/lib/iconDetect.ts
+++ b/src/lib/iconDetect.ts
@@ -1,10 +1,11 @@
 import { fetchWithHardTimeout } from "@/lib/fetchTimeout";
 import { ssrfSafeFetch } from "@/lib/ssrfGuard";
+import { guessNamesFromHostname, matchIconLibraries } from "@/lib/iconLibraries";
 
 const DETECT_TIMEOUT_MS = 5000;
 const MAX_HTML_BYTES = 100_000;
 
-export type IconSource = "page" | "favicon" | "simple-icons";
+export type IconSource = "page" | "favicon" | "dashboard-icons" | "simple-icons";
 
 export interface IconDetectionResult {
   icon: string | null;
@@ -183,35 +184,6 @@ async function detectFavicon(target: URL, allowPrivateNetworks: boolean): Promis
   }
 }
 
-function guessSimpleIconsSlug(hostname: string): string | null {
-  const parts = hostname.toLowerCase().split(".").filter(Boolean);
-  if (parts.length < 2) return null;
-  // Drop the TLD (and a leading "www"): app.plex.tv -> plex
-  const withoutTld = parts.slice(0, -1);
-  const withoutWww = withoutTld[0] === "www" ? withoutTld.slice(1) : withoutTld;
-  const slug = withoutWww[withoutWww.length - 1];
-  return slug && /^[a-z0-9-]+$/.test(slug) ? slug : null;
-}
-
-async function detectSimpleIcons(target: URL): Promise<string | null> {
-  const slug = guessSimpleIconsSlug(target.hostname);
-  if (!slug) return null;
-  const iconUrl = `https://cdn.simpleicons.org/${slug}`;
-  try {
-    const response = await fetchWithHardTimeout(
-      // Simple Icons is a fixed, well-known public CDN, not a caller-
-      // supplied host — still routed through the guard for consistency and
-      // redirect safety, but never needs private-network access.
-      (signal) => ssrfSafeFetch(iconUrl, { method: "HEAD", signal, allowPrivateNetworks: false }),
-      "Simple Icons fetch timed out",
-      DETECT_TIMEOUT_MS
-    );
-    return response.status === 200 ? iconUrl : null;
-  } catch {
-    return null;
-  }
-}
-
 /**
  * Off by default: kokpit's core use case is detecting icons for LAN-only
  * self-hosted services, but shipping that reachable by default means any
@@ -224,7 +196,25 @@ function allowPrivateNetworksEnabled(): boolean {
   return process.env.KOKPIT_ICON_DETECT_ALLOW_PRIVATE_NETWORKS === "true";
 }
 
-export async function detectServiceIcon(rawUrl: string): Promise<IconDetectionResult> {
+/**
+ * Detection order, from most to least reliable:
+ *  1. The page's own declared <link rel="icon"> — the actual configured
+ *     favicon, when the URL is reachable at all.
+ *  2. /favicon.ico, same reachability requirement.
+ *  3. The service's given name matched against dashboard-icons (curated
+ *     for self-hosted homelab apps) then Simple Icons (general brands) —
+ *     doesn't require the target URL to be reachable at all, which matters
+ *     for services fronted by a VPN/tailnet the dashboard server itself
+ *     isn't on.
+ *  4. A hostname-derived guess (e.g. sonarr.example.com -> "sonarr")
+ *     matched the same way — a common reverse-proxy subdomain-per-app
+ *     convention, but kept as a last resort since a tile's name and its
+ *     hostname aren't guaranteed to be related.
+ */
+export async function detectServiceIcon(
+  rawUrl: string,
+  name?: string
+): Promise<IconDetectionResult> {
   let target: URL;
   try {
     target = new URL(rawUrl);
@@ -247,8 +237,15 @@ export async function detectServiceIcon(rawUrl: string): Promise<IconDetectionRe
   const favicon = await detectFavicon(target, allowPrivateNetworks);
   if (favicon) return { icon: favicon, source: "favicon" };
 
-  const simpleIcon = await detectSimpleIcons(target);
-  if (simpleIcon) return { icon: simpleIcon, source: "simple-icons" };
+  if (name && name.trim() !== "") {
+    const byName = await matchIconLibraries(name).catch(() => null);
+    if (byName) return { icon: byName.url, source: byName.source };
+  }
+
+  for (const guess of guessNamesFromHostname(target.hostname)) {
+    const byHostname = await matchIconLibraries(guess).catch(() => null);
+    if (byHostname) return { icon: byHostname.url, source: byHostname.source };
+  }
 
   return { icon: null, source: null };
 }

--- a/src/lib/iconLibraries.ts
+++ b/src/lib/iconLibraries.ts
@@ -32,34 +32,60 @@ function normalizeName(name: string): string {
 }
 
 async function fetchJson(url: string): Promise<unknown> {
-  const response = await fetchWithHardTimeout(
-    (signal) => ssrfSafeFetch(url, { method: "GET", signal, allowPrivateNetworks: false }),
+  // Body parsing happens inside the same hard-timeout callback as the fetch
+  // itself, same reasoning as detectFromPage in iconDetect.ts: fetch()
+  // resolving only means headers arrived, and a server that stalls the body
+  // stream afterward would otherwise hang past the timeout budget once the
+  // race has already resolved.
+  return fetchWithHardTimeout(
+    async (signal) => {
+      const response = await ssrfSafeFetch(url, {
+        method: "GET",
+        signal,
+        allowPrivateNetworks: false,
+      });
+      if (!response.ok) {
+        if (response.body && !response.bodyUsed) {
+          await response.body.cancel().catch(() => {});
+        }
+        throw new Error(`Icon index fetch failed: ${response.status}`);
+      }
+      return response.json();
+    },
     "Icon index fetch timed out",
     FETCH_TIMEOUT_MS
   );
-  if (!response.ok) {
-    if (response.body && !response.bodyUsed) {
-      await response.body.cancel().catch(() => {});
-    }
-    throw new Error(`Icon index fetch failed: ${response.status}`);
-  }
-  return response.json();
 }
+
+// A failed load is remembered for a short backoff window rather than retried
+// immediately: a single detection attempt can call load() up to three times
+// in a row (name guess + two hostname guesses), and without this an outage
+// would pay the full fetch timeout on every one of those instead of once.
+const FAILURE_BACKOFF_MS = 60_000;
 
 function makeCache(loader: () => Promise<LibraryIndex>) {
   let cached: { index: LibraryIndex; fetchedAt: number } | null = null;
   let inflight: Promise<LibraryIndex> | null = null;
+  let failedAt: number | null = null;
 
   return async function load(): Promise<LibraryIndex> {
     if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
       return cached.index;
     }
     if (inflight) return inflight;
+    if (failedAt !== null && Date.now() - failedAt < FAILURE_BACKOFF_MS) {
+      throw new Error("Icon index load recently failed, backing off");
+    }
 
     inflight = loader()
       .then((index) => {
         cached = { index, fetchedAt: Date.now() };
+        failedAt = null;
         return index;
+      })
+      .catch((err) => {
+        failedAt = Date.now();
+        throw err;
       })
       .finally(() => {
         inflight = null;
@@ -98,6 +124,7 @@ const loadDashboardIcons = makeCache(async () => {
 
 interface SimpleIconEntry {
   title: string;
+  slug?: string;
   aliases?: { aka?: string[] };
 }
 
@@ -105,15 +132,22 @@ const loadSimpleIcons = makeCache(async () => {
   const data = (await fetchJson(SIMPLE_ICONS_DATA_URL)) as SimpleIconEntry[];
   const byNormalizedName = new Map<string, LibraryEntry>();
   for (const item of data) {
-    // The CDN slug is derived from the title via Simple Icons' own
-    // slugification, which we don't replicate exactly (it has special
-    // handling for a handful of characters) — this is a best-effort
-    // candidate, verified with a HEAD request before ever being returned.
-    const slug = normalizeName(item.title);
+    // A handful of entries declare an explicit `slug` that overrides the
+    // title-derived one, used when the auto-slugified title would collide
+    // with another icon (e.g. "Graphite" -> "graphite_editor", not
+    // "graphite"). Falling back to the normalized title otherwise is still
+    // only a best-effort match of Simple Icons' own slugification — verified
+    // with a HEAD request before ever being returned.
+    const slug = item.slug || normalizeName(item.title);
     if (!slug) continue;
     const entry: LibraryEntry = { slug, base: "svg" };
     const titleKey = normalizeName(item.title);
     if (titleKey && !byNormalizedName.has(titleKey)) byNormalizedName.set(titleKey, entry);
+    // Also index the slug itself: a divergent explicit slug (e.g.
+    // "graphite_editor") is itself a reasonable thing for a hostname guess
+    // or a user-typed name to match against, separately from the title.
+    const slugKey = normalizeName(slug);
+    if (slugKey && !byNormalizedName.has(slugKey)) byNormalizedName.set(slugKey, entry);
     for (const alias of item.aliases?.aka ?? []) {
       const key = normalizeName(alias);
       if (key && !byNormalizedName.has(key)) byNormalizedName.set(key, entry);

--- a/src/lib/iconLibraries.ts
+++ b/src/lib/iconLibraries.ts
@@ -1,0 +1,201 @@
+import { fetchWithHardTimeout } from "@/lib/fetchTimeout";
+import { ssrfSafeFetch } from "@/lib/ssrfGuard";
+
+const FETCH_TIMEOUT_MS = 5000;
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000;
+
+const DASHBOARD_ICONS_METADATA_URL =
+  "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/metadata.json";
+const SIMPLE_ICONS_DATA_URL =
+  "https://cdn.jsdelivr.net/gh/simple-icons/simple-icons@develop/data/simple-icons.json";
+
+export type IconLibrarySource = "dashboard-icons" | "simple-icons";
+
+interface LibraryEntry {
+  slug: string;
+  /** File extension to request, e.g. "svg" or "png". Only meaningful for dashboard-icons. */
+  base: string;
+}
+
+interface LibraryIndex {
+  byNormalizedName: Map<string, LibraryEntry>;
+}
+
+// Matching key: strip everything but letters/digits and lowercase, so
+// "Nginx Proxy Manager", "nginx-proxy-manager", and "NginxProxyManager" all
+// collapse to the same key. Homelab dashboard-icons entries aren't
+// consistently hyphenated (e.g. the real slug is "filebrowser", not
+// "file-browser"), so matching on the raw slug string would silently miss
+// real entries — comparing fully-stripped forms sidesteps that.
+function normalizeName(name: string): string {
+  return name.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+async function fetchJson(url: string): Promise<unknown> {
+  const response = await fetchWithHardTimeout(
+    (signal) => ssrfSafeFetch(url, { method: "GET", signal, allowPrivateNetworks: false }),
+    "Icon index fetch timed out",
+    FETCH_TIMEOUT_MS
+  );
+  if (!response.ok) {
+    if (response.body && !response.bodyUsed) {
+      await response.body.cancel().catch(() => {});
+    }
+    throw new Error(`Icon index fetch failed: ${response.status}`);
+  }
+  return response.json();
+}
+
+function makeCache(loader: () => Promise<LibraryIndex>) {
+  let cached: { index: LibraryIndex; fetchedAt: number } | null = null;
+  let inflight: Promise<LibraryIndex> | null = null;
+
+  return async function load(): Promise<LibraryIndex> {
+    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) {
+      return cached.index;
+    }
+    if (inflight) return inflight;
+
+    inflight = loader()
+      .then((index) => {
+        cached = { index, fetchedAt: Date.now() };
+        return index;
+      })
+      .finally(() => {
+        inflight = null;
+      });
+    return inflight;
+  };
+}
+
+interface DashboardIconMetaEntry {
+  base?: string;
+  aliases?: string[];
+}
+
+const loadDashboardIcons = makeCache(async () => {
+  const data = (await fetchJson(DASHBOARD_ICONS_METADATA_URL)) as Record<
+    string,
+    DashboardIconMetaEntry
+  >;
+  const byNormalizedName = new Map<string, LibraryEntry>();
+  // Canonical slugs first, so an alias can never shadow another icon's
+  // direct name match.
+  for (const [slug, meta] of Object.entries(data)) {
+    const key = normalizeName(slug);
+    if (key) byNormalizedName.set(key, { slug, base: meta.base || "svg" });
+  }
+  for (const [slug, meta] of Object.entries(data)) {
+    for (const alias of meta.aliases ?? []) {
+      const key = normalizeName(alias);
+      if (key && !byNormalizedName.has(key)) {
+        byNormalizedName.set(key, { slug, base: meta.base || "svg" });
+      }
+    }
+  }
+  return { byNormalizedName };
+});
+
+interface SimpleIconEntry {
+  title: string;
+  aliases?: { aka?: string[] };
+}
+
+const loadSimpleIcons = makeCache(async () => {
+  const data = (await fetchJson(SIMPLE_ICONS_DATA_URL)) as SimpleIconEntry[];
+  const byNormalizedName = new Map<string, LibraryEntry>();
+  for (const item of data) {
+    // The CDN slug is derived from the title via Simple Icons' own
+    // slugification, which we don't replicate exactly (it has special
+    // handling for a handful of characters) — this is a best-effort
+    // candidate, verified with a HEAD request before ever being returned.
+    const slug = normalizeName(item.title);
+    if (!slug) continue;
+    const entry: LibraryEntry = { slug, base: "svg" };
+    const titleKey = normalizeName(item.title);
+    if (titleKey && !byNormalizedName.has(titleKey)) byNormalizedName.set(titleKey, entry);
+    for (const alias of item.aliases?.aka ?? []) {
+      const key = normalizeName(alias);
+      if (key && !byNormalizedName.has(key)) byNormalizedName.set(key, entry);
+    }
+  }
+  return { byNormalizedName };
+});
+
+async function verifyIconUrl(url: string): Promise<boolean> {
+  try {
+    const response = await fetchWithHardTimeout(
+      (signal) => ssrfSafeFetch(url, { method: "HEAD", signal, allowPrivateNetworks: false }),
+      "Icon verification timed out",
+      FETCH_TIMEOUT_MS
+    );
+    if (response.body && !response.bodyUsed) {
+      await response.body.cancel().catch(() => {});
+    }
+    return response.status === 200;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Matches a candidate name (a service's display name, or a hostname-derived
+ * guess) against dashboard-icons first, then Simple Icons. dashboard-icons
+ * is checked first because it's curated specifically for self-hosted
+ * homelab apps — the audience this feature is for — while Simple Icons is
+ * general tech/company brands.
+ */
+export async function matchIconLibraries(
+  candidateName: string
+): Promise<{ url: string; source: IconLibrarySource } | null> {
+  const key = normalizeName(candidateName);
+  if (!key) return null;
+
+  const dashboardIndex = await loadDashboardIcons().catch(() => null);
+  const dashboardEntry = dashboardIndex?.byNormalizedName.get(key);
+  if (dashboardEntry) {
+    const url = `https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons/${dashboardEntry.base}/${dashboardEntry.slug}.${dashboardEntry.base}`;
+    return { url, source: "dashboard-icons" };
+  }
+
+  const simpleIndex = await loadSimpleIcons().catch(() => null);
+  const simpleEntry = simpleIndex?.byNormalizedName.get(key);
+  if (simpleEntry) {
+    const url = `https://cdn.simpleicons.org/${simpleEntry.slug}`;
+    if (await verifyIconUrl(url)) return { url, source: "simple-icons" };
+  }
+
+  return null;
+}
+
+/**
+ * Derives rough "app name" guesses from a hostname for the last-resort
+ * fallback tier, trying two different conventions since they disagree on
+ * which label is the interesting one:
+ *  - Reverse-proxy subdomain-per-app (the dominant pattern for self-hosted
+ *    homelab setups): sonarr.example.com -> "sonarr" (the leftmost label).
+ *  - Public SaaS brand domain: app.plex.tv -> "plex" (the label just
+ *    before the TLD, skipping a leading "www"/subdomain prefix) — this
+ *    would otherwise guess "app" instead of "plex".
+ * Ordered leftmost-label first, since that's the more common shape for
+ * kokpit's actual audience. Deliberately weak either way — only used
+ * after every other, more reliable signal (page/favicon fetch, and
+ * matching on the service's actual given name) has failed.
+ */
+export function guessNamesFromHostname(hostname: string): string[] {
+  const parts = hostname.toLowerCase().split(".").filter(Boolean);
+  if (parts.length < 2) return [];
+
+  const guesses: string[] = [];
+  const isValid = (s: string | undefined): s is string => !!s && /^[a-z0-9-]+$/.test(s);
+
+  const leftmost = parts[0];
+  if (leftmost !== "www" && isValid(leftmost)) guesses.push(leftmost);
+
+  const withoutTld = parts.slice(0, -1);
+  const withoutWww = withoutTld[0] === "www" ? withoutTld.slice(1) : withoutTld;
+  const brandGuess = withoutWww[withoutWww.length - 1];
+  if (isValid(brandGuess) && brandGuess !== leftmost) guesses.push(brandGuess);
+
+  return guesses;
+}


### PR DESCRIPTION
Services fronted by a VPN/tailnet (e.g. Tailscale MagicDNS hostnames)
are unreachable from the dashboard server, so page/favicon.ico
detection always fails for them even though they're common self-hosted
apps with well-known icons.

After the existing page and favicon.ico strategies fail, try matching
the service's given name against dashboard-icons (curated for
self-hosted homelab apps, checked first) and then Simple Icons
(general brands) - this works without ever reaching the target URL.
As a last resort, also try names guessed from the hostname, covering
both the reverse-proxy subdomain-per-app convention and the public
SaaS brand-domain convention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved service icon detection by using the service name alongside the URL and derived hostname guesses.
  * Expanded icon matching to support both dashboard-icons and Simple Icons, including aliases and naming variations.
* **Bug Fixes**
  * Improved handling of non-image favicons and invalid/unavailable icon sources, with safer results when no match exists.
  * Prevented stale icon-detect updates when the user edits the service name while a request is in progress.
* **Tests**
  * Updated and expanded icon detection and library-matching test coverage for the new request and fallback behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->