### PR TITLE
chore: bump version to 0.4.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kokpit",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kokpit",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "dependencies": {
         "@testing-library/dom": "^10.4.1",
         "bcryptjs": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kokpit",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "private": true,
   "engines": {
     "node": ">=22.19.0"


### PR DESCRIPTION
Version bump for the 0.4.0 release (icon library fallback matching from #60).

---
_Generated by [Claude Code](https://claude.ai/code/session_01ExjmqSGjwmU4HtHytYUafL)_