### PR TITLE
feat: warn on tiles whose widget config fails validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ services:
 
 Credentials in `widget.config` are read server-side only and are never sent to the browser.
 
+**Troubleshooting widget configuration:** If a widget's config fails validation (e.g., a missing required field like `token` or a malformed URL), the tile displays a small warning badge in its corner. Hover or click the badge to see the specific validation errors. Users with edit permission can click the badge to open the service editor with the widget section focused, then fix the configuration and save.
+
 ---
 
 ### Plex

--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ services:
 
 Credentials in `widget.config` are read server-side only and are never sent to the browser.
 
-**Troubleshooting widget configuration:** If a widget's config fails validation (e.g., a missing required field like `token` or a malformed URL), the tile displays a small warning badge in its corner. Hover or click the badge to see the specific validation errors. Users with edit permission can click the badge to open the service editor with the widget section focused, then fix the configuration and save.
+**Troubleshooting widget configuration:** If a widget's config fails validation (e.g., a missing required field like `token` or a malformed URL), the tile displays a small warning badge in its corner. Hover the badge to see the specific validation errors in a tooltip. Users with edit permission can click the badge to open the service editor with the widget section focused, then fix the configuration and save.
 
 ---
 

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -143,7 +143,7 @@ Mark tasks with `[x]` as you complete them. Claude Code will read this state.
   - Welcome card with "Add your first service" when the dashboard is empty (today: blank page)
   - Ghost "+" tile in empty groups while editing; first-edit coach marks
 
-- [ ] `P2` **Broken-widget feedback** *(part of UX redesign Phase C)*
+- [x] `P2` **Broken-widget feedback** *(part of UX redesign Phase C)*
   - Warning badge on tiles whose widget config fails validation, instead of today's silent downgrade to a plain link
   - Badge links to the edit dialog with the validation error shown
 

--- a/e2e/tests/widget-badge.spec.ts
+++ b/e2e/tests/widget-badge.spec.ts
@@ -42,6 +42,12 @@ function sonarrTile(page: Page) {
     .filter({ has: page.locator('.service-tile__name:text-is("Sonarr")') });
 }
 
+function prowlarrTile(page: Page) {
+  return page
+    .locator(".service-tile")
+    .filter({ has: page.locator('.service-tile__name:text-is("Prowlarr")') });
+}
+
 test.describe("broken-widget feedback", () => {
   test.beforeAll(async ({ request }) => {
     // Warm up dev-mode route compilation before the first real test.
@@ -79,10 +85,7 @@ test.describe("broken-widget feedback", () => {
     // Sonarr's config is broken, so it gets the badge and no dot, while
     // Prowlarr's config is valid, so it keeps its dot and gets no badge.
     await expect(tile.locator(".status-dot")).toHaveCount(0);
-    const prowlarrDotTile = page
-      .locator(".service-tile")
-      .filter({ has: page.locator('.service-tile__name:text-is("Prowlarr")') });
-    await expect(prowlarrDotTile.locator(".status-dot")).toBeVisible();
+    await expect(prowlarrTile(page).locator(".status-dot")).toBeVisible();
 
     // A widget-less sibling keeps rendering as a plain link.
     const grafanaTile = page
@@ -94,11 +97,8 @@ test.describe("broken-widget feedback", () => {
     // whose config is VALID gets no badge, even though its data fetch fails
     // against a port with nothing behind it. A broken connection and a broken
     // config are different problems and must look different.
-    const prowlarrTile = page
-      .locator(".service-tile")
-      .filter({ has: page.locator('.service-tile__name:text-is("Prowlarr")') });
-    await expect(prowlarrTile.locator(".service-tile__widget")).toHaveCount(1);
-    await expect(prowlarrTile.locator(".tile-widget-badge")).toHaveCount(0);
+    await expect(prowlarrTile(page).locator(".service-tile__widget")).toHaveCount(1);
+    await expect(prowlarrTile(page).locator(".tile-widget-badge")).toHaveCount(0);
   });
 
   test("clicking the badge opens the service's edit dialog", async ({ page }) => {
@@ -115,5 +115,16 @@ test.describe("broken-widget feedback", () => {
     await expect(dialog).toBeVisible();
     await expect(dialog.getByText("Edit Service")).toBeVisible();
     await expect(dialog.getByLabel("Name *")).toHaveValue("Sonarr");
+
+    // focusWidget behavior: the dialog scrolls to the Widget section and
+    // focuses the first invalid config field — here, sonarr-queue's missing
+    // `api_key` — with its validation error visible, instead of leaving the
+    // user to hunt for what needs fixing.
+    await expect(dialog.getByText("Widget", { exact: true })).toBeInViewport();
+    const apiKeyInput = dialog.getByLabel("API Key *");
+    await expect(apiKeyInput).toBeFocused();
+    await expect(
+      dialog.getByRole("alert").filter({ hasText: "api_key" })
+    ).toBeVisible();
   });
 });

--- a/e2e/tests/widget-badge.spec.ts
+++ b/e2e/tests/widget-badge.spec.ts
@@ -75,6 +75,15 @@ test.describe("broken-widget feedback", () => {
     await expect(tile.locator(".service-tile__widget")).toHaveCount(0);
     await expect(tile.locator(".widget-error")).toHaveCount(0);
 
+    // The badge and the status dot share one slot and are mutually exclusive:
+    // Sonarr's config is broken, so it gets the badge and no dot, while
+    // Prowlarr's config is valid, so it keeps its dot and gets no badge.
+    await expect(tile.locator(".status-dot")).toHaveCount(0);
+    const prowlarrDotTile = page
+      .locator(".service-tile")
+      .filter({ has: page.locator('.service-tile__name:text-is("Prowlarr")') });
+    await expect(prowlarrDotTile.locator(".status-dot")).toBeVisible();
+
     // A widget-less sibling keeps rendering as a plain link.
     const grafanaTile = page
       .locator(".service-tile")

--- a/e2e/tests/widget-badge.spec.ts
+++ b/e2e/tests/widget-badge.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect, type Page } from "@playwright/test";
+
+/**
+ * Broken-widget feedback: when a service's `widget.config` fails that
+ * widget's Zod schema, the tile no longer silently degrades to a plain link —
+ * it shows a warning badge instead of the widget area. With
+ * KOKPIT_AUTH_DISABLED (this test server's config) the protected layout
+ * grants `canEdit: true` even in view mode, so the badge is interactive there
+ * too: clicking it opens the service's edit dialog, entering edit mode along
+ * the way (see EditModeProvider's requestServiceEdit/pendingEditService).
+ *
+ * Mutates shared state via PATCH /api/settings like the other spec files —
+ * playwright.config.ts pins workers: 1 so these writes never race.
+ */
+
+const SERVICES = [
+  {
+    name: "Sonarr",
+    url: "http://localhost:8001",
+    // sonarr-queue's schema requires both `url` and `api_key`; `api_key` is
+    // missing here, so the config fails validation.
+    widget: { type: "sonarr-queue", config: { url: "http://localhost:8001" } },
+  },
+  { name: "Grafana", url: "http://localhost:3001" },
+];
+
+function sonarrTile(page: Page) {
+  return page
+    .locator(".service-tile")
+    .filter({ has: page.locator('.service-tile__name:text-is("Sonarr")') });
+}
+
+test.describe("broken-widget feedback", () => {
+  test.beforeAll(async ({ request }) => {
+    // Warm up dev-mode route compilation before the first real test.
+    await request.get("/").catch(() => null);
+  });
+
+  test.beforeEach(async ({ request }) => {
+    const res = await request.patch("/api/settings", {
+      data: { services: SERVICES, groups: [], bookmarks: [] },
+    });
+    expect(res.ok(), `Settings patch failed: ${res.status()}`).toBeTruthy();
+  });
+
+  test("shows a warning badge instead of the widget when its config is invalid", async ({
+    page,
+  }) => {
+    await page.goto("/");
+    const tile = sonarrTile(page);
+    await expect(tile).toBeVisible();
+
+    const badge = tile.locator(".tile-widget-badge");
+    await expect(badge).toBeVisible();
+    await expect(badge).toHaveAttribute("data-widget-config-invalid", "true");
+    await expect(badge).toHaveAttribute(
+      "aria-label",
+      "Widget configuration error: Sonarr"
+    );
+
+    // No silent link-degrade, and this is deliberately NOT the unrelated
+    // "unknown widget type" error box (that's a different failure mode).
+    await expect(tile.locator(".service-tile__widget")).toHaveCount(0);
+    await expect(tile.locator(".widget-error")).toHaveCount(0);
+
+    // A valid, unaffected sibling tile keeps rendering as a plain link.
+    const grafanaTile = page
+      .locator(".service-tile")
+      .filter({ has: page.locator('.service-tile__name:text-is("Grafana")') });
+    await expect(grafanaTile.locator(".tile-widget-badge")).toHaveCount(0);
+  });
+
+  test("clicking the badge opens the service's edit dialog", async ({ page }) => {
+    await page.goto("/");
+    const badge = sonarrTile(page).locator(".tile-widget-badge");
+    await expect(badge).toBeVisible();
+
+    await badge.click();
+
+    // requestServiceEdit entered edit mode to mount the dialog.
+    await expect(page.locator(".edit-bar")).toBeVisible();
+
+    const dialog = page.locator("dialog.service-form-dialog");
+    await expect(dialog).toBeVisible();
+    await expect(dialog.getByText("Edit Service")).toBeVisible();
+    await expect(dialog.getByLabel("Name *")).toHaveValue("Sonarr");
+  });
+});

--- a/e2e/tests/widget-badge.spec.ts
+++ b/e2e/tests/widget-badge.spec.ts
@@ -21,6 +21,18 @@ const SERVICES = [
     // missing here, so the config fails validation.
     widget: { type: "sonarr-queue", config: { url: "http://localhost:8001" } },
   },
+  {
+    name: "Prowlarr",
+    url: "http://localhost:8002",
+    // The control that matters: a widget whose config PASSES its schema. Its
+    // data fetch will fail (nothing is listening on that port), which is the
+    // point — a runtime fetch failure is a different condition from a config
+    // failure and must not raise the badge.
+    widget: {
+      type: "prowlarr-stats",
+      config: { url: "http://localhost:8002", api_key: "test-key" },
+    },
+  },
   { name: "Grafana", url: "http://localhost:3001" },
 ];
 
@@ -63,11 +75,21 @@ test.describe("broken-widget feedback", () => {
     await expect(tile.locator(".service-tile__widget")).toHaveCount(0);
     await expect(tile.locator(".widget-error")).toHaveCount(0);
 
-    // A valid, unaffected sibling tile keeps rendering as a plain link.
+    // A widget-less sibling keeps rendering as a plain link.
     const grafanaTile = page
       .locator(".service-tile")
       .filter({ has: page.locator('.service-tile__name:text-is("Grafana")') });
     await expect(grafanaTile.locator(".tile-widget-badge")).toHaveCount(0);
+
+    // The control that actually guards against false positives: a widget
+    // whose config is VALID gets no badge, even though its data fetch fails
+    // against a port with nothing behind it. A broken connection and a broken
+    // config are different problems and must look different.
+    const prowlarrTile = page
+      .locator(".service-tile")
+      .filter({ has: page.locator('.service-tile__name:text-is("Prowlarr")') });
+    await expect(prowlarrTile.locator(".service-tile__widget")).toHaveCount(1);
+    await expect(prowlarrTile.locator(".tile-widget-badge")).toHaveCount(0);
   });
 
   test("clicking the badge opens the service's edit dialog", async ({ page }) => {

--- a/src/__tests__/components/EditModeProvider.test.tsx
+++ b/src/__tests__/components/EditModeProvider.test.tsx
@@ -30,6 +30,7 @@ const active: EditModeState = {
   status: "idle",
   error: null,
   conflict: false,
+  pendingEditService: null,
 };
 
 describe("editModeReducer", () => {
@@ -96,6 +97,69 @@ describe("editModeReducer", () => {
     expect(next.draft).not.toBeNull();
     // Stale revision is kept so any re-save re-conflicts instead of overwriting.
     expect(next.baseRevision).toBe("rev-1");
+  });
+
+  it("REQUEST_SERVICE_EDIT sets pendingEditService", () => {
+    const next = editModeReducer(initialEditModeState, {
+      type: "REQUEST_SERVICE_EDIT",
+      name: "Plex",
+    });
+    expect(next.pendingEditService).toBe("Plex");
+  });
+
+  it("CLEAR_PENDING_EDIT clears pendingEditService", () => {
+    const pending: EditModeState = { ...active, pendingEditService: "Plex" };
+    const next = editModeReducer(pending, { type: "CLEAR_PENDING_EDIT" });
+    expect(next.pendingEditService).toBeNull();
+  });
+
+  it("CLEAR_PENDING_EDIT is a no-op (same reference) when already null", () => {
+    expect(editModeReducer(active, { type: "CLEAR_PENDING_EDIT" })).toBe(active);
+  });
+
+  it("pendingEditService survives ENTER_START (regression: fresh state objects)", () => {
+    const pending: EditModeState = {
+      ...initialEditModeState,
+      pendingEditService: "Plex",
+    };
+    const next = editModeReducer(pending, { type: "ENTER_START" });
+    expect(next.pendingEditService).toBe("Plex");
+  });
+
+  it("pendingEditService survives ENTER_SUCCESS (regression: fresh state objects)", () => {
+    const pending: EditModeState = {
+      ...initialEditModeState,
+      pendingEditService: "Plex",
+      status: "loading",
+    };
+    const config = cfg();
+    const next = editModeReducer(pending, {
+      type: "ENTER_SUCCESS",
+      config,
+      revision: "rev-1",
+    });
+    expect(next.pendingEditService).toBe("Plex");
+    expect(next.active).toBe(true);
+  });
+
+  it("pendingEditService is dropped by DISCARD", () => {
+    const pending: EditModeState = { ...active, pendingEditService: "Plex" };
+    expect(
+      editModeReducer(pending, { type: "DISCARD" }).pendingEditService
+    ).toBeNull();
+  });
+
+  it("pendingEditService is dropped by ENTER_ERROR", () => {
+    const pending: EditModeState = {
+      ...initialEditModeState,
+      pendingEditService: "Plex",
+      status: "loading",
+    };
+    const next = editModeReducer(pending, {
+      type: "ENTER_ERROR",
+      error: "boom",
+    });
+    expect(next.pendingEditService).toBeNull();
   });
 
   it("RELOAD_SUCCESS refreshes the draft and clears the conflict, staying active", () => {

--- a/src/__tests__/components/EditModeProvider.test.tsx
+++ b/src/__tests__/components/EditModeProvider.test.tsx
@@ -215,9 +215,11 @@ function Harness() {
       <span data-testid="active">{String(em.active)}</span>
       <span data-testid="conflict">{String(em.conflict)}</span>
       <span data-testid="dirty">{String(em.dirty)}</span>
+      <span data-testid="status">{em.status}</span>
       <span data-testid="services">{em.draft?.services.length ?? "none"}</span>
       <span data-testid="baseRevision">{em.baseRevision ?? "none"}</span>
       <button onClick={() => void em.enter()}>enter</button>
+      <button onClick={() => em.requestServiceEdit("Plex")}>request-edit</button>
       <button onClick={() => em.setServices([])}>clear-services</button>
       <button
         onClick={() =>
@@ -265,6 +267,35 @@ describe("EditModeProvider (hook flows)", () => {
     });
     expect(screen.getByTestId("active").textContent).toBe("true");
     expect(screen.getByTestId("services").textContent).toBe("1");
+  });
+
+  it("requestServiceEdit does not fire a duplicate GET while entry is already in flight", async () => {
+    let resolveFetch!: (res: Response) => void;
+    const fetchMock = vi.fn().mockReturnValue(
+      new Promise<Response>((resolve) => {
+        resolveFetch = resolve;
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    await setup();
+
+    // First call kicks off entry (status → "loading"); a second call — e.g.
+    // a double-click on the broken-widget badge — must not fire another GET
+    // while the first is still in flight.
+    act(() => {
+      fireEvent.click(screen.getByText("request-edit"));
+    });
+    expect(screen.getByTestId("status").textContent).toBe("loading");
+    act(() => {
+      fireEvent.click(screen.getByText("request-edit"));
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFetch(fakeResponse(cfg(), { revision: "rev-1" }));
+    });
+    expect(screen.getByTestId("active").textContent).toBe("true");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   it("save with a stale revision surfaces a conflict and keeps the draft", async () => {

--- a/src/__tests__/components/EditTileMenus.test.tsx
+++ b/src/__tests__/components/EditTileMenus.test.tsx
@@ -9,8 +9,15 @@ const setServices = vi.fn();
 const setGroups = vi.fn();
 const setBookmarks = vi.fn();
 const updateDraft = vi.fn();
+const requestServiceEdit = vi.fn();
+// ServiceTile's broken-widget badge calls useEditModeOptional independently of
+// the useEditMode() stub above (it's meant to work standalone, outside any
+// provider too). This file exercises EditableServiceGrid, which only ever
+// mounts while edit mode is active, so canEdit: true keeps the badge in its
+// real (interactive) shape here — none of these tests assert on it directly.
 vi.mock("@/components/edit/EditModeProvider", () => ({
   useEditMode: () => ({ setServices, setGroups, setBookmarks, updateDraft }),
+  useEditModeOptional: () => ({ canEdit: true, requestServiceEdit }),
 }));
 
 import "@/integrations";

--- a/src/__tests__/components/EditableServiceGrid.test.tsx
+++ b/src/__tests__/components/EditableServiceGrid.test.tsx
@@ -98,18 +98,45 @@ describe("edit-mode drag handles", () => {
   });
 });
 
+// jsdom doesn't implement <dialog>'s showModal/close at all (neither method
+// exists on the prototype), so there's nothing for vi.spyOn to wrap until a
+// base implementation is installed once, here. Each test then spies on top
+// of this stub and vi.restoreAllMocks() reverts to it — unlike a direct
+// `HTMLDialogElement.prototype.showModal = vi.fn()` assignment, which
+// vi.clearAllMocks() (see afterEach below) does NOT undo, leaking the
+// patched prototype methods into later suites in this file.
+if (typeof HTMLDialogElement.prototype.showModal !== "function") {
+  HTMLDialogElement.prototype.showModal = function () {};
+}
+if (typeof HTMLDialogElement.prototype.close !== "function") {
+  HTMLDialogElement.prototype.close = function () {};
+}
+
 describe("pendingEditService (broken-widget badge → ServiceForm handoff)", () => {
+  let showModalSpy: ReturnType<typeof vi.spyOn>;
+  let closeSpy: ReturnType<typeof vi.spyOn>;
+
   beforeEach(() => {
-    HTMLDialogElement.prototype.showModal = vi.fn();
-    HTMLDialogElement.prototype.close = vi.fn().mockImplementation(function (
-      this: HTMLDialogElement
-    ) {
-      this.dispatchEvent(new Event("close"));
-    });
+    showModalSpy = vi
+      .spyOn(HTMLDialogElement.prototype, "showModal")
+      .mockImplementation(() => {});
+    closeSpy = vi
+      .spyOn(HTMLDialogElement.prototype, "close")
+      .mockImplementation(function (this: HTMLDialogElement) {
+        this.dispatchEvent(new Event("close"));
+      });
   });
 
   afterEach(() => {
+    // Clears call history for every mock in the file (module-scope
+    // setServices/setGroups/setBookmarks/clearPendingEditService included),
+    // same as before. mockRestore() on the two dialog spies additionally
+    // reverts HTMLDialogElement.prototype back to the plain stub installed
+    // above, so the next beforeEach spies on that stub fresh instead of
+    // stacking a spy on top of the previous test's spy.
     vi.clearAllMocks();
+    showModalSpy.mockRestore();
+    closeSpy.mockRestore();
     pendingEditService = null;
   });
 

--- a/src/__tests__/components/EditableServiceGrid.test.tsx
+++ b/src/__tests__/components/EditableServiceGrid.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
-import { render, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, act, screen } from "@testing-library/react";
 import { KokpitConfigSchema, type KokpitConfig } from "@/config/schema";
 
 // EditableServiceGrid reads the B1 setters from useEditMode; stub the context so
@@ -8,8 +8,20 @@ import { KokpitConfigSchema, type KokpitConfig } from "@/config/schema";
 const setServices = vi.fn();
 const setGroups = vi.fn();
 const setBookmarks = vi.fn();
+// Mutable so individual tests can seed a pending name before rendering — see
+// the "pendingEditService" describe block below.
+let pendingEditService: string | null = null;
+const clearPendingEditService = vi.fn(() => {
+  pendingEditService = null;
+});
 vi.mock("@/components/edit/EditModeProvider", () => ({
-  useEditMode: () => ({ setServices, setGroups, setBookmarks }),
+  useEditMode: () => ({
+    setServices,
+    setGroups,
+    setBookmarks,
+    pendingEditService,
+    clearPendingEditService,
+  }),
 }));
 
 import EditableServiceGrid from "@/components/edit/EditableServiceGrid";
@@ -83,6 +95,52 @@ describe("edit-mode drag handles", () => {
     // Implicit "Bookmarks" section renders but is pinned — no reorder handle.
     expect(container.querySelector(".service-group__header")).not.toBeNull();
     expect(container.querySelector(".group-drag-handle")).toBeNull();
+  });
+});
+
+describe("pendingEditService (broken-widget badge → ServiceForm handoff)", () => {
+  beforeEach(() => {
+    HTMLDialogElement.prototype.showModal = vi.fn();
+    HTMLDialogElement.prototype.close = vi.fn().mockImplementation(function (
+      this: HTMLDialogElement
+    ) {
+      this.dispatchEvent(new Event("close"));
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    pendingEditService = null;
+  });
+
+  it("a pendingEditService naming a real service opens its ServiceForm dialog, then clears the pending name", async () => {
+    pendingEditService = "Plex";
+    await act(async () => {
+      render(<EditableServiceGrid config={cfg()} />);
+    });
+    expect(screen.getByText("Edit Service")).toBeInTheDocument();
+    const nameInput = screen.getByLabelText("Name *") as HTMLInputElement;
+    expect(nameInput.value).toBe("Plex");
+    expect(clearPendingEditService).toHaveBeenCalledTimes(1);
+  });
+
+  it("a pendingEditService naming no service just clears the pending name (no dialog)", async () => {
+    pendingEditService = "No Such Service";
+    await act(async () => {
+      render(<EditableServiceGrid config={cfg()} />);
+    });
+    expect(screen.queryByText("Edit Service")).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(clearPendingEditService).toHaveBeenCalledTimes(1);
+  });
+
+  it("a null pendingEditService is left alone (no dialog, no clear)", async () => {
+    pendingEditService = null;
+    await act(async () => {
+      render(<EditableServiceGrid config={cfg()} />);
+    });
+    expect(screen.queryByText("Edit Service")).not.toBeInTheDocument();
+    expect(clearPendingEditService).not.toHaveBeenCalled();
   });
 });
 

--- a/src/__tests__/components/ServiceForm.test.tsx
+++ b/src/__tests__/components/ServiceForm.test.tsx
@@ -647,6 +647,35 @@ describe("ServiceForm – saved config vs. live edits", () => {
     // stripping the empty `fields` array lets the schema default apply. The
     // saved-config warning must not block that legitimately-working action.
     expect(screen.getByText("Test connection")).toBeEnabled();
+    // Cleaning genuinely does repair this config, so the normalize hint is
+    // accurate here.
+    expect(
+      screen.getByText(/Saving from here will normalize it/)
+    ).toBeInTheDocument();
+  });
+
+  it("omits the normalize hint when saving would not actually repair the config", () => {
+    render(
+      <ServiceForm
+        service={{
+          name: "My Plex",
+          // `token` is required and has no schema default, so stripping empty
+          // values on save fixes nothing — promising normalization would lie.
+          widget: {
+            type: "plex",
+            config: { url: "http://plex.local:32400" },
+          },
+        }}
+        existingGroups={[]}
+        onSave={noop}
+        onClose={noop}
+      />
+    );
+
+    expect(screen.getByText(/token: /)).toBeInTheDocument();
+    expect(
+      screen.queryByText(/Saving from here will normalize it/)
+    ).not.toBeInTheDocument();
   });
 
   it("hands the display over to live validation once the user edits the widget config", () => {

--- a/src/__tests__/components/ServiceForm.test.tsx
+++ b/src/__tests__/components/ServiceForm.test.tsx
@@ -603,6 +603,115 @@ describe("ServiceForm – optional widget config", () => {
   });
 });
 
+describe("ServiceForm – saved config vs. live edits", () => {
+  // Regression test for the "broken widget feedback" bug: the tile validates
+  // the RAW saved config (fields: [] fails Plex's `.min(1)`, hence the
+  // warning badge), but the dialog used to validate the config AFTER
+  // cleanWidgetConfig() strips the empty array — at which point the schema's
+  // `.default([...])` kicks in and the config passes. The dialog then told
+  // the user everything was fine, contradicting the badge that sent them
+  // there. token is deliberately left valid so only `fields` trips the raw
+  // schema; that isolates the stripping-reveals-a-default case from a
+  // genuinely-broken field, which stripping would not fix.
+  it("shows the saved-config issue (not the positive line) for a saved config that only validates after cleaning strips a field down to its default", () => {
+    const { container } = render(
+      <ServiceForm
+        service={{
+          name: "My Plex",
+          widget: {
+            type: "plex",
+            config: {
+              url: "http://plex.local:32400",
+              token: "secret",
+              fields: [],
+            },
+          },
+        }}
+        existingGroups={[]}
+        onSave={noop}
+        onClose={noop}
+      />
+    );
+
+    expect(
+      screen.queryByText("Widget configured — it will render on the dashboard tile.")
+    ).not.toBeInTheDocument();
+    const issues = Array.from(
+      container.querySelectorAll(".service-form__widget-issues li")
+    ).map((el) => el.textContent);
+    expect(issues).toEqual(
+      expect.arrayContaining([expect.stringMatching(/^fields: /)])
+    );
+    // The saved config fails validation, but the LIVE cleaned config (what
+    // Test Connection actually sends) is valid — url and token are fine, and
+    // stripping the empty `fields` array lets the schema default apply. The
+    // saved-config warning must not block that legitimately-working action.
+    expect(screen.getByText("Test connection")).toBeEnabled();
+  });
+
+  it("hands the display over to live validation once the user edits the widget config", () => {
+    const { container } = render(
+      <ServiceForm
+        service={{
+          name: "My Plex",
+          widget: {
+            type: "plex",
+            config: {
+              url: "http://plex.local:32400",
+              token: "secret",
+              fields: [],
+            },
+          },
+        }}
+        existingGroups={[]}
+        onSave={noop}
+        onClose={noop}
+      />
+    );
+
+    expect(container.querySelector(".service-form__widget-issues")).toBeInTheDocument();
+
+    // Touch the widget config (token still ends up non-empty) — the saved
+    // config's issue list should no longer be authoritative.
+    fireEvent.change(screen.getByLabelText(/^Token/), {
+      target: { value: "secret2" },
+    });
+
+    // Live validation takes over: url + token are filled and the still-empty
+    // `fields` array cleans down to its default, so the config is valid.
+    expect(
+      screen.getByText("Widget configured — it will render on the dashboard tile.")
+    ).toBeInTheDocument();
+    expect(container.querySelector(".service-form__widget-issues")).not.toBeInTheDocument();
+  });
+
+  it("shows the positive line (no false alarm) for a saved config that is already valid", () => {
+    const { container } = render(
+      <ServiceForm
+        service={{
+          name: "My Plex",
+          widget: {
+            type: "plex",
+            config: {
+              url: "http://plex.local:32400",
+              token: "secret",
+              fields: ["streams"],
+            },
+          },
+        }}
+        existingGroups={[]}
+        onSave={noop}
+        onClose={noop}
+      />
+    );
+
+    expect(
+      screen.getByText("Widget configured — it will render on the dashboard tile.")
+    ).toBeInTheDocument();
+    expect(container.querySelector(".service-form__widget-issues")).not.toBeInTheDocument();
+  });
+});
+
 describe("ServiceForm – focusWidget", () => {
   it("focuses the first invalid widget config field on mount", () => {
     render(

--- a/src/__tests__/components/ServiceForm.test.tsx
+++ b/src/__tests__/components/ServiceForm.test.tsx
@@ -543,6 +543,130 @@ describe("ServiceForm – optional widget config", () => {
     expect(screen.getByText(/widget configured/i)).toBeInTheDocument();
     expect(screen.queryByText(/widget not configured/i)).not.toBeInTheDocument();
   });
+
+  it("keeps the friendly not-configured hint (no error list) while the config is entirely empty", () => {
+    const { container } = render(
+      <ServiceForm service={null} existingGroups={[]} onSave={noop} onClose={noop} />
+    );
+    fireEvent.change(screen.getByLabelText("Tile type"), {
+      target: { value: "plex" },
+    });
+    expect(
+      screen.getByText(
+        "Widget not configured — the tile will render as a plain link until the required fields are filled."
+      )
+    ).toBeInTheDocument();
+    // No per-field Zod error list yet — that would be a wall of red text on
+    // a freshly-selected widget type nobody has touched.
+    expect(container.querySelector(".service-form__widget-issues")).not.toBeInTheDocument();
+  });
+
+  it("lists the specific Zod issues once the user has entered something but the config is still invalid", () => {
+    const { container } = render(
+      <ServiceForm service={null} existingGroups={[]} onSave={noop} onClose={noop} />
+    );
+    fireEvent.change(screen.getByLabelText("Tile type"), {
+      target: { value: "plex" },
+    });
+    // Fill only the URL — Token is still required, so the config remains
+    // invalid, but it's no longer empty.
+    fireEvent.change(screen.getByLabelText(/Server URL/), {
+      target: { value: "http://plex.local:32400" },
+    });
+
+    expect(screen.queryByText(/widget not configured/i)).not.toBeInTheDocument();
+    const issues = Array.from(
+      container.querySelectorAll(".service-form__widget-issues li")
+    ).map((el) => el.textContent);
+    expect(issues).toEqual(
+      expect.arrayContaining([expect.stringMatching(/^token: /)])
+    );
+  });
+
+  it("still shows the positive line once a valid config is entered", () => {
+    const { container } = render(
+      <ServiceForm service={null} existingGroups={[]} onSave={noop} onClose={noop} />
+    );
+    fireEvent.change(screen.getByLabelText("Tile type"), {
+      target: { value: "plex" },
+    });
+    fireEvent.change(screen.getByLabelText(/Server URL/), {
+      target: { value: "http://plex.local:32400" },
+    });
+    fireEvent.change(screen.getByLabelText(/^Token/), {
+      target: { value: "secret" },
+    });
+    expect(
+      screen.getByText("Widget configured — it will render on the dashboard tile.")
+    ).toBeInTheDocument();
+    expect(container.querySelector(".service-form__widget-issues")).not.toBeInTheDocument();
+  });
+});
+
+describe("ServiceForm – focusWidget", () => {
+  it("focuses the first invalid widget config field on mount", () => {
+    render(
+      <ServiceForm
+        service={{
+          name: "My Plex",
+          widget: { type: "plex", config: { url: "http://plex.local:32400" } },
+        }}
+        existingGroups={[]}
+        onSave={noop}
+        onClose={noop}
+        focusWidget
+      />
+    );
+    expect(screen.getByLabelText(/^Token/)).toHaveFocus();
+  });
+
+  it("shows the specific issues immediately (even with an empty config) when opened from the badge", () => {
+    const { container } = render(
+      <ServiceForm
+        service={{ name: "My Plex", widget: { type: "plex" } }}
+        existingGroups={[]}
+        onSave={noop}
+        onClose={noop}
+        focusWidget
+      />
+    );
+    expect(container.querySelector(".service-form__widget-issues")).toBeInTheDocument();
+    expect(screen.queryByText(/widget not configured/i)).not.toBeInTheDocument();
+  });
+
+  it("falls back to focusing the tile-type selector when nothing is specifically invalid", () => {
+    render(
+      <ServiceForm
+        service={{
+          name: "My Plex",
+          widget: {
+            type: "plex",
+            config: { url: "http://plex.local:32400", token: "secret" },
+          },
+        }}
+        existingGroups={[]}
+        onSave={noop}
+        onClose={noop}
+        focusWidget
+      />
+    );
+    expect(screen.getByLabelText("Tile type")).toHaveFocus();
+  });
+
+  it("does not move focus when focusWidget is not set", () => {
+    render(
+      <ServiceForm
+        service={{
+          name: "My Plex",
+          widget: { type: "plex", config: { url: "http://plex.local:32400" } },
+        }}
+        existingGroups={[]}
+        onSave={noop}
+        onClose={noop}
+      />
+    );
+    expect(screen.getByLabelText(/^Token/)).not.toHaveFocus();
+  });
 });
 
 describe("ServiceForm – test connection", () => {

--- a/src/__tests__/components/ServiceGrid.test.tsx
+++ b/src/__tests__/components/ServiceGrid.test.tsx
@@ -534,6 +534,9 @@ describe("ServiceGrid", () => {
     // affordance to open a dialog that doesn't exist here).
     expect(badge).toHaveAttribute("role", "img");
     expect(badge).not.toHaveClass("tile-widget-badge--interactive");
+    // Plex has a url, so it would normally get a status dot — the badge
+    // takes that slot instead of stacking alongside it.
+    expect(container.querySelector(".status-dot")).toBeNull();
   });
 
   it("keeps the error box for an unknown widget type", async () => {

--- a/src/__tests__/components/ServiceGrid.test.tsx
+++ b/src/__tests__/components/ServiceGrid.test.tsx
@@ -474,15 +474,27 @@ describe("ServiceGrid", () => {
       if (emptyConfigValid) {
         // Schema accepts an empty config — the widget renders.
         expect(container.querySelector(".service-tile__widget")).not.toBeNull();
+        expect(container.querySelector(".tile-widget-badge")).toBeNull();
       } else {
-        // Unconfigured widget — plain link tile, no error box.
+        // Config required but missing: no silent link degrade — the
+        // broken-widget badge takes the widget area's place instead.
         expect(container.querySelector(".service-tile__widget")).toBeNull();
         expect(container.querySelector(".widget-error")).toBeNull();
+        const badge = container.querySelector(".tile-widget-badge");
+        expect(badge).not.toBeNull();
+        expect(badge).toHaveAttribute("data-widget-config-invalid", "true");
+        expect(badge).toHaveAttribute(
+          "aria-label",
+          "Widget configuration error: Svc"
+        );
+        // No edit-mode provider in view mode → non-interactive variant.
+        expect(badge).toHaveAttribute("role", "img");
+        expect(badge).not.toHaveClass("tile-widget-badge--interactive");
       }
     }
   );
 
-  it("renders a plain tile when the widget config is partial/invalid", async () => {
+  it("renders a warning badge (not a plain tile) when the widget config is partial/invalid", async () => {
     getConfig.mockReturnValue(
       makeConfig({
         services: [
@@ -502,8 +514,26 @@ describe("ServiceGrid", () => {
       ({ container } = render(<ServiceGrid />));
     });
     expect(screen.getByText("Plex")).toBeInTheDocument();
+    // Widget area is suppressed, and this is NOT the "unknown widget type"
+    // error box — it's the new badge affordance.
     expect(container.querySelector(".service-tile__widget")).toBeNull();
     expect(container.querySelector(".widget-error")).toBeNull();
+
+    const badge = container.querySelector(".tile-widget-badge");
+    expect(badge).not.toBeNull();
+    expect(badge).toHaveAttribute("data-widget-config-invalid", "true");
+    expect(badge).toHaveAttribute(
+      "aria-label",
+      "Widget configuration error: Plex"
+    );
+    expect(badge).toHaveAttribute(
+      "title",
+      "token: Invalid input: expected string, received undefined"
+    );
+    // View mode has no EditModeProvider, so the badge is inert (no click
+    // affordance to open a dialog that doesn't exist here).
+    expect(badge).toHaveAttribute("role", "img");
+    expect(badge).not.toHaveClass("tile-widget-badge--interactive");
   });
 
   it("keeps the error box for an unknown widget type", async () => {

--- a/src/__tests__/components/ServiceGrid.test.tsx
+++ b/src/__tests__/components/ServiceGrid.test.tsx
@@ -526,10 +526,14 @@ describe("ServiceGrid", () => {
       "aria-label",
       "Widget configuration error: Plex"
     );
-    expect(badge).toHaveAttribute(
-      "title",
-      "token: Invalid input: expected string, received undefined"
-    );
+    // Partial match rather than the full Zod message: the exact wording
+    // ("Invalid input: expected string, received undefined") is a Zod
+    // implementation detail that has changed across versions. This still
+    // proves the right field path is reported (token) and that it's the
+    // invalid-input case, not some other failure mode.
+    const badgeTitle = badge?.getAttribute("title");
+    expect(badgeTitle).toMatch(/^token: /);
+    expect(badgeTitle).toMatch(/invalid|expected|required/i);
     // View mode has no EditModeProvider, so the badge is inert (no click
     // affordance to open a dialog that doesn't exist here).
     expect(badge).toHaveAttribute("role", "img");

--- a/src/__tests__/components/ServiceTile.test.tsx
+++ b/src/__tests__/components/ServiceTile.test.tsx
@@ -320,6 +320,49 @@ describe("ServiceTile broken-widget badge", () => {
     expect(container.querySelector(".service-tile__widget")).not.toBeNull();
   });
 
+  it("badge and status dot share one slot: an invalid config shows the badge and no status dot", async () => {
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <ServiceTile
+          name="Sonarr"
+          url="http://sonarr.local"
+          widget={{ type: "sonarr-queue", invalid: issues }}
+        />
+      ));
+    });
+    expect(container.querySelector(".tile-widget-badge")).not.toBeNull();
+    expect(container.querySelector(".status-dot")).toBeNull();
+  });
+
+  it("badge and status dot share one slot: a valid config shows the status dot and no badge", async () => {
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <ServiceTile
+          name="Sonarr"
+          url="http://sonarr.local"
+          widget={{ type: "sonarr-queue" }}
+        />
+      ));
+    });
+    expect(container.querySelector(".status-dot")).not.toBeNull();
+    expect(container.querySelector(".tile-widget-badge")).toBeNull();
+  });
+
+  it("renders the badge even when the tile has no url (and so no status dot slot to begin with)", async () => {
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <ServiceTile name="Sonarr" widget={{ type: "sonarr-queue", invalid: issues }} />
+      ));
+    });
+    expect(container.querySelector(".tile-widget-badge")).not.toBeNull();
+    expect(container.querySelector(".status-dot")).toBeNull();
+    // No url → renders as a div, not a link.
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
   it("does not render a badge when there is no widget at all", async () => {
     let container!: HTMLElement;
     await act(async () => {

--- a/src/__tests__/components/ServiceTile.test.tsx
+++ b/src/__tests__/components/ServiceTile.test.tsx
@@ -508,7 +508,7 @@ describe("ServiceTile broken-widget badge", () => {
     expect(requestServiceEdit).toHaveBeenCalledTimes(2);
   });
 
-  it("clicking the non-interactive badge does not throw and does not navigate", async () => {
+  it("clicking the non-interactive badge does not throw and does not intercept the click", async () => {
     editModeOptional.current = null;
     let container!: HTMLElement;
     await act(async () => {
@@ -520,7 +520,18 @@ describe("ServiceTile broken-widget badge", () => {
         />
       ));
     });
+    const link = container.querySelector("a.service-tile")!;
+    let capturedEvent: Event | null = null;
+    link.addEventListener("click", (e) => (capturedEvent = e), true);
+
     const badge = container.querySelector(".tile-widget-badge")!;
     expect(() => fireEvent.click(badge)).not.toThrow();
+
+    // Unlike the interactive badge (which calls preventDefault +
+    // stopPropagation), the non-interactive one has no click handler at all —
+    // the click bubbles straight through to the tile's anchor unimpeded, so
+    // nothing here stops the link's default navigation.
+    expect(capturedEvent).not.toBeNull();
+    expect((capturedEvent as unknown as Event).defaultPrevented).toBe(false);
   });
 });

--- a/src/__tests__/components/ServiceTile.test.tsx
+++ b/src/__tests__/components/ServiceTile.test.tsx
@@ -1,6 +1,20 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import ServiceTile from "@/components/ServiceTile";
+import type { WidgetConfigIssue } from "@/widgets/tileWidget";
+
+// The broken-widget badge reads edit-mode availability via
+// useEditModeOptional(), independently of any wrapping <EditModeProvider> (it
+// must work with no provider at all — that's the whole point of the "Optional"
+// hook). Mocking it directly, with a mutable ref tests can point at whatever
+// they need, is far simpler than standing up a real provider (fetch/router
+// mocking) just to flip `canEdit`.
+const editModeOptional = vi.hoisted(() => ({
+  current: null as null | { canEdit: boolean; requestServiceEdit: (name: string) => void },
+}));
+vi.mock("@/components/edit/EditModeProvider", () => ({
+  useEditModeOptional: () => editModeOptional.current,
+}));
 
 describe("ServiceTile", () => {
   beforeEach(() => {
@@ -11,11 +25,13 @@ describe("ServiceTile", () => {
         json: () => Promise.resolve({ ok: true, status: 200 }),
       } as Response)
     );
+    editModeOptional.current = null;
   });
 
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();
+    editModeOptional.current = null;
   });
 
   it("renders the service name", async () => {
@@ -239,5 +255,229 @@ describe("ServiceTile", () => {
       vi.advanceTimersByTime(30_000);
     });
     expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("ServiceTile broken-widget badge", () => {
+  const issues: WidgetConfigIssue[] = [
+    { path: "api_key", message: "Required" },
+    { path: "url", message: "Invalid url" },
+  ];
+
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        json: () => Promise.resolve({ ok: true }),
+      } as Response)
+    );
+    editModeOptional.current = null;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    editModeOptional.current = null;
+  });
+
+  it("renders the badge (not the widget body) when widget.invalid is set", async () => {
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <ServiceTile
+          name="Sonarr"
+          url="http://sonarr.local"
+          widget={{ type: "sonarr-queue", invalid: issues }}
+        />
+      ));
+    });
+    const badge = container.querySelector(".tile-widget-badge");
+    expect(badge).not.toBeNull();
+    expect(badge).toHaveAttribute("data-widget-config-invalid", "true");
+    expect(badge).toHaveAttribute(
+      "aria-label",
+      "Widget configuration error: Sonarr"
+    );
+    expect(badge).toHaveAttribute(
+      "title",
+      "api_key: Required\nurl: Invalid url"
+    );
+    expect(container.querySelector(".service-tile__widget")).toBeNull();
+  });
+
+  it("does not render a badge for a valid widget", async () => {
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <ServiceTile
+          name="Sonarr"
+          url="http://sonarr.local"
+          widget={{ type: "sonarr-queue" }}
+          preview
+        />
+      ));
+    });
+    expect(container.querySelector(".tile-widget-badge")).toBeNull();
+    expect(container.querySelector(".service-tile__widget")).not.toBeNull();
+  });
+
+  it("does not render a badge when there is no widget at all", async () => {
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <ServiceTile name="Jellyfin" url="http://jellyfin.local" />
+      ));
+    });
+    expect(container.querySelector(".tile-widget-badge")).toBeNull();
+  });
+
+  it("is non-interactive (role=img, no tabIndex) with no edit-mode provider", async () => {
+    editModeOptional.current = null;
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <ServiceTile
+          name="Sonarr"
+          url="http://sonarr.local"
+          widget={{ type: "sonarr-queue", invalid: issues }}
+        />
+      ));
+    });
+    const badge = container.querySelector(".tile-widget-badge")!;
+    expect(badge).toHaveAttribute("role", "img");
+    expect(badge).not.toHaveAttribute("tabIndex");
+    expect(badge).not.toHaveClass("tile-widget-badge--interactive");
+  });
+
+  it("is non-interactive when edit mode is available but canEdit is false", async () => {
+    editModeOptional.current = { canEdit: false, requestServiceEdit: vi.fn() };
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <ServiceTile
+          name="Sonarr"
+          url="http://sonarr.local"
+          widget={{ type: "sonarr-queue", invalid: issues }}
+        />
+      ));
+    });
+    const badge = container.querySelector(".tile-widget-badge")!;
+    expect(badge).toHaveAttribute("role", "img");
+    expect(badge).not.toHaveClass("tile-widget-badge--interactive");
+  });
+
+  it("is interactive (role=button, tabIndex 0) when edit mode is available and canEdit", async () => {
+    editModeOptional.current = { canEdit: true, requestServiceEdit: vi.fn() };
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <ServiceTile
+          name="Sonarr"
+          url="http://sonarr.local"
+          widget={{ type: "sonarr-queue", invalid: issues }}
+        />
+      ));
+    });
+    const badge = container.querySelector(".tile-widget-badge")!;
+    expect(badge).toHaveAttribute("role", "button");
+    expect(badge).toHaveAttribute("tabIndex", "0");
+    expect(badge).toHaveClass("tile-widget-badge--interactive");
+  });
+
+  it("clicking the interactive badge calls requestServiceEdit and prevents the link navigation", async () => {
+    const requestServiceEdit = vi.fn();
+    editModeOptional.current = { canEdit: true, requestServiceEdit };
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <ServiceTile
+          name="Sonarr"
+          url="http://sonarr.local"
+          widget={{ type: "sonarr-queue", invalid: issues }}
+        />
+      ));
+    });
+    const link = container.querySelector("a.service-tile")!;
+    let capturedEvent: Event | null = null;
+    // Capture phase fires (top-down) before the badge's own bubble-phase
+    // onClick runs, but it's the same event object throughout, so by the time
+    // the synchronous dispatch finishes, `defaultPrevented` reflects whatever
+    // the badge's handler did.
+    link.addEventListener("click", (e) => (capturedEvent = e), true);
+
+    const badge = container.querySelector(".tile-widget-badge")!;
+    fireEvent.click(badge);
+
+    expect(requestServiceEdit).toHaveBeenCalledWith("Sonarr");
+    expect(requestServiceEdit).toHaveBeenCalledTimes(1);
+    expect(capturedEvent).not.toBeNull();
+    expect((capturedEvent as unknown as Event).defaultPrevented).toBe(true);
+  });
+
+  it("clicking the interactive badge does not bubble the click to an ancestor handler", async () => {
+    const requestServiceEdit = vi.fn();
+    editModeOptional.current = { canEdit: true, requestServiceEdit };
+    const parentClick = vi.fn();
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <div onClick={parentClick}>
+          <ServiceTile
+            name="Sonarr"
+            url="http://sonarr.local"
+            widget={{ type: "sonarr-queue", invalid: issues }}
+          />
+        </div>
+      ));
+    });
+    const badge = container.querySelector(".tile-widget-badge")!;
+    fireEvent.click(badge);
+    expect(requestServiceEdit).toHaveBeenCalledTimes(1);
+    // e.stopPropagation() in the badge's onClick must stop it here — a
+    // regression would let the click fall through to the grid/tile ancestor
+    // (e.g. starting a drag, or a future ancestor click handler) on top of
+    // opening the editor.
+    expect(parentClick).not.toHaveBeenCalled();
+  });
+
+  it("Enter and Space on the interactive badge call requestServiceEdit", async () => {
+    const requestServiceEdit = vi.fn();
+    editModeOptional.current = { canEdit: true, requestServiceEdit };
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <ServiceTile
+          name="Sonarr"
+          url="http://sonarr.local"
+          widget={{ type: "sonarr-queue", invalid: issues }}
+        />
+      ));
+    });
+    const badge = container.querySelector(".tile-widget-badge")!;
+
+    fireEvent.keyDown(badge, { key: "Enter" });
+    expect(requestServiceEdit).toHaveBeenCalledTimes(1);
+
+    fireEvent.keyDown(badge, { key: " " });
+    expect(requestServiceEdit).toHaveBeenCalledTimes(2);
+
+    // An unrelated key is a no-op.
+    fireEvent.keyDown(badge, { key: "a" });
+    expect(requestServiceEdit).toHaveBeenCalledTimes(2);
+  });
+
+  it("clicking the non-interactive badge does not throw and does not navigate", async () => {
+    editModeOptional.current = null;
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <ServiceTile
+          name="Sonarr"
+          url="http://sonarr.local"
+          widget={{ type: "sonarr-queue", invalid: issues }}
+        />
+      ));
+    });
+    const badge = container.querySelector(".tile-widget-badge")!;
+    expect(() => fireEvent.click(badge)).not.toThrow();
   });
 });

--- a/src/__tests__/widgets/tileWidget.test.ts
+++ b/src/__tests__/widgets/tileWidget.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { z } from "zod";
+import { registerWidget, clearRegistry } from "@/widgets";
+import type { AnyWidgetDefinition } from "@/widgets";
+import { widgetConfigIssues, resolveTileWidget } from "@/widgets/tileWidget";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeWidget(id: string, configSchema: z.ZodType<any> = z.object({})): AnyWidgetDefinition {
+  return {
+    id,
+    name: `Widget ${id}`,
+    configSchema,
+    fetchData: async () => ({}),
+    component: () => null,
+  };
+}
+
+describe("widgetConfigIssues", () => {
+  it("returns no issues when the config satisfies the schema", () => {
+    const def = makeWidget("ok", z.object({ url: z.string().url() }));
+    expect(
+      widgetConfigIssues(def, { url: "http://example.com" })
+    ).toEqual([]);
+  });
+
+  it("returns one issue per failed field, with path + message only", () => {
+    const def = makeWidget(
+      "strict",
+      z.object({ url: z.string().url(), api_key: z.string().min(1) })
+    );
+    const issues = widgetConfigIssues(def, {});
+    expect(issues).toHaveLength(2);
+    expect(issues.map((i) => i.path).sort()).toEqual(["api_key", "url"]);
+    for (const issue of issues) {
+      expect(Object.keys(issue).sort()).toEqual(["message", "path"]);
+      expect(typeof issue.message).toBe("string");
+      expect(issue.message.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("treats a missing/undefined config the same as an empty object", () => {
+    const def = makeWidget(
+      "requires-field",
+      z.object({ url: z.string().url() })
+    );
+    expect(widgetConfigIssues(def, undefined)).toEqual(
+      widgetConfigIssues(def, {})
+    );
+    expect(widgetConfigIssues(def, undefined)).toHaveLength(1);
+  });
+
+  it("labels a whole-object (root-level) failure with the 'config' path", () => {
+    const def = makeWidget("root-fail", z.string());
+    const issues = widgetConfigIssues(def, { not: "a string" });
+    expect(issues).toHaveLength(1);
+    expect(issues[0].path).toBe("config");
+  });
+
+  it("joins nested paths with dots", () => {
+    const def = makeWidget(
+      "nested",
+      z.object({ auth: z.object({ token: z.string().min(1) }) })
+    );
+    const issues = widgetConfigIssues(def, { auth: {} });
+    expect(issues.map((i) => i.path)).toContain("auth.token");
+  });
+
+  // SECURITY: config carries credentials (API keys, tokens, passwords). The
+  // whole reason TileWidget only exposes {path, message} instead of the raw
+  // Zod issue is so those values never cross the server/client boundary, even
+  // when they're also the thing that failed validation.
+  it("never leaks a credential value from the config into the returned issues", () => {
+    const SECRET = "sk-live-super-secret-should-never-leave-the-server-12345";
+    const def = makeWidget(
+      "credentialed",
+      z.object({
+        url: z.string().url(),
+        api_key: z.string().min(1),
+        // A type mismatch is the case most likely to carry the raw input in
+        // some Zod issue shapes (invalid_type issues), so exercise it too.
+        port: z.number(),
+      })
+    );
+    const result = widgetConfigIssues(def, {
+      url: "not-a-url",
+      api_key: SECRET,
+      port: SECRET,
+    });
+    expect(result.length).toBeGreaterThan(0);
+    expect(JSON.stringify(result)).not.toContain(SECRET);
+  });
+});
+
+describe("resolveTileWidget", () => {
+  beforeEach(() => {
+    clearRegistry();
+  });
+  afterEach(() => {
+    clearRegistry();
+  });
+
+  it("returns undefined when the service has no widget", () => {
+    expect(resolveTileWidget(undefined)).toBeUndefined();
+  });
+
+  it("passes through an unknown widget type with no `invalid`", () => {
+    // No widget registered under this id at all.
+    const result = resolveTileWidget({ type: "not-a-real-widget" });
+    expect(result).toEqual({ type: "not-a-real-widget" });
+    expect(result).not.toHaveProperty("invalid");
+  });
+
+  it("known type + valid config: sanitized widget, no `invalid`", () => {
+    registerWidget(makeWidget("plexish", z.object({ url: z.string().url() })));
+    const result = resolveTileWidget({
+      type: "plexish",
+      config: { url: "http://plex.local:32400" },
+      refresh_interval_ms: 5000,
+    });
+    expect(result).toEqual({
+      type: "plexish",
+      refresh_interval_ms: 5000,
+    });
+    expect(result).not.toHaveProperty("invalid");
+  });
+
+  it("known type + invalid config: sanitized widget with populated `invalid`", () => {
+    registerWidget(
+      makeWidget(
+        "sonarrish",
+        z.object({ url: z.string().url(), api_key: z.string().min(1) })
+      )
+    );
+    const result = resolveTileWidget({
+      type: "sonarrish",
+      config: { url: "http://sonarr.local" }, // api_key missing
+    });
+    expect(result?.type).toBe("sonarrish");
+    expect(result?.invalid).toBeDefined();
+    expect(result?.invalid?.length).toBeGreaterThan(0);
+    expect(result?.invalid?.[0]).toEqual(
+      expect.objectContaining({ path: "api_key" })
+    );
+  });
+
+  it("never leaks the raw service.widget.config on the resolved tile widget", () => {
+    registerWidget(
+      makeWidget("secretive", z.object({ token: z.string().min(50) }))
+    );
+    const result = resolveTileWidget({
+      type: "secretive",
+      config: { token: "short-secret-value" },
+    });
+    expect(result).not.toHaveProperty("config");
+    expect(JSON.stringify(result)).not.toContain("short-secret-value");
+  });
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -539,11 +539,12 @@ button {
   height: 20px;
   padding: 0;
   line-height: 0;
+  /* No background fill: it occupies the status dot's slot and should read as
+     the same kind of bare indicator. Dropping the fill also removes the
+     optical mismatch of a bottom-heavy triangle inside a circle. */
   color: var(--color-warning, #f59e0b);
-  background: color-mix(in srgb, var(--color-warning, #f59e0b) 18%, transparent);
-  border-radius: var(--radius);
   z-index: 2;
-  transition: background 150ms ease, color 150ms ease;
+  transition: color 150ms ease, transform 150ms ease;
 }
 
 /* Only interactive when edit mode is available (span[role=button], so it can
@@ -552,10 +553,17 @@ button {
   cursor: pointer;
 }
 
-.tile-widget-badge--interactive:hover,
+.tile-widget-badge--interactive:hover {
+  color: color-mix(in srgb, var(--color-warning, #f59e0b) 70%, var(--color-text));
+  transform: scale(1.12);
+}
+
+/* Keyboard focus needs its own indicator: with no background left to shift,
+   suppressing the outline would make focus invisible. */
 .tile-widget-badge--interactive:focus-visible {
-  background: color-mix(in srgb, var(--color-warning, #f59e0b) 32%, transparent);
-  outline: none;
+  outline: 2px solid var(--color-warning, #f59e0b);
+  outline-offset: 2px;
+  border-radius: 50%;
 }
 
 .tile-widget-badge__glyph {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -523,17 +523,21 @@ button {
 
 /* Broken-widget badge: shown instead of the widget area when a service's
    widget config fails the widget's schema. Modelled on .widget-error, but as
-   an absolutely-positioned corner affordance. The top-left corner belongs to
-   .tile-drag-handle and the top-right to .status-dot / .tile-kebab, so this
-   takes the bottom-left. */
+   an absolutely-positioned corner affordance. It takes the .status-dot's
+   top-right slot rather than adding a new one — the two are mutually
+   exclusive (see ServiceTile.tsx), so there's never a collision to resolve.
+   Bottom-left was tried first but sat on top of the wrapped
+   .service-tile__description on 1x1 tiles; don't reintroduce that. */
 .tile-widget-badge {
   position: absolute;
-  bottom: 6px;
-  left: 8px;
+  top: 6px;
+  right: 6px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  padding: 2px 4px;
+  width: 20px;
+  height: 20px;
+  padding: 0;
   line-height: 0;
   color: var(--color-warning, #f59e0b);
   background: color-mix(in srgb, var(--color-warning, #f59e0b) 18%, transparent);
@@ -556,13 +560,6 @@ button {
 
 .tile-widget-badge__glyph {
   display: block;
-}
-
-/* Reserve the badge's strip so the name/description never runs underneath it.
-   Applies at every size preset and both mobile breakpoints because it keys off
-   the badge's presence, not the tile size. */
-.service-tile:has(> .tile-widget-badge) {
-  padding-bottom: calc(var(--gap) + 18px);
 }
 
 /* === SERVICE GROUPS === */
@@ -3448,8 +3445,11 @@ button {
   display: block;
 }
 
-/* Keep the edit-mode status dot clear of the kebab in the same corner. */
-.service-tile--editable .status-dot {
+/* Keep the edit-mode status dot clear of the kebab in the same corner. The
+   badge shares the dot's slot (they're mutually exclusive), so it needs the
+   identical shift for the same reason. */
+.service-tile--editable .status-dot,
+.service-tile--editable .tile-widget-badge {
   right: 30px;
 }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,6 +12,7 @@
   --color-accent-hover: #4f52d6;
   --color-border: #2e2e2e;
   --color-error: #ef4444;
+  --color-warning: #f59e0b;
   --radius: 8px;
   --gap: 16px;
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
@@ -28,6 +29,7 @@
   --color-accent-hover: #4f52d6;
   --color-border: #2e2e2e;
   --color-error: #ef4444;
+  --color-warning: #f59e0b;
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.4);
   --shadow-md: 0 12px 32px rgba(0, 0, 0, 0.45);
 }
@@ -42,6 +44,7 @@
   --color-accent-hover: #4f52d6;
   --color-border: #dddddd;
   --color-error: #dc2626;
+  --color-warning: #d97706;
   --shadow-sm: 0 1px 3px rgba(17, 17, 17, 0.08);
   --shadow-md: 0 12px 32px rgba(17, 17, 17, 0.12);
 }
@@ -56,6 +59,7 @@
   --color-accent-hover: #4f52d6;
   --color-border: #1f1f1f;
   --color-error: #ef4444;
+  --color-warning: #f59e0b;
   --shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.6);
   --shadow-md: 0 12px 32px rgba(0, 0, 0, 0.7);
 }
@@ -70,6 +74,7 @@
   --color-accent-hover: #0000cc;
   --color-border: #000000;
   --color-error: #cc0000;
+  --color-warning: #8a4b00;
   --shadow-sm: none;
   --shadow-md: none;
 }
@@ -514,6 +519,50 @@ button {
 .status-dot--pending {
   background: var(--color-text-muted);
   opacity: 0.5;
+}
+
+/* Broken-widget badge: shown instead of the widget area when a service's
+   widget config fails the widget's schema. Modelled on .widget-error, but as
+   an absolutely-positioned corner affordance. The top-left corner belongs to
+   .tile-drag-handle and the top-right to .status-dot / .tile-kebab, so this
+   takes the bottom-left. */
+.tile-widget-badge {
+  position: absolute;
+  bottom: 6px;
+  left: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px 4px;
+  line-height: 0;
+  color: var(--color-warning, #f59e0b);
+  background: color-mix(in srgb, var(--color-warning, #f59e0b) 18%, transparent);
+  border-radius: var(--radius);
+  z-index: 2;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+/* Only interactive when edit mode is available (span[role=button], so it can
+   live inside the anchor tile). */
+.tile-widget-badge--interactive {
+  cursor: pointer;
+}
+
+.tile-widget-badge--interactive:hover,
+.tile-widget-badge--interactive:focus-visible {
+  background: color-mix(in srgb, var(--color-warning, #f59e0b) 32%, transparent);
+  outline: none;
+}
+
+.tile-widget-badge__glyph {
+  display: block;
+}
+
+/* Reserve the badge's strip so the name/description never runs underneath it.
+   Applies at every size preset and both mobile breakpoints because it keys off
+   the badge's presence, not the tile size. */
+.service-tile:has(> .tile-widget-badge) {
+  padding-bottom: calc(var(--gap) + 18px);
 }
 
 /* === SERVICE GROUPS === */
@@ -1333,6 +1382,15 @@ button {
 
 .settings-form-hint--error {
   color: var(--color-error);
+}
+
+.service-form__widget-issues ul {
+  margin: 0.25rem 0 0;
+  padding-left: 1.1rem;
+}
+
+.service-form__widget-issues li {
+  margin: 0.15rem 0;
 }
 
 /* === GROUP COMBOBOX === */

--- a/src/components/ServiceForm.tsx
+++ b/src/components/ServiceForm.tsx
@@ -16,6 +16,7 @@ import {
   getWidgetsWithServiceEditorPreset,
 } from "@/widgets";
 import type { WidgetConfigField } from "@/widgets";
+import { widgetConfigIssues, type WidgetConfigIssue } from "@/widgets/tileWidget";
 import { SIZE_ORDER, sizeLabel } from "./settingsSizeOptions";
 
 interface ServiceFormProps {
@@ -31,6 +32,14 @@ interface ServiceFormProps {
    * service.
    */
   initialPreset?: string;
+  /**
+   * True when this dialog was opened by clicking a tile's broken-widget
+   * badge rather than the kebab menu's Edit item. On mount, scrolls the
+   * Widget section into view and moves focus to the first invalid config
+   * field (or the tile-type selector, if there isn't one), so the user lands
+   * where the fix is needed instead of having to hunt for it.
+   */
+  focusWidget?: boolean;
   onSave: (service: Service) => void;
   onClose: () => void;
 }
@@ -350,10 +359,12 @@ export default function ServiceForm({
   takenNames = [],
   initialGroup,
   initialPreset,
+  focusWidget = false,
   onSave,
   onClose,
 }: ServiceFormProps) {
   const dialogRef = useRef<HTMLDialogElement>(null);
+  const widgetSectionRef = useRef<HTMLDivElement>(null);
   const initial = initFromService(service);
   // For a NEW service opened from the edit-mode preset picker, seed the tile
   // type + its default name/icon exactly as picking it in the dropdown would.
@@ -422,10 +433,23 @@ export default function ServiceForm({
       : ((orphanWidget?.config as Record<string, unknown>) ?? {})
   );
   // Mirrors the dashboard's rule: the widget renders only when its config
-  // passes the schema. Unknown types can't be validated client-side.
-  const widgetConfigValid = selectedWidgetDef
-    ? selectedWidgetDef.configSchema.safeParse(activeCleanedConfig).success
-    : null;
+  // passes the schema. Unknown types can't be validated client-side. Uses the
+  // same shared mapper as the tile badge (src/widgets/tileWidget.ts) so the
+  // dialog's error list always matches what the badge's tooltip says.
+  const configIssues: WidgetConfigIssue[] = selectedWidgetDef
+    ? widgetConfigIssues(selectedWidgetDef, activeCleanedConfig)
+    : [];
+  const widgetConfigValid = selectedWidgetDef ? configIssues.length === 0 : null;
+  const widgetConfigEmpty = Object.keys(activeCleanedConfig).length === 0;
+  // An entirely empty config right after picking a widget type is the
+  // expected starting point, not a mistake — listing every "Required" issue
+  // at that moment is a wall of red text for no benefit, so the friendly
+  // hint (below) stays for that case. Once the user has typed *something*
+  // and it's still invalid, or the dialog was opened from a broken-tile
+  // badge (an already-saved config that fails validation), show the actual
+  // Zod issues so they know exactly what to fix.
+  const showSpecificWidgetIssues =
+    configIssues.length > 0 && (!widgetConfigEmpty || focusWidget);
 
   function handleWidgetConfigChange(key: string, value: unknown) {
     setWidgetConfig((prev) => ({ ...prev, [key]: value }));
@@ -608,6 +632,30 @@ export default function ServiceForm({
 
   useEffect(() => {
     dialogRef.current?.showModal();
+  }, []);
+
+  // Opened from the broken-widget badge: scroll the Widget section into
+  // view and move focus to the first invalid config field, so the user
+  // lands right where the fix is needed. Runs once on mount, after the
+  // showModal() effect above so it wins over the dialog's default initial
+  // focus. Deliberately mount-only — this isn't meant to steal focus again
+  // on every keystroke as issues resolve.
+  useEffect(() => {
+    if (!focusWidget || !showWidgetSection) return;
+    widgetSectionRef.current?.scrollIntoView?.({ block: "nearest" });
+
+    const firstInvalidField = selectedWidgetDef?.configFields?.find((field) =>
+      configIssues.some(
+        (issue) => issue.path === field.key || issue.path.startsWith(`${field.key}.`)
+      )
+    );
+    const targetId = firstInvalidField
+      ? `sf-widget-${firstInvalidField.key}`
+      : "sf-tile-type";
+    dialogRef.current
+      ?.querySelector<HTMLElement>(`#${targetId}`)
+      ?.focus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   function handleSubmit(e: React.FormEvent) {
@@ -923,7 +971,7 @@ export default function ServiceForm({
 
         {showWidgetSection && (
           <>
-            <div className="service-form__section-divider">
+            <div className="service-form__section-divider" ref={widgetSectionRef}>
               <span>Widget</span>
             </div>
 
@@ -988,16 +1036,43 @@ export default function ServiceForm({
               />
             </div>
 
-            {selectedWidgetDef && (
+            {selectedWidgetDef && widgetConfigValid && (
               <p
                 role="status"
-                className={`settings-form-hint service-form__widget-status service-form__widget-status--${
-                  widgetConfigValid ? "active" : "inactive"
-                }`}
+                className="settings-form-hint service-form__widget-status service-form__widget-status--active"
               >
-                {widgetConfigValid
-                  ? "Widget configured — it will render on the dashboard tile."
-                  : "Widget not configured — the tile will render as a plain link until the required fields are filled."}
+                Widget configured — it will render on the dashboard tile.
+              </p>
+            )}
+
+            {selectedWidgetDef && !widgetConfigValid && showSpecificWidgetIssues && (
+              <div
+                className="service-form__widget-issues"
+                role="alert"
+              >
+                <p className="settings-form-hint settings-form-hint--error">
+                  Widget configuration doesn&rsquo;t match its schema — the tile
+                  will render as a plain link until these are fixed:
+                </p>
+                <ul>
+                  {configIssues.map((issue) => (
+                    <li
+                      key={`${issue.path}:${issue.message}`}
+                      className="settings-form-hint settings-form-hint--error"
+                    >
+                      {issue.path}: {issue.message}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+
+            {selectedWidgetDef && !widgetConfigValid && !showSpecificWidgetIssues && (
+              <p
+                role="status"
+                className="settings-form-hint service-form__widget-status service-form__widget-status--inactive"
+              >
+                Widget not configured — the tile will render as a plain link until the required fields are filled.
               </p>
             )}
 

--- a/src/components/ServiceForm.tsx
+++ b/src/components/ServiceForm.tsx
@@ -1090,10 +1090,20 @@ export default function ServiceForm({
                     </li>
                   ))}
                 </ul>
-                <p className="settings-form-hint">
-                  Saving from here will normalize it (any field you leave
-                  empty falls back to its default).
-                </p>
+                {/*
+                  Only true when the current (cleaned) config actually
+                  validates — i.e. the saved YAML holds an empty value on a
+                  field that has a schema default, so saving strips it and the
+                  default takes over. For a genuinely missing required field
+                  like Plex's `token`, saving fixes nothing and promising
+                  otherwise would be a lie.
+                */}
+                {widgetConfigValid && (
+                  <p className="settings-form-hint">
+                    Saving from here will normalize it (the empty value falls
+                    back to this field&rsquo;s default).
+                  </p>
+                )}
               </div>
             )}
 

--- a/src/components/ServiceForm.tsx
+++ b/src/components/ServiceForm.tsx
@@ -286,26 +286,73 @@ function GroupCombobox({
   );
 }
 
+// The two issue lists (saved-config vs. live) render in mutually-exclusive
+// branches but share the same field keys, so their <li> ids are namespaced by
+// `kind` to avoid collisions. `index` is folded in too since a schema can, in
+// principle, report more than one issue for the same path. `path` is
+// sanitized because it comes from a Zod path (dotted, can contain characters
+// that aren't valid in an id token) — this is only used to build a readable
+// id, not to look anything up, so a lossy sanitize is fine.
+function widgetIssueElementId(
+  kind: "saved" | "live",
+  path: string,
+  index: number
+): string {
+  const sanitizedPath = path.replace(/[^a-zA-Z0-9_-]+/g, "-") || "root";
+  return `sf-widget-issue-${kind}-${index}-${sanitizedPath}`;
+}
+
 function WidgetConfigFields({
   fields,
   config,
   onChange,
+  issues,
+  issueKind,
 }: {
   fields: WidgetConfigField[];
   config: Record<string, unknown>;
   onChange: (key: string, value: unknown) => void;
+  /** Whichever issue list is currently displayed on screen (saved or live), or empty when neither is shown. */
+  issues: WidgetConfigIssue[];
+  issueKind: "saved" | "live";
 }) {
+  // Same "does this issue belong to this field" rule as the focusWidget mount
+  // effect below: exact path match, or a nested path under `field.key.`.
+  function issueIdsFor(key: string): string[] {
+    return issues
+      .map((issue, i) => ({ issue, i }))
+      .filter(
+        ({ issue }) =>
+          issue.path === key || issue.path.startsWith(`${key}.`)
+      )
+      .map(({ i }) => widgetIssueElementId(issueKind, issues[i].path, i));
+  }
+
   return (
     <>
       {fields.map((field) => {
         const value = config[field.key];
+        const fieldIssueIds = issueIdsFor(field.key);
+        const hintId = field.description ? `sf-widget-${field.key}-hint` : undefined;
+        const describedBy =
+          [...fieldIssueIds, hintId].filter(Boolean).join(" ") || undefined;
 
         if (field.type === "multiselect" && field.options) {
           const selected = Array.isArray(value) ? (value as string[]) : [];
+          // There's no single input this label/description apply to — it's a
+          // group of checkboxes — so the group gets role="group" plus
+          // aria-labelledby/aria-describedby instead of an input's
+          // aria-invalid/aria-describedby pairing.
+          const labelId = `sf-widget-${field.key}-label`;
           return (
             <div key={field.key} className="settings-form-row settings-form-row--multiselect">
-              <label>{field.label}</label>
-              <div className="widget-multiselect">
+              <label id={labelId}>{field.label}</label>
+              <div
+                className="widget-multiselect"
+                role="group"
+                aria-labelledby={labelId}
+                aria-describedby={describedBy}
+              >
                 {field.options.map((opt) => (
                   <label key={opt.value} className="widget-multiselect__option">
                     <input
@@ -323,7 +370,7 @@ function WidgetConfigFields({
                 ))}
               </div>
               {field.description && (
-                <p className="settings-form-hint">{field.description}</p>
+                <p id={hintId} className="settings-form-hint">{field.description}</p>
               )}
             </div>
           );
@@ -342,9 +389,11 @@ function WidgetConfigFields({
                 onChange(field.key, field.type === "number" ? (raw === "" ? undefined : Number(raw)) : raw);
               }}
               placeholder={field.placeholder}
+              aria-invalid={fieldIssueIds.length > 0 ? true : undefined}
+              aria-describedby={describedBy}
             />
             {field.description && (
-              <p className="settings-form-hint">{field.description}</p>
+              <p id={hintId} className="settings-form-hint">{field.description}</p>
             )}
           </div>
         );
@@ -481,6 +530,18 @@ export default function ServiceForm({
   const displayedWidgetIssues: WidgetConfigIssue[] = showSavedConfigIssues
     ? savedConfigIssues
     : configIssues;
+  // Same "which list is on screen" question, but for the aria-invalid /
+  // aria-describedby wiring on the fields themselves: unlike the focus
+  // effect (only meaningful once, under focusWidget), the fields render on
+  // every pass, so this must also cover the "nothing shown yet" case (a
+  // freshly-picked widget type with an empty, untouched config) — otherwise
+  // required-field issues that aren't actually displayed would still mark
+  // fields invalid and point aria-describedby at ids that don't exist.
+  const showingWidgetIssuesList = showSavedConfigIssues || showSpecificWidgetIssues;
+  const fieldIssueKind: "saved" | "live" = showSavedConfigIssues ? "saved" : "live";
+  const fieldIssues: WidgetConfigIssue[] = showingWidgetIssuesList
+    ? displayedWidgetIssues
+    : [];
 
   function handleWidgetConfigChange(key: string, value: unknown) {
     setWidgetConfig((prev) => ({ ...prev, [key]: value }));
@@ -686,9 +747,15 @@ export default function ServiceForm({
     const targetId = firstInvalidField
       ? `sf-widget-${firstInvalidField.key}`
       : "sf-tile-type";
-    dialogRef.current
-      ?.querySelector<HTMLElement>(`#${targetId}`)
-      ?.focus();
+    // getElementById (not querySelector) because targetId embeds a
+    // widget-defined field.key: interpolating it into a CSS selector throws
+    // a SyntaxError for a key with a CSS-special character (or a leading
+    // digit). getElementById takes a literal id, no selector parsing. Still
+    // scoped to the dialog, matching the previous querySelector's intent.
+    const target = document.getElementById(targetId);
+    if (target && dialogRef.current?.contains(target)) {
+      target.focus();
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -1026,6 +1093,8 @@ export default function ServiceForm({
                       ? handleWidgetConfigChange
                       : handleOrphanWidgetConfigChange
                   }
+                  issues={fieldIssues}
+                  issueKind={fieldIssueKind}
                 />
               )}
 
@@ -1081,9 +1150,10 @@ export default function ServiceForm({
                   widget&rsquo;s schema:
                 </p>
                 <ul>
-                  {savedConfigIssues.map((issue) => (
+                  {savedConfigIssues.map((issue, i) => (
                     <li
                       key={`${issue.path}:${issue.message}`}
+                      id={widgetIssueElementId("saved", issue.path, i)}
                       className="settings-form-hint settings-form-hint--error"
                     >
                       {issue.path}: {issue.message}
@@ -1126,9 +1196,10 @@ export default function ServiceForm({
                   will render as a plain link until these are fixed:
                 </p>
                 <ul>
-                  {configIssues.map((issue) => (
+                  {configIssues.map((issue, i) => (
                     <li
                       key={`${issue.path}:${issue.message}`}
+                      id={widgetIssueElementId("live", issue.path, i)}
                       className="settings-form-hint settings-form-hint--error"
                     >
                       {issue.path}: {issue.message}

--- a/src/components/ServiceForm.tsx
+++ b/src/components/ServiceForm.tsx
@@ -400,6 +400,24 @@ export default function ServiceForm({
   const [orphanWidget, setOrphanWidget] = useState<ServiceWidget | null>(initial.orphanWidget);
   const [widgetConfig, setWidgetConfig] = useState<Record<string, unknown>>(initial.widgetConfig);
   const [refreshInterval, setRefreshInterval] = useState<string>(initial.refreshInterval);
+  // True once the user has actively edited the widget config (or switched
+  // tile type) in this dialog session. Distinguishes "showing the saved
+  // config's problems" from "showing live edit feedback" below.
+  const [widgetConfigTouched, setWidgetConfigTouched] = useState(false);
+  // The issues the RAW saved config (settings.yaml, pre-`cleanWidgetConfig`)
+  // fails against its widget schema — i.e. exactly what made the tile show
+  // its warning badge. Computed once on mount (not recomputed as the user
+  // types) since its whole purpose is to describe the state the dialog was
+  // opened in. Guarded at the point of use below: it only applies while the
+  // selected widget type still matches what was actually saved, and while
+  // the user hasn't touched anything yet.
+  const [savedConfigIssues] = useState<WidgetConfigIssue[]>(() => {
+    const w = service?.widget;
+    if (!w) return [];
+    const def = getWidget(w.type);
+    if (!def) return [];
+    return widgetConfigIssues(def, w.config);
+  });
   const [testStatus, setTestStatus] = useState<TestStatus>({ state: "idle" });
   const [iconDetectStatus, setIconDetectStatus] = useState<IconDetectStatus>({ state: "idle" });
   const [iconPreviewError, setIconPreviewError] = useState(false);
@@ -450,9 +468,23 @@ export default function ServiceForm({
   // Zod issues so they know exactly what to fix.
   const showSpecificWidgetIssues =
     configIssues.length > 0 && (!widgetConfigEmpty || focusWidget);
+  // The saved-config issues only describe reality while (a) the user hasn't
+  // edited the widget config yet in this session, and (b) the widget type
+  // selected right now is still the one that was actually saved — switching
+  // types (or clearing back to Generic) makes the old issue list meaningless.
+  const showSavedConfigIssues =
+    !widgetConfigTouched &&
+    savedConfigIssues.length > 0 &&
+    service?.widget?.type === activeWidgetType;
+  // Whichever issue set is actually on screen right now — used to pick the
+  // field the focusWidget mount effect should focus.
+  const displayedWidgetIssues: WidgetConfigIssue[] = showSavedConfigIssues
+    ? savedConfigIssues
+    : configIssues;
 
   function handleWidgetConfigChange(key: string, value: unknown) {
     setWidgetConfig((prev) => ({ ...prev, [key]: value }));
+    setWidgetConfigTouched(true);
     setTestStatus({ state: "idle" });
   }
 
@@ -462,10 +494,12 @@ export default function ServiceForm({
       const cfg = { ...((prev.config as Record<string, unknown>) ?? {}), [key]: value };
       return { ...prev, config: cfg };
     });
+    setWidgetConfigTouched(true);
     setTestStatus({ state: "idle" });
   }
 
   function handleTileTypeChange(newTile: string) {
+    setWidgetConfigTouched(true);
     setTestStatus({ state: "idle" });
     if (newTile === "") {
       if (tileType !== "") {
@@ -645,7 +679,7 @@ export default function ServiceForm({
     widgetSectionRef.current?.scrollIntoView?.({ block: "nearest" });
 
     const firstInvalidField = selectedWidgetDef?.configFields?.find((field) =>
-      configIssues.some(
+      displayedWidgetIssues.some(
         (issue) => issue.path === field.key || issue.path.startsWith(`${field.key}.`)
       )
     );
@@ -1036,7 +1070,34 @@ export default function ServiceForm({
               />
             </div>
 
-            {selectedWidgetDef && widgetConfigValid && (
+            {selectedWidgetDef && showSavedConfigIssues && (
+              <div
+                className="service-form__widget-issues"
+                role="alert"
+              >
+                <p className="settings-form-hint settings-form-hint--error">
+                  This is the saved configuration, and it&rsquo;s why the tile
+                  shows a warning badge — it doesn&rsquo;t match the
+                  widget&rsquo;s schema:
+                </p>
+                <ul>
+                  {savedConfigIssues.map((issue) => (
+                    <li
+                      key={`${issue.path}:${issue.message}`}
+                      className="settings-form-hint settings-form-hint--error"
+                    >
+                      {issue.path}: {issue.message}
+                    </li>
+                  ))}
+                </ul>
+                <p className="settings-form-hint">
+                  Saving from here will normalize it (any field you leave
+                  empty falls back to its default).
+                </p>
+              </div>
+            )}
+
+            {selectedWidgetDef && !showSavedConfigIssues && widgetConfigValid && (
               <p
                 role="status"
                 className="settings-form-hint service-form__widget-status service-form__widget-status--active"
@@ -1045,7 +1106,7 @@ export default function ServiceForm({
               </p>
             )}
 
-            {selectedWidgetDef && !widgetConfigValid && showSpecificWidgetIssues && (
+            {selectedWidgetDef && !showSavedConfigIssues && !widgetConfigValid && showSpecificWidgetIssues && (
               <div
                 className="service-form__widget-issues"
                 role="alert"
@@ -1067,7 +1128,7 @@ export default function ServiceForm({
               </div>
             )}
 
-            {selectedWidgetDef && !widgetConfigValid && !showSpecificWidgetIssues && (
+            {selectedWidgetDef && !showSavedConfigIssues && !widgetConfigValid && !showSpecificWidgetIssues && (
               <p
                 role="status"
                 className="settings-form-hint service-form__widget-status service-form__widget-status--inactive"

--- a/src/components/ServiceGrid.tsx
+++ b/src/components/ServiceGrid.tsx
@@ -11,31 +11,13 @@ import {
   serviceNameUniquenessKey,
   type BookmarkGroup,
   type Service,
-  type ServiceWidget,
   type Size,
 } from "@/config/schema";
-import { getWidget, getWidgetSizeHints } from "@/widgets";
+import { getWidgetSizeHints } from "@/widgets";
+import { resolveTileWidget } from "@/widgets/tileWidget";
 import BookmarkTile from "./BookmarkTile";
 import CollapsibleGroup from "./CollapsibleGroup";
-import ServiceTile, { TileWidget } from "./ServiceTile";
-
-// Decide what the client tile gets to see of a service's widget:
-// - no widget → nothing
-// - unknown type → sanitized pass-through, so the renderer surfaces the typo
-// - known type with valid config → sanitized widget
-// - known type with missing/invalid config → nothing (plain link tile)
-// Config (credentials) never leaves the server either way.
-function resolveTileWidget(widget?: ServiceWidget): TileWidget | undefined {
-  if (!widget) return undefined;
-  const def = getWidget(widget.type);
-  if (def && !def.configSchema.safeParse(widget.config ?? {}).success) {
-    return undefined;
-  }
-  return {
-    type: widget.type,
-    refresh_interval_ms: widget.refresh_interval_ms,
-  };
-}
+import ServiceTile from "./ServiceTile";
 
 /**
  * Default tile size for a bookmark group without an explicit

--- a/src/components/ServiceTile.tsx
+++ b/src/components/ServiceTile.tsx
@@ -281,14 +281,26 @@ export default function ServiceTile({ name, url, icon, description, widget, size
     <>
       {handle}
       {kebab}
-      {url && <StatusDot url={url} preview={preview} />}
+      {/*
+       * The status dot and the broken-widget badge share one slot (the
+       * top-right corner) and are mutually exclusive: a config that fails
+       * its schema is a more actionable signal than reachability, so the
+       * badge takes the dot's place instead of stacking alongside it. Do
+       * NOT "restore" `{url && <StatusDot ... />}` next to the badge — that
+       * was the old bottom-left layout and collided with the wrapped
+       * description on 1x1 tiles. The badge renders here even when there's
+       * no `url` (and so no dot today), since an invalid config still needs
+       * reporting.
+       */}
+      {invalidIssues ? (
+        <WidgetConfigBadge name={name} issues={invalidIssues} />
+      ) : (
+        url && <StatusDot url={url} preview={preview} />
+      )}
       <ServiceIcon icon={icon} url={url} name={name} />
       <span className="service-tile__name">{name}</span>
       {description && (
         <span className="service-tile__description">{description}</span>
-      )}
-      {invalidIssues && (
-        <WidgetConfigBadge name={name} issues={invalidIssues} />
       )}
       {widget && !invalidIssues && (
         <div className="service-tile__widget" data-widget-type={widget.type}>

--- a/src/components/ServiceTile.tsx
+++ b/src/components/ServiceTile.tsx
@@ -3,14 +3,14 @@
 import { useEffect, useState } from "react";
 import type { Size } from "@/config/schema";
 import { resolveIconRef } from "@/config/iconRef";
+import type { TileWidget, WidgetConfigIssue } from "@/widgets/tileWidget";
+import { useEditModeOptional } from "./edit/EditModeProvider";
 import { WidgetRenderer } from "./WidgetRenderer";
 
-// Client-safe slice of ServiceWidget: the config (credentials) stays on the
-// server — the widget data API looks it up in settings.yaml by service name.
-export interface TileWidget {
-  type: string;
-  refresh_interval_ms?: number;
-}
+// The client-safe widget slice now lives next to the resolver that builds it
+// (src/widgets/tileWidget.ts); re-exported here so the long-standing
+// `import ServiceTile, { TileWidget } from "./ServiceTile"` keeps working.
+export type { TileWidget };
 
 /**
  * Optional dnd-kit wiring for edit mode (B2). When present, the tile becomes a
@@ -50,6 +50,97 @@ export function DragGrip() {
       <circle cx="2.5" cy="13" r="1.3" fill="currentColor" />
       <circle cx="7.5" cy="13" r="1.3" fill="currentColor" />
     </svg>
+  );
+}
+
+/** Warning glyph for the broken-widget badge (no icon library in this repo). */
+function WarningTriangle() {
+  return (
+    <svg
+      className="tile-widget-badge__glyph"
+      aria-hidden="true"
+      width="14"
+      height="14"
+      viewBox="0 0 16 16"
+    >
+      <path
+        d="M8 1.8 15.1 14.2H0.9z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.4"
+        strokeLinejoin="round"
+      />
+      <rect x="7.3" y="6" width="1.4" height="4.1" rx="0.7" fill="currentColor" />
+      <circle cx="8" cy="11.9" r="0.85" fill="currentColor" />
+    </svg>
+  );
+}
+
+/**
+ * Badge shown instead of the widget when a service's widget config fails the
+ * widget's own schema — the visible replacement for the old silent downgrade
+ * to a plain link. Clicking it jumps straight to the service's edit dialog
+ * (entering edit mode first if needed), which is where the config gets fixed.
+ *
+ * The tile root is often an `<a>`, so — like Kebab — the trigger is a
+ * `span[role=button]` that swallows the click rather than a nested `<button>`.
+ * Without an edit-mode provider (or without edit rights) it degrades to a
+ * plain, non-interactive badge that still carries the tooltip.
+ */
+function WidgetConfigBadge({
+  name,
+  issues,
+}: {
+  name: string;
+  issues: WidgetConfigIssue[];
+}) {
+  const editMode = useEditModeOptional();
+  const interactive = editMode != null && editMode.canEdit;
+
+  const label = `Widget configuration error: ${name}`;
+  const tooltip = issues.map((i) => `${i.path}: ${i.message}`).join("\n");
+
+  if (!interactive) {
+    return (
+      <span
+        className="tile-widget-badge"
+        data-widget-config-invalid="true"
+        role="img"
+        aria-label={label}
+        title={tooltip}
+      >
+        <WarningTriangle />
+      </span>
+    );
+  }
+
+  const openEditor = () => editMode.requestServiceEdit(name);
+
+  return (
+    <span
+      role="button"
+      tabIndex={0}
+      className="tile-widget-badge tile-widget-badge--interactive"
+      data-widget-config-invalid="true"
+      aria-label={label}
+      title={tooltip}
+      // Never start a tile drag, follow the tile's link, or bubble to the grid.
+      onPointerDown={(e) => e.stopPropagation()}
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        openEditor();
+      }}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          e.stopPropagation();
+          openEditor();
+        }
+      }}
+    >
+      <WarningTriangle />
+    </span>
   );
 }
 
@@ -168,6 +259,12 @@ export default function ServiceTile({ name, url, icon, description, widget, size
     (drag ? " service-tile--editable" : "") +
     (drag?.dragging ? " service-tile--dragging" : "");
 
+  // Known widget type whose config failed the widget's schema: show the badge
+  // and skip the widget area entirely, so the tile body stays the plain link it
+  // already was — the badge is purely additive on top of it.
+  const invalidIssues =
+    widget?.invalid && widget.invalid.length > 0 ? widget.invalid : undefined;
+
   const handle = drag ? (
     <span
       ref={drag.handleRef}
@@ -190,7 +287,10 @@ export default function ServiceTile({ name, url, icon, description, widget, size
       {description && (
         <span className="service-tile__description">{description}</span>
       )}
-      {widget && (
+      {invalidIssues && (
+        <WidgetConfigBadge name={name} issues={invalidIssues} />
+      )}
+      {widget && !invalidIssues && (
         <div className="service-tile__widget" data-widget-type={widget.type}>
           {preview ? (
             <span className="service-tile__widget-preview" aria-hidden="true">

--- a/src/components/ServiceTile.tsx
+++ b/src/components/ServiceTile.tsx
@@ -59,8 +59,8 @@ function WarningTriangle() {
     <svg
       className="tile-widget-badge__glyph"
       aria-hidden="true"
-      width="14"
-      height="14"
+      width="16"
+      height="16"
       viewBox="0 0 16 16"
     >
       <path

--- a/src/components/edit/EditModeProvider.tsx
+++ b/src/components/edit/EditModeProvider.tsx
@@ -350,10 +350,13 @@ export function EditModeProvider({ canEdit, children }: EditModeProviderProps) {
       // From view mode the edit grid (and with it the dialog) does not exist
       // yet, so entry has to happen too. A failed entry resets to
       // initialEditModeState via ENTER_ERROR, which drops the pending name —
-      // the right outcome: no edit mode, nothing to open.
-      if (!state.active) void enter();
+      // the right outcome: no edit mode, nothing to open. Also guard against
+      // a duplicate entry request: a double-click on the badge (or a click
+      // while entry is already in flight) would otherwise fire a second
+      // GET /api/settings before the first one resolves.
+      if (!state.active && state.status !== "loading") void enter();
     },
-    [canEdit, state.active, enter]
+    [canEdit, state.active, state.status, enter]
   );
 
   const clearPendingEditService = useCallback(

--- a/src/components/edit/EditModeProvider.tsx
+++ b/src/components/edit/EditModeProvider.tsx
@@ -57,6 +57,12 @@ export interface EditModeState {
   error: string | null;
   /** True when a save 409'd — the on-disk config moved under us. */
   conflict: boolean;
+  /**
+   * Service whose edit dialog should open as soon as the edit grid mounts.
+   * Set from view mode (the broken-widget badge) where the ServiceForm dialog
+   * does not exist yet; EditableServiceGrid consumes it and clears it.
+   */
+  pendingEditService: string | null;
 }
 
 export const initialEditModeState: EditModeState = {
@@ -67,6 +73,7 @@ export const initialEditModeState: EditModeState = {
   status: "idle",
   error: null,
   conflict: false,
+  pendingEditService: null,
 };
 
 export type EditModeAction =
@@ -79,7 +86,9 @@ export type EditModeAction =
   | { type: "SAVE_SUCCESS"; revision: string | null }
   | { type: "SAVE_ERROR"; error: string }
   | { type: "CONFLICT"; error: string }
-  | { type: "RELOAD_SUCCESS"; config: KokpitConfig; revision: string | null };
+  | { type: "RELOAD_SUCCESS"; config: KokpitConfig; revision: string | null }
+  | { type: "REQUEST_SERVICE_EDIT"; name: string }
+  | { type: "CLEAR_PENDING_EDIT" };
 
 export function editModeReducer(
   state: EditModeState,
@@ -97,6 +106,10 @@ export function editModeReducer(
         status: "idle",
         error: null,
         conflict: false,
+        // Carried across the entry round-trip: REQUEST_SERVICE_EDIT is
+        // dispatched from view mode *before* enter() resolves, and this case
+        // builds a fresh state object rather than spreading.
+        pendingEditService: state.pendingEditService,
       };
     case "ENTER_ERROR":
       return { ...initialEditModeState, status: "error", error: action.error };
@@ -139,6 +152,11 @@ export function editModeReducer(
         error: null,
         conflict: false,
       };
+    case "REQUEST_SERVICE_EDIT":
+      return { ...state, pendingEditService: action.name };
+    case "CLEAR_PENDING_EDIT":
+      if (state.pendingEditService === null) return state;
+      return { ...state, pendingEditService: null };
     default:
       return state;
   }
@@ -157,6 +175,8 @@ export function changedKeys(
 }
 
 export interface EditModeContextValue extends EditModeState {
+  /** Whether the current viewer may edit (mirrors the provider prop). */
+  canEdit: boolean;
   /** True when the draft differs from the baseline. */
   dirty: boolean;
   /** Number of changed top-level editable keys (edit-bar counter). */
@@ -176,6 +196,14 @@ export interface EditModeContextValue extends EditModeState {
   setServices: (services: Service[]) => void;
   setGroups: (groups: Group[] | undefined) => void;
   setBookmarks: (bookmarks: BookmarkGroup[] | undefined) => void;
+  /**
+   * Ask for a service's edit dialog. Entering edit mode when needed, since the
+   * dialog only exists inside EditableServiceGrid — the request is parked in
+   * `pendingEditService` until that grid mounts and picks it up.
+   */
+  requestServiceEdit: (name: string) => void;
+  /** Drop a pending request (after it has been honoured, or is unresolvable). */
+  clearPendingEditService: () => void;
 }
 
 const EditModeContext = createContext<EditModeContextValue | null>(null);
@@ -315,6 +343,24 @@ export function EditModeProvider({ canEdit, children }: EditModeProviderProps) {
     else void enter();
   }, [state.active, discard, enter]);
 
+  const requestServiceEdit = useCallback(
+    (name: string) => {
+      if (!canEdit) return;
+      dispatch({ type: "REQUEST_SERVICE_EDIT", name });
+      // From view mode the edit grid (and with it the dialog) does not exist
+      // yet, so entry has to happen too. A failed entry resets to
+      // initialEditModeState via ENTER_ERROR, which drops the pending name —
+      // the right outcome: no edit mode, nothing to open.
+      if (!state.active) void enter();
+    },
+    [canEdit, state.active, enter]
+  );
+
+  const clearPendingEditService = useCallback(
+    () => dispatch({ type: "CLEAR_PENDING_EDIT" }),
+    []
+  );
+
   // First global hotkey in the app: Mod+E toggles edit mode. Ignored while the
   // user is typing into a field so it never eats an in-form keystroke.
   useEffect(() => {
@@ -357,6 +403,7 @@ export function EditModeProvider({ canEdit, children }: EditModeProviderProps) {
   const value = useMemo<EditModeContextValue>(
     () => ({
       ...state,
+      canEdit,
       dirty: keys.length > 0,
       dirtyCount: keys.length,
       enter,
@@ -368,9 +415,12 @@ export function EditModeProvider({ canEdit, children }: EditModeProviderProps) {
       setServices,
       setGroups,
       setBookmarks,
+      requestServiceEdit,
+      clearPendingEditService,
     }),
     [
       state,
+      canEdit,
       keys,
       enter,
       toggle,
@@ -381,6 +431,8 @@ export function EditModeProvider({ canEdit, children }: EditModeProviderProps) {
       setServices,
       setGroups,
       setBookmarks,
+      requestServiceEdit,
+      clearPendingEditService,
     ]
   );
 
@@ -399,4 +451,14 @@ export function useEditMode(): EditModeContextValue {
     throw new Error("useEditMode must be used within an EditModeProvider");
   }
   return ctx;
+}
+
+/**
+ * Same as useEditMode, but returns null instead of throwing when there is no
+ * provider. For components that live in both the dashboard tree and standalone
+ * (e.g. ServiceTile, which is rendered on its own in unit tests) and only want
+ * edit affordances when edit mode is actually available.
+ */
+export function useEditModeOptional(): EditModeContextValue | null {
+  return useContext(EditModeContext);
 }

--- a/src/components/edit/EditableServiceGrid.tsx
+++ b/src/components/edit/EditableServiceGrid.tsx
@@ -19,7 +19,7 @@
 //  - Sensors: PointerSensor with an 8px activation distance (taps/scrolls on
 //    touch never start a drag) + KeyboardSensor (full keyboard DnD for free).
 import "@/integrations";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   DndContext,
   DragOverlay,
@@ -65,7 +65,6 @@ import {
   type BookmarkGroup,
   type KokpitConfig,
   type Service,
-  type ServiceWidget,
   type Size,
 } from "@/config/schema";
 import {
@@ -76,25 +75,15 @@ import {
 } from "@/config/groupCascade";
 import { duplicateBookmark, duplicateService } from "@/config/duplicate";
 import { useEditMode } from "./EditModeProvider";
-import { getWidget, getWidgetSizeHints } from "@/widgets";
+import { getWidgetSizeHints } from "@/widgets";
+import { resolveTileWidget } from "@/widgets/tileWidget";
 import BookmarkTile from "../BookmarkTile";
 import CollapsibleGroup, { migrateGroupCollapseKey } from "../CollapsibleGroup";
-import ServiceTile, { type TileWidget } from "../ServiceTile";
+import ServiceTile from "../ServiceTile";
 import ServiceForm from "../ServiceForm";
 import BookmarkGroupForm from "../BookmarkGroupForm";
 import AddTilePicker, { type AddChoice } from "./AddTilePicker";
 import { BookmarkTileMenu, GroupKebab, ServiceTileMenu } from "./tileMenus";
-
-// Mirrors ServiceGrid.resolveTileWidget: unknown types pass through so the typo
-// still surfaces; known-but-invalid config downgrades to a plain link.
-function resolveTileWidget(widget?: ServiceWidget): TileWidget | undefined {
-  if (!widget) return undefined;
-  const def = getWidget(widget.type);
-  if (def && !def.configSchema.safeParse(widget.config ?? {}).success) {
-    return undefined;
-  }
-  return { type: widget.type, refresh_interval_ms: widget.refresh_interval_ms };
-}
 
 function resolveBookmarkSize(bookmark: BookmarkGroup): Size {
   if (bookmark.placement?.size) return bookmark.placement.size;
@@ -360,7 +349,7 @@ const collisionDetection: CollisionDetection = (args) => {
 // Which edit dialog (if any) is mounted. `group` is the target section an
 // add-flow was launched from (null = ungrouped / no placement).
 type ActiveDialog =
-  | { kind: "service-edit"; name: string }
+  | { kind: "service-edit"; name: string; focusWidget?: boolean }
   | { kind: "service-add"; group: string | null; preset?: string }
   | { kind: "bookmark-edit"; name: string }
   | { kind: "bookmark-add"; group: string | null }
@@ -372,13 +361,34 @@ export default function EditableServiceGrid({
 }: {
   config: KokpitConfig;
 }) {
-  const { setServices, setGroups, setBookmarks, updateDraft } = useEditMode();
+  const {
+    setServices,
+    setGroups,
+    setBookmarks,
+    updateDraft,
+    pendingEditService,
+    clearPendingEditService,
+  } = useEditMode();
   const services = config.services;
   const bookmarks = useMemo(() => config.bookmarks ?? [], [config.bookmarks]);
   const declaredGroups = useMemo(() => config.groups ?? [], [config.groups]);
 
   const [activeId, setActiveId] = useState<string | null>(null);
   const [dialog, setDialog] = useState<ActiveDialog>(null);
+
+  // A view-mode affordance (the broken-widget badge) can ask for a service's
+  // edit dialog before this grid exists; the request waits in the provider
+  // until we mount. Honour it once, then clear it — including when it names a
+  // service that is no longer in the draft, so it can't linger.
+  useEffect(() => {
+    if (!pendingEditService) return;
+    const service = services.find((s) => keyEq(s.name, pendingEditService));
+    // Seeded from the broken-widget badge (not the kebab's Edit item): focus
+    // the Widget section so the Zod error is right where the user lands.
+    if (service)
+      setDialog({ kind: "service-edit", name: service.name, focusWidget: true });
+    clearPendingEditService();
+  }, [pendingEditService, services, clearPendingEditService]);
 
   // Group names (declared + auto-appended), de-duped, for the forms' pickers.
   const knownGroupNames = useMemo(() => {
@@ -934,6 +944,7 @@ export default function EditableServiceGrid({
           takenNames={services
             .filter((s) => !keyEq(s.name, dialog.name))
             .map((s) => s.name)}
+          focusWidget={dialog.focusWidget}
           onSave={(updated) => {
             handleServiceEditSave(dialog.name, updated);
             close();

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -51,7 +51,7 @@ export interface WidgetDefinition<TConfig = Record<string, unknown>, TData = unk
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyWidgetDefinition = WidgetDefinition<any, any>;
+export type AnyWidgetDefinition = WidgetDefinition<any, any>;
 
 const widgetRegistry = new Map<string, AnyWidgetDefinition>();
 

--- a/src/widgets/tileWidget.ts
+++ b/src/widgets/tileWidget.ts
@@ -1,0 +1,66 @@
+// Shared server/client boundary for a service's widget: what the tile is
+// allowed to know about `service.widget`. Lives here (not in a component) so
+// the server grid (ServiceGrid) and the edit-mode grid (EditableServiceGrid)
+// derive it identically from one implementation.
+import type { ServiceWidget } from "@/config/schema";
+import { getWidget, type AnyWidgetDefinition } from "@/widgets";
+
+/** One Zod issue, reduced to the two fields that are safe to send to a tile. */
+export interface WidgetConfigIssue {
+  /** Dotted config path, e.g. `"api_key"`. `"config"` for a root-level issue. */
+  path: string;
+  message: string;
+}
+
+// Client-safe slice of ServiceWidget: the config (credentials) stays on the
+// server — the widget data API looks it up in settings.yaml by service name.
+export interface TileWidget {
+  type: string;
+  refresh_interval_ms?: number;
+  /** Set when the widget type is KNOWN but its config fails the widget's schema. */
+  invalid?: WidgetConfigIssue[];
+}
+
+/** Path label used when a Zod issue has no path (whole-object failure). */
+const ROOT_ISSUE_PATH = "config";
+
+/**
+ * Validation issues for `config` against a widget's own `configSchema`, in a
+ * form that is safe to hand to a client component.
+ *
+ * SECURITY: map ONLY `path` and `message`. Never spread the Zod issue and
+ * never include `input` / `received` / `values` — Zod 4 issues can carry the
+ * offending input value, and widget configs hold credentials (API keys,
+ * tokens). Config values must never leave the server; that is the entire
+ * reason TileWidget is a slice of ServiceWidget rather than the whole thing.
+ */
+export function widgetConfigIssues(
+  def: AnyWidgetDefinition,
+  config: unknown
+): WidgetConfigIssue[] {
+  const result = def.configSchema.safeParse(config ?? {});
+  if (result.success) return [];
+  return result.error.issues.map((issue) => ({
+    path: issue.path.join(".") || ROOT_ISSUE_PATH,
+    message: issue.message,
+  }));
+}
+
+// Decide what the client tile gets to see of a service's widget:
+// - no widget → nothing
+// - unknown type → sanitized pass-through, so the renderer surfaces the typo
+// - known type with valid config → sanitized widget
+// - known type with missing/invalid config → sanitized widget + the schema
+//   issues, so the tile can show a warning badge instead of silently
+//   downgrading to a plain link
+// Config (credentials) never leaves the server either way.
+export function resolveTileWidget(widget?: ServiceWidget): TileWidget | undefined {
+  if (!widget) return undefined;
+  const def = getWidget(widget.type);
+  const issues = def ? widgetConfigIssues(def, widget.config) : [];
+  return {
+    type: widget.type,
+    refresh_interval_ms: widget.refresh_interval_ms,
+    ...(issues.length > 0 ? { invalid: issues } : {}),
+  };
+}


### PR DESCRIPTION
Implements **Broken-widget feedback** (`docs/Roadmap.md:146`, P2, UX redesign Phase C — see the design note at `docs/plans/2026-07-20-dashboard-ux-redesign.md:231`).

## Problem

When a service's `widget.config` failed its widget's Zod `configSchema`, `resolveTileWidget()` computed the validation issues and then threw them away, returning `undefined`. The tile silently degraded to a plain link with no indication anything was wrong. The same logic was duplicated in the view-mode grid (`ServiceGrid`) and the edit-mode grid (`EditableServiceGrid`).

## What changed

A tile with an invalid widget config now shows a warning badge. Its tooltip lists the specific problems, and clicking it opens the service editor scrolled to the widget section, focused on the first invalid field, with the errors listed.

- **`src/widgets/tileWidget.ts` (new)** — one shared `resolveTileWidget()` replacing the two copies, now carrying the schema issues through to the tile as `TileWidget.invalid`.
- **`ServiceTile`** — `WidgetConfigBadge`, following the existing `Kebab` pattern (a `span` with `role="button"` plus event guards, since the tile root is an `<a>` and a nested `<button>` would be invalid HTML). Degrades to a non-interactive `role="img"` variant when there's no edit-mode provider or `canEdit` is false.
- **`EditModeProvider`** — `pendingEditService` / `requestServiceEdit(name)` plumbing. `ServiceForm` was previously reachable only from the edit-mode kebab menu; a view-mode badge now has a path to it. Also exports `useEditModeOptional()` so `ServiceTile` stays renderable standalone.
- **`ServiceForm`** — lists the real Zod issues via the same shared helper the badge tooltip uses, so the two can't drift. Adds `focusWidget`.
- **`globals.css`** — a `--color-warning` token in all five themes plus the badge styles.

Unknown widget *types* are deliberately unchanged — they still surface through `WidgetRenderer`'s "Unknown widget type" box.

## Behaviour change worth noting

**The badge and the status dot share one slot and are mutually exclusive.** While a widget config is invalid, that tile shows the badge instead of its reachability dot; the dot returns once the config is valid. A broken config is the more actionable signal and the one the user can fix from the tile.

This replaced an earlier bottom-left placement that was a confirmed visual bug: on a `normal` 1×1 tile — and at the mobile breakpoint, where every preset collapses to 1×1 — the badge rendered on top of the wrapped description. The `padding-bottom` reserve meant to prevent it never worked, because the tile is a fixed-height grid item, so the padding shrank the content box instead of moving the text. The top-right corner is chrome-only, so the collision is now structurally impossible rather than mitigated. (This also removed the only `:has()` rule in the stylesheet.)

## Security

Only a Zod issue's `path` and `message` cross the server/client boundary — never the offending input value. Widget configs hold credentials, and `TileWidget` exists precisely so config never reaches the browser. `src/__tests__/widgets/tileWidget.test.ts` enforces this: it feeds a secret-bearing invalid config through and asserts the secret appears nowhere in the serialized result.

## Notes for review

- The badge is a bare 16px glyph with no background fill, matching the bare status dot whose slot it takes. Contrast measured against each theme's actual tile background: dark 8.10:1, oled 9.22:1, high-contrast 6.80:1, light 3.19:1 — all above the 3:1 WCAG bar for graphical objects, though **light is close to it**; darkening light's `--color-warning` toward `#b45309` would buy margin if you want it.
- Hover is a colour shift plus a slight scale, and `:focus-visible` has its own outline. The earlier version set `outline: none` and used a background shift as the focus indicator, which would have made keyboard focus invisible once the background was dropped.
- The empty-config case keeps the original friendly hint instead of showing a wall of "Required" errors on a widget type the user just picked; specific issues appear once they've entered something, or when arriving from a badge click.
- Tile *size* still comes from `getWidgetSizeHints(service.widget.type)` regardless of validity, so a broken widget still reserves widget-sized space while rendering nothing in it. That predates this PR and is left alone.

## Testing

- `npm run lint` clean (2 pre-existing warnings in untouched files), `npm run type-check` clean, `npm test` 1353/1353 passing across 96 files.
- New: `src/__tests__/widgets/tileWidget.test.ts`, badge coverage in `ServiceTile.test.tsx` (including badge/status-dot mutual exclusion), reducer coverage in `EditModeProvider.test.tsx`, dialog-seeding coverage in `EditableServiceGrid.test.tsx`, form coverage in `ServiceForm.test.tsx`, and `e2e/tests/widget-badge.spec.ts`.
- The e2e "valid sibling" control is a widget whose config genuinely passes its schema and whose *data fetch* fails against a dead port — so it also proves a runtime failure doesn't raise the config badge.
- Layout was verified by measuring badge/description bounding boxes in a real browser at desktop and mobile widths: no intersections.
- No visual-regression snapshot was added — a baseline can't be generated in the dev container (pinned Playwright browser revision 1208 vs. the 1194 available, CDN blocked by egress policy), and a mismatched baseline is worse than none. Worth a follow-up if you want the badge covered by `visual.spec.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added warning badges for tiles with invalid widget configuration.
  * Users with edit permission can select the badge to open the service editor and focus on the widget settings.
  * Widget configuration feedback now distinguishes missing, invalid and correctly configured states.

* **Documentation**
  * Added troubleshooting guidance for invalid widget configuration.

* **Tests**
  * Added comprehensive coverage for badge display, accessibility, editing interactions and widget validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->