### PR TITLE
fix: verify Docker publication before release succeeds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,12 @@
 name: Publish Docker Image
 
 on:
+  workflow_call:
+    inputs:
+      tag:
+        description: Existing GitHub Release tag to publish.
+        required: true
+        type: string
   release:
     types: [published]
   workflow_dispatch:
@@ -28,20 +34,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+          ref: ${{ github.event.release.tag_name || inputs.tag }}
 
       - name: Resolve release info
         id: release_info
         run: |
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            IS_PRERELEASE=$(gh release view "$TAG" --json isPrerelease -q .isPrerelease)
-          else
+          if [ "${{ github.event_name }}" = "release" ]; then
             IS_PRERELEASE="${{ github.event.release.prerelease }}"
+          else
+            IS_PRERELEASE=$(gh release view "$TAG" --json isPrerelease -q .isPrerelease)
           fi
           echo "prerelease=$IS_PRERELEASE" >> "$GITHUB_OUTPUT"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ inputs.tag }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -74,3 +80,32 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Verify published image tags
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          IS_PRERELEASE: ${{ steps.release_info.outputs.prerelease }}
+        run: |
+          VERSION="${TAG#v}"
+          tags=("$TAG" "$VERSION")
+          if [ "$IS_PRERELEASE" != "true" ]; then
+            tags+=("${VERSION%.*}" latest)
+          fi
+
+          for tag in "${tags[@]}"; do
+            for attempt in 1 2 3 4 5 6; do
+              if docker buildx imagetools inspect "$IMAGE:$tag" > /dev/null; then
+                echo "Verified $IMAGE:$tag"
+                break
+              fi
+
+              if [ "$attempt" = "6" ]; then
+                echo "::error::Timed out waiting for $IMAGE:$tag"
+                exit 1
+              fi
+
+              echo "Waiting for $IMAGE:$tag (attempt $attempt of 6)"
+              sleep 10
+            done
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,11 @@ jobs:
         run: |
           git tag "v$VERSION"
           git push origin "v$VERSION"
-          gh release create "v$VERSION" --title "v$VERSION" --generate-notes
+          RELEASE_FLAGS=()
+          if [[ "$VERSION" == *-* ]]; then
+            RELEASE_FLAGS+=(--prerelease)
+          fi
+          gh release create "v$VERSION" --title "v$VERSION" --generate-notes "${RELEASE_FLAGS[@]}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      actions: write
     steps:
       - uses: actions/checkout@v6
         with:
@@ -98,12 +97,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ inputs.version }}
 
-      - name: Trigger Docker publish
-        run: |
-          # The release we just created was authored by GITHUB_TOKEN, so GitHub
-          # suppresses the "release published" event that would normally trigger
-          # publish.yml (loop prevention). Dispatch it explicitly instead.
-          gh workflow run publish.yml -f "tag=v$VERSION"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ inputs.version }}
+
+  publish:
+    name: Publish and verify Docker image
+    needs: release
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag: v${{ inputs.version }}
+    secrets: inherit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,11 +82,13 @@ A self-hosted personal dashboard / homepage — a modern alternative to Homepage
 2. **Bump the version on `main` via a PR** (Actions can't do this step, so do it directly):
    - Create a branch off `main`, run `npm version <version> --no-git-tag-version`, commit `package.json` + `package-lock.json`, push.
    - Open a PR into `main` (`mcp__github__create_pull_request`) and merge it (`mcp__github__merge_pull_request`, squash).
-3. **Trigger the release workflow**: `mcp__github__actions_run_trigger`, method `run_workflow`, `workflow_id: release.yml`, `ref: main`, `inputs: {"version": "<version>"}`. It runs the full test gate (lint, type-check, unit, E2E), checks `package.json` matches the input version, tags `vX.Y.Z`, and creates the GitHub Release.
-4. **Docker publish**: `release.yml`'s last step explicitly dispatches `.github/workflows/publish.yml` (`gh workflow run publish.yml -f tag=vX.Y.Z`) rather than relying on the `release: published` event — GitHub suppresses events authored by `GITHUB_TOKEN` to prevent recursive workflow runs, so the release `release.yml` creates would never auto-trigger `publish.yml` otherwise. (Releases made by an actual human via the GitHub UI still trigger it normally through the `release` event.)
-5. **Verify**: check the release workflow run, the new tag/release, and that the publish workflow run for the new tag succeeded (`mcp__github__actions_list`, `mcp__github__list_releases`). Then inspect GHCR and confirm `vX.Y.Z`, `X.Y.Z`, and `X.Y` exist; stable releases must also update `latest`.
+3. **Trigger the release workflow**: `mcp__github__actions_run_trigger`, method `run_workflow`, `workflow_id: release.yml`, `ref: main`, `inputs: {"version": "<version>"}`. It runs the full test gate (lint, type-check, unit, E2E), checks `package.json` matches the input version, tags `vX.Y.Z`, creates the GitHub Release, then calls the Docker workflow.
+4. **Docker publish and verification**: `release.yml` calls `.github/workflows/publish.yml` as a dependent reusable workflow. It pushes the image and verifies its GHCR manifests before the release run can succeed. GitHub UI releases still trigger `publish.yml` through `release: published`; the workflow remains manually runnable for recovery.
+5. **Verify**: a successful Create Release run already includes verified Docker publication. Check the new tag/release and inspect GHCR when needed: `vX.Y.Z`, `X.Y.Z`, and `X.Y` must exist; stable releases must also update `latest`.
 
 If `release.yml`'s "Verify package.json version matches input" step fails, it means step 2 was skipped or used the wrong version — fix the PR, then re-run.
+
+If Docker publication fails, the tag and GitHub Release remain but the release run is marked failed. Fix the cause, manually run `publish.yml` for the existing `vX.Y.Z` tag, then confirm its expected GHCR tags.
 
 ---
 

--- a/docs/DOCKER_RELEASES.md
+++ b/docs/DOCKER_RELEASES.md
@@ -39,7 +39,7 @@ Kokpit uses **semantic versioning**: `MAJOR.MINOR.PATCH`
 
 **Pre-releases** (e.g., `v0.2.0-beta.1`, `v0.2.0-rc.1`):
 - Use when features are still being tested
-- Mark as "Pre-release" on GitHub
+- The release workflow automatically marks versions with a suffix as "Pre-release" on GitHub
 - Only produce version-specific tags: `v0.2.0-beta.1` and `0.2.0-beta.1`
 - **Do NOT** get the `latest` tag (users avoid pre-releases by default)
 

--- a/docs/DOCKER_RELEASES.md
+++ b/docs/DOCKER_RELEASES.md
@@ -10,20 +10,21 @@ Kokpit publishes pre-built Docker images to [GitHub Container Registry](https://
 
 ## Publishing Workflow
 
-The release process is driven by two workflows and a `workflow_dispatch` trigger — not by manually creating a release through the GitHub UI:
+The normal release process is driven by two workflows and a `workflow_dispatch` trigger. Releases created through the GitHub UI remain supported and use the same publish-and-verify workflow.
 
 1. **Bump `package.json`/`package-lock.json` on `main` via a merged PR.** `main` requires a PR for every change (GitHub Actions can't open/merge its own PRs in this repo, so this step can't happen inside CI).
 2. **Run `release.yml`** (`workflow_dispatch`, input: `version`, e.g. `0.2.6`). It:
    - Runs the full test gate (lint, type-check, unit tests, E2E, auth E2E)
    - Verifies `package.json` on `main` matches the input version (fails otherwise — go back to step 1)
    - Tags `vX.Y.Z` and creates the GitHub Release (`gh release create --generate-notes`)
-   - Explicitly dispatches `publish.yml` for that tag
+   - Calls `publish.yml` as a dependent reusable workflow for that tag
 3. **`publish.yml` builds and pushes the Docker image:**
    - Builds the Docker image (using the `runner` stage)
    - Pushes to GHCR with appropriate tags
    - Creates metadata labels (version, source, docs)
+   - Verifies every expected GHCR image manifest before it completes
 
-Releases created by `release.yml` are authored by `GITHUB_TOKEN`, and GitHub suppresses the `release: published` event for token-authored releases (loop prevention) — so `release.yml`'s last step dispatches `publish.yml` directly (`gh workflow run publish.yml -f tag=vX.Y.Z`) instead of relying on that event. A release made by an actual human through the GitHub UI still triggers `publish.yml` normally via the `release: published` event, since `workflow_dispatch` is only the fallback path for token-authored releases.
+Releases created by `release.yml` are authored by `GITHUB_TOKEN`, and GitHub suppresses the `release: published` event for token-authored releases (loop prevention). Instead of dispatching a detached run, `release.yml` calls `publish.yml` as a reusable workflow and waits for it. A release made by an actual human through the GitHub UI still triggers `publish.yml` through the normal `release: published` event and receives the same manifest verification.
 
 ## Versioning Strategy
 
@@ -91,26 +92,26 @@ Commit `package.json` + `package-lock.json`, push, open a PR into `main`, and me
 
 ### Step 2: Run the release workflow
 
-Go to **Actions → Create Release → Run workflow**, select `main`, and enter the version (no `v` prefix, e.g. `0.2.6`). This runs the full test gate first, then — only if it passes — verifies the version, tags `v0.2.6`, creates the GitHub Release, and dispatches `publish.yml`.
+Go to **Actions → Create Release → Run workflow**, select `main`, and enter the version (no `v` prefix, e.g. `0.2.6`). This runs the full test gate first, then — only if it passes — verifies the version, tags `v0.2.6`, creates the GitHub Release, and waits for `publish.yml` to publish and verify the image.
 
 If the "Verify package.json version matches input" step fails, Step 1 was skipped or used the wrong version — fix the PR and re-run.
 
 ### Step 3: Verify in GHCR
 
-Once `release.yml` completes and the `publish.yml` run it triggers finishes (check **Actions**):
+Once `release.yml` succeeds, GHCR manifest verification has completed as part of that run. As an additional check:
 1. Go to [Container Registry](https://github.com/pmyszczynski/kokpit/pkgs/container/kokpit)
 2. Confirm all expected tags appear: `v0.2.6`, `0.2.6`, and `0.2`; stable releases must also have `latest`
 3. Check the tag details for image size and build info
 
 ### Alternative: publishing a pre-existing manual release
 
-A release created directly through the GitHub UI (rather than via `release.yml`) still triggers `publish.yml` automatically through the normal `release: published` event — the `workflow_dispatch` trigger on `publish.yml` exists only as a fallback for `release.yml`'s token-authored releases, not as the primary path.
+A release created directly through the GitHub UI (rather than via `release.yml`) still triggers `publish.yml` automatically through the normal `release: published` event. `publish.yml` is also reusable by `release.yml` and can be manually dispatched with its `tag` input to recover a failed publication.
 
 ## Workflow Details
 
 **File:** `.github/workflows/publish.yml`
 
-**Trigger:** `release` event (published), or `workflow_dispatch` with a `tag` input — the latter is what `release.yml` uses, since token-authored releases don't fire the `release` event.
+**Trigger:** `release` event (published), `workflow_call` with a `tag` input (used by `release.yml`), or `workflow_dispatch` with a `tag` input (for recovery).
 
 **Steps:**
 1. Checkout code
@@ -121,7 +122,8 @@ A release created directly through the GitHub UI (rather than via `release.yml`)
    - `type=raw` → the exact release tag (for example, `v0.2.0`)
    - `type=raw,value=latest` → only if not a pre-release
 5. Build and push only the `runner` stage (minimal production image)
-6. Cache build layers in GitHub Actions cache (faster next build)
+6. Verify each expected GHCR manifest with bounded retries, allowing for registry propagation
+7. Cache build layers in GitHub Actions cache (faster next build)
 
 **Output tags for `v0.2.0` (stable):**
 ```
@@ -186,26 +188,31 @@ docker compose up kokpit  # Update docker-compose.yml to pull instead of build
 
 ## Troubleshooting
 
-### Workflow failed to push image
+### Release or Docker publish workflow failed
 
 **Check:**
 1. Go to [Actions tab](https://github.com/pmyszczynski/kokpit/actions)
-2. Find the failed run under "Publish Docker Image"
-3. Click to see error logs
+2. Open the failed "Create Release" run or "Publish Docker Image" run
+3. Read the failed job's logs, including `Verify published image tags`
 
 **Common causes:**
 - Release was marked as pre-release (check via Edit Release)
 - Tag doesn't follow semver (use `v0.2.0` not `0.2.0` or `release-0.2.0`)
 - GitHub token issue (shouldn't happen with standard setup)
+- GHCR propagation did not complete before the bounded verification retry limit
+
+The tag and GitHub Release are intentionally preserved after a publish failure,
+but the release is incomplete. Correct the cause, run **Actions → Publish Docker
+Image → Run workflow** with the existing release tag (for example, `v0.2.6`),
+then confirm all expected tags in GHCR.
 
 ### Image not appearing in GHCR
 
-1. Workflow may still be running (check Actions)
-2. Check if release was published (not in draft)
-3. Try re-running the workflow:
-   - Go to Actions → Publish Docker Image
-   - Find the run
-   - Click "Re-run all jobs"
+1. Check whether the release or publish workflow failed (a successful release run
+   has already verified the manifests)
+2. Check if the GitHub Release was published (not a draft)
+3. Correct the reported cause and manually run `publish.yml` for the existing
+   release tag, as described above
 
 ### Want to test the workflow without a public release
 

--- a/docs/superpowers/plans/2026-07-25-synchronous-release-publish.md
+++ b/docs/superpowers/plans/2026-07-25-synchronous-release-publish.md
@@ -1,0 +1,264 @@
+# Synchronous Docker Release Publishing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make a successful Create Release workflow prove that all promised Docker image tags are available from GHCR.
+
+**Architecture:** Convert `publish.yml` into a reusable workflow while retaining its GitHub Release and manual-dispatch triggers. `release.yml` will call that workflow as a dependent job; the publishing workflow will inspect the expected GHCR manifests after it pushes them and fail on a bounded retry timeout.
+
+**Tech Stack:** GitHub Actions reusable workflows, Docker Buildx `imagetools inspect`, Vitest, YAML workflow parser.
+
+## Global Constraints
+
+- `main` changes must go through a PR; do not change the prior version-bump PR requirement.
+- A stable `vX.Y.Z` must publish `vX.Y.Z`, `X.Y.Z`, `X.Y`, and `latest`.
+- A pre-release `vX.Y.Z-suffix` must publish only `vX.Y.Z-suffix` and `X.Y.Z-suffix`.
+- Preserve the GitHub Release and git tag after a publishing failure; the workflow must show the incomplete release by failing.
+- Keep GitHub UI Release publishing and `publish.yml` manual dispatch working.
+- Do not add registry credentials, third-party services, or dependencies.
+
+---
+
+## File Structure
+
+| File | Responsibility |
+| --- | --- |
+| `.github/workflows/publish.yml` | Build, push, and confirm Docker tags for release, manual, and reusable-workflow invocations. |
+| `.github/workflows/release.yml` | Test, tag, create the GitHub Release, and synchronously call Docker publishing. |
+| `src/__tests__/workflows/publish.test.ts` | Parse both workflows and guard their release/publish contract. |
+| `AGENTS.md` | Concise release process for maintainers and agents. |
+| `docs/DOCKER_RELEASES.md` | Detailed release behavior and incomplete-release recovery instructions. |
+
+### Task 1: Test and implement the synchronous release contract
+
+**Files:**
+- Modify: `.github/workflows/publish.yml:3-76`
+- Modify: `.github/workflows/release.yml:11-109`
+- Modify: `src/__tests__/workflows/publish.test.ts:1-28`
+
+**Interfaces:**
+- Consumes: the release input `inputs.version` (`X.Y.Z` or `X.Y.Z-suffix`) and an existing GitHub Release named `v${version}`.
+- Produces: a reusable `.github/workflows/publish.yml` workflow accepting `inputs.tag: string`; the release job calls it as a dependent `publish` job.
+- Produces: a `Verify published image tags` step that resolves `$TAG` to the exact release tag and invokes `docker buildx imagetools inspect "$IMAGE:$tag"` for every expected image tag.
+
+- [ ] **Step 1: Write failing workflow-parser tests**
+
+Replace the narrow metadata helper with helpers that parse both workflow files and locate named steps. Add these assertions:
+
+```ts
+const publishWorkflow = parseWorkflow(".github/workflows/publish.yml");
+const releaseWorkflow = parseWorkflow(".github/workflows/release.yml");
+const releaseTag = "${{ github.event.release.tag_name || inputs.tag }}";
+
+expect(publishWorkflow.on.workflow_call.inputs.tag).toMatchObject({
+  required: true,
+  type: "string",
+});
+
+expect(checkoutStep.with.ref).toBe(releaseTag);
+expect(verificationStep.run).toContain("docker buildx imagetools inspect");
+expect(verificationStep.run).toContain('tags=("$TAG" "$VERSION")');
+expect(verificationStep.run).toContain('tags+=("${VERSION%.*}" latest)');
+expect(verificationStep.run).toContain("for attempt in 1 2 3 4 5 6");
+
+expect(releaseWorkflow.jobs.publish.needs).toBe("release");
+expect(releaseWorkflow.jobs.publish.uses).toBe("./.github/workflows/publish.yml");
+expect(releaseWorkflow.jobs.publish.with.tag).toBe("v${{ inputs.version }}");
+expect(JSON.stringify(releaseWorkflow)).not.toContain("gh workflow run publish.yml");
+```
+
+Keep the existing assertions that Docker metadata derives exact and minor tags from `releaseTag`.
+
+- [ ] **Step 2: Run the focused test to verify it fails**
+
+Run: `npm test -- src/__tests__/workflows/publish.test.ts`
+
+Expected: FAIL because `publish.yml` does not yet declare `workflow_call` or a verification step, and `release.yml` still dispatches rather than calls publishing.
+
+- [ ] **Step 3: Make `publish.yml` reusable and verify manifests**
+
+Add this trigger before the existing `release` trigger:
+
+```yaml
+  workflow_call:
+    inputs:
+      tag:
+        description: Existing GitHub Release tag to publish.
+        required: true
+        type: string
+```
+
+Use the same expression for every non-shell release-tag consumer:
+
+```yaml
+ref: ${{ github.event.release.tag_name || inputs.tag }}
+```
+
+Set `TAG` in `Resolve release info` to that expression. Treat only a `release`
+event as carrying `github.event.release.prerelease`; query `gh release view
+"$TAG" --json isPrerelease -q .isPrerelease` for both `workflow_call` and
+`workflow_dispatch`.
+
+After `Build and push Docker image`, add:
+
+```yaml
+      - name: Verify published image tags
+        env:
+          IMAGE: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          TAG: ${{ github.event.release.tag_name || inputs.tag }}
+          IS_PRERELEASE: ${{ steps.release_info.outputs.prerelease }}
+        run: |
+          VERSION="${TAG#v}"
+          tags=("$TAG" "$VERSION")
+          if [ "$IS_PRERELEASE" != "true" ]; then
+            tags+=("${VERSION%.*}" latest)
+          fi
+
+          for tag in "${tags[@]}"; do
+            for attempt in 1 2 3 4 5 6; do
+              if docker buildx imagetools inspect "$IMAGE:$tag" > /dev/null; then
+                echo "Verified $IMAGE:$tag"
+                break
+              fi
+
+              if [ "$attempt" = "6" ]; then
+                echo "::error::Timed out waiting for $IMAGE:$tag"
+                exit 1
+              fi
+
+              echo "Waiting for $IMAGE:$tag (attempt $attempt of 6)"
+              sleep 10
+            done
+          done
+```
+
+- [ ] **Step 4: Make `release.yml` wait for publishing**
+
+Remove the `actions: write` permission from the `release` job and delete its
+`Trigger Docker publish` step. Add this peer job after `release`:
+
+```yaml
+  publish:
+    name: Publish and verify Docker image
+    needs: release
+    permissions:
+      contents: read
+      packages: write
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag: v${{ inputs.version }}
+    secrets: inherit
+```
+
+The `release` job creates the existing tag and GitHub Release first. A failure
+in the `publish` job therefore preserves those artifacts and marks the parent
+workflow failed, allowing a manual rerun of `publish.yml` for the same tag.
+
+- [ ] **Step 5: Run the focused test to verify it passes**
+
+Run: `npm test -- src/__tests__/workflows/publish.test.ts`
+
+Expected: PASS with all parser assertions proving the synchronous reusable
+workflow call and post-push verification contract.
+
+- [ ] **Step 6: Commit the functional change**
+
+```bash
+git add .github/workflows/publish.yml .github/workflows/release.yml src/__tests__/workflows/publish.test.ts
+git commit -m "fix: verify Docker publication before release succeeds"
+```
+
+### Task 2: Document verified publishing and recovery
+
+**Files:**
+- Modify: `AGENTS.md:85-89`
+- Modify: `docs/DOCKER_RELEASES.md:13-26,92-113,185-216`
+
+**Interfaces:**
+- Consumes: the release contract from Task 1.
+- Produces: maintainer instructions that define a completed release as a
+  completed GHCR publish plus manifest verification.
+
+- [ ] **Step 1: Update the concise release process**
+
+Replace the asynchronous-dispatch explanation in `AGENTS.md` with these facts:
+
+```markdown
+4. **Docker publish and verification**: after the tag and GitHub Release are
+   created, `release.yml` calls `publish.yml` as a dependent reusable workflow.
+   It pushes the image and verifies its GHCR manifests before the release run
+   can succeed. Human-created GitHub Releases still trigger `publish.yml` via
+   `release: published`; it remains manually runnable for recovery.
+5. **Verify**: a successful Create Release run already includes Docker
+   publication verification. Confirm the tag/release and inspect GHCR when
+   needed; expected stable tags are `vX.Y.Z`, `X.Y.Z`, `X.Y`, and `latest`.
+```
+
+- [ ] **Step 2: Update the detailed Docker release guide**
+
+Change the workflow overview, Step 2/3 instructions, trigger description, and
+troubleshooting text so they state:
+
+1. `release.yml` waits on `publish.yml` through `workflow_call`.
+2. The post-push check retries GHCR manifest inspection for all expected tags.
+3. A failed release run can leave an intentional, visible incomplete release;
+   correct the cause and manually run `publish.yml` with its existing `vX.Y.Z`
+   tag, then confirm the required tags.
+4. A GitHub UI release keeps its normal `release: published` route and performs
+   the same verification within `publish.yml`.
+
+- [ ] **Step 3: Verify documentation formatting and links**
+
+Run: `git diff --check && rg -n "dispatches `publish.yml`|gh workflow run publish.yml|workflow_call|incomplete release" AGENTS.md docs/DOCKER_RELEASES.md`
+
+Expected: no whitespace errors; the obsolete dispatch wording is gone and the
+new synchronous/recovery wording appears in both documents.
+
+- [ ] **Step 4: Commit the documentation**
+
+```bash
+git add AGENTS.md docs/DOCKER_RELEASES.md
+git commit -m "docs: describe verified Docker releases"
+```
+
+### Task 3: Perform final validation and open the change for review
+
+**Files:**
+- Verify: `.github/workflows/publish.yml`
+- Verify: `.github/workflows/release.yml`
+- Verify: `src/__tests__/workflows/publish.test.ts`
+- Verify: `AGENTS.md`
+- Verify: `docs/DOCKER_RELEASES.md`
+
+**Interfaces:**
+- Consumes: the functional and documentation changes from Tasks 1 and 2.
+- Produces: a clean, validated branch suitable for a PR into `main`.
+
+- [ ] **Step 1: Run focused workflow tests**
+
+Run: `npm test -- src/__tests__/workflows/publish.test.ts`
+
+Expected: PASS.
+
+- [ ] **Step 2: Run the complete unit suite and lint**
+
+Run: `npm test && npm run lint`
+
+Expected: all unit tests pass; lint exits successfully. Report pre-existing
+warnings separately if any remain.
+
+- [ ] **Step 3: Validate the final diff and branch state**
+
+Run: `git diff origin/main...HEAD --check && git status --short --branch && git log --oneline origin/main..HEAD`
+
+Expected: no whitespace errors, no unrelated files, and only the design, plan,
+workflow/test, and documentation commits on the branch.
+
+- [ ] **Step 4: Push and open a PR**
+
+```bash
+git push -u origin codex/synchronous-release-publish
+gh pr create --base main --head codex/synchronous-release-publish \
+  --title "fix: verify Docker publication before release succeeds" \
+  --body "Makes Docker publishing a synchronous release dependency and verifies expected GHCR tags after each push."
+```

--- a/docs/superpowers/specs/2026-07-25-synchronous-release-publish-design.md
+++ b/docs/superpowers/specs/2026-07-25-synchronous-release-publish-design.md
@@ -1,0 +1,112 @@
+# Synchronous Docker Release Publishing Design
+
+## Goal
+
+A successful `Create Release` workflow must mean that the release's Docker
+image is available from GHCR under every tag promised by the project. The
+workflow must fail if publishing or subsequent registry verification fails.
+
+## Context
+
+`release.yml` currently creates the git tag and GitHub Release, then starts
+`publish.yml` with `gh workflow run`. Dispatching is asynchronous, so the
+release workflow can report success before Docker publishing has failed. The
+previous tag regression occurred in that blind spot: workflow configuration was
+valid enough to run, but GHCR did not receive the expected versioned tags.
+
+The existing `publish.yml` must remain directly runnable for releases created
+by a human in the GitHub UI, because a `release: published` event still
+triggers it. It must also remain manually dispatchable to repair a published
+release.
+
+## Design
+
+### Reuse `publish.yml` from `release.yml`
+
+Add a `workflow_call` trigger to `publish.yml` with a required string `tag`
+input. It keeps its existing `release: published` and `workflow_dispatch`
+triggers.
+
+Replace the `Trigger Docker publish` step in `release.yml` with a `publish`
+job that:
+
+1. Depends on the successful `release` job.
+2. Calls `./.github/workflows/publish.yml` from the same commit.
+3. Passes `v${{ inputs.version }}` as the `tag` input.
+4. Grants only the permissions needed for the called workflow to push to GHCR
+   (`contents: read`, `packages: write`) and inherits the repository token.
+
+Using a reusable workflow makes Docker publishing a synchronous dependency of
+the release workflow. The release run finishes only after the called workflow
+finishes.
+
+### Resolve release information consistently
+
+`publish.yml` derives the release tag from `inputs.tag` for `workflow_call`
+and `workflow_dispatch`, and from `github.event.release.tag_name` for GitHub
+Release events. The checkout reference and Docker metadata rules use that
+resolved tag.
+
+For the two non-release-event triggers, it queries the existing GitHub Release
+to determine whether it is a pre-release. This preserves the current
+stable-versus-pre-release policy for all entry points.
+
+### Verify published manifests
+
+Immediately after `docker/build-push-action` completes, add a `Verify published
+image tags` step. It authenticates using the preceding registry login and uses
+`docker buildx imagetools inspect` to confirm that each expected image manifest
+is retrievable from GHCR.
+
+The expected tags are derived from the same release tag used for Docker
+metadata:
+
+| Release type | Required GHCR tags |
+| --- | --- |
+| Stable `vX.Y.Z` | `vX.Y.Z`, `X.Y.Z`, `X.Y`, `latest` |
+| Pre-release `vX.Y.Z-suffix` | `vX.Y.Z-suffix`, `X.Y.Z-suffix` |
+
+Each tag is retried a small, bounded number of times with a short delay to
+allow for registry propagation. Failure after the final retry fails the
+publish workflow and, when called from `release.yml`, fails the entire release
+run.
+
+## Failure Semantics
+
+The git tag and GitHub Release are created before image publishing starts. If
+publishing or manifest verification fails, they remain in place; the release
+workflow is marked failed and documents an incomplete release. An operator can
+correct the cause and re-run `publish.yml` for the same tag without creating a
+second release. The design deliberately does not delete a release or tag on a
+failure, avoiding destructive automatic rollback.
+
+## Tests
+
+Extend the workflow-parser tests to verify:
+
+1. `publish.yml` supports `workflow_call` with a required tag input.
+2. Docker metadata and checkout resolve the invoked tag correctly.
+3. The post-push verification step uses `docker buildx imagetools inspect`,
+   checks both exact tags, conditionally checks stable aliases, and has bounded
+   retries.
+4. `release.yml` has a dependent reusable-workflow `publish` job, passes the
+   `v`-prefixed version, and no longer dispatches Docker publishing with
+   `gh workflow run`.
+
+The existing unit test suite remains the validation command for these parser
+tests. CI then validates the workflow syntax and the next release exercises the
+end-to-end GHCR verification path.
+
+## Documentation
+
+Update `AGENTS.md` and `docs/DOCKER_RELEASES.md` to say that a completed
+release run includes completed, verified Docker publication. Document the
+incomplete-release recovery path: correct the issue, re-run `publish.yml` for
+the existing tag, and confirm the expected GHCR tags.
+
+## Non-goals
+
+- Releasing a version without a prior version-bump PR.
+- Automatically deleting tags or GitHub Releases after a publish failure.
+- Changing which image tags stable and pre-release versions receive.
+- Adding a new external registry, secret, or cloud dependency.

--- a/src/__tests__/workflows/publish.test.ts
+++ b/src/__tests__/workflows/publish.test.ts
@@ -5,24 +5,85 @@ import { parseDocument } from "yaml";
 
 const releaseTag = "${{ github.event.release.tag_name || inputs.tag }}";
 
-function publishMetadataTags() {
-  const workflow = parseDocument(
-    readFileSync(resolve(process.cwd(), ".github/workflows/publish.yml"), "utf8"),
-  ).toJS();
-  const steps = workflow.jobs["build-and-push"].steps;
-  const metadataStep = steps.find(
-    (step: { uses?: string }) => step.uses === "docker/metadata-action@v6",
+type Workflow = {
+  on: Record<string, unknown>;
+  jobs: Record<string, Record<string, unknown>>;
+};
+
+type WorkflowStep = {
+  name?: string;
+  uses?: string;
+  with?: Record<string, string>;
+  run?: string;
+};
+
+function readWorkflow(path: string): Workflow {
+  return parseDocument(readFileSync(resolve(process.cwd(), path), "utf8")).toJS() as Workflow;
+}
+
+function publishSteps(workflow: Workflow): WorkflowStep[] {
+  return workflow.jobs["build-and-push"].steps as WorkflowStep[];
+}
+
+function findStep(steps: WorkflowStep[], name: string): WorkflowStep {
+  const step = steps.find((candidate) => candidate.name === name);
+
+  if (!step) {
+    throw new Error(`Missing workflow step: ${name}`);
+  }
+
+  return step;
+}
+
+function findMetadataStep(steps: WorkflowStep[]): WorkflowStep {
+  const step = steps.find(
+    (candidate) => candidate.uses === "docker/metadata-action@v6",
   );
 
-  return metadataStep.with.tags as string;
+  if (!step) {
+    throw new Error("Missing Docker metadata step");
+  }
+
+  return step;
 }
 
 describe("Docker publish workflow", () => {
   it("derives version tags from the release tag for manual dispatches", () => {
-    const tags = publishMetadataTags();
+    const publishWorkflow = readWorkflow(".github/workflows/publish.yml");
+    const metadataStep = findMetadataStep(publishSteps(publishWorkflow));
+    const tags = metadataStep.with?.tags;
 
     expect(tags).toContain(`type=semver,pattern={{version}},value=${releaseTag}`);
     expect(tags).toContain(`type=semver,pattern={{major}}.{{minor}},value=${releaseTag}`);
     expect(tags).toContain(`type=raw,value=${releaseTag}`);
+  });
+
+  it("verifies every expected image tag after publishing", () => {
+    const publishWorkflow = readWorkflow(".github/workflows/publish.yml");
+    const steps = publishSteps(publishWorkflow);
+    const checkoutStep = findStep(steps, "Checkout code");
+    const verificationStep = findStep(steps, "Verify published image tags");
+    const workflowCall = publishWorkflow.on.workflow_call as {
+      inputs?: Record<string, { required?: boolean; type?: string }>;
+    };
+
+    expect(workflowCall.inputs?.tag).toMatchObject({ required: true, type: "string" });
+    expect(checkoutStep.with?.ref).toBe(releaseTag);
+    expect(verificationStep.run).toContain("docker buildx imagetools inspect");
+    expect(verificationStep.run).toContain('tags=("$TAG" "$VERSION")');
+    expect(verificationStep.run).toContain('tags+=("${VERSION%.*}" latest)');
+    expect(verificationStep.run).toContain("for attempt in 1 2 3 4 5 6");
+  });
+});
+
+describe("Create Release workflow", () => {
+  it("waits for Docker publication to complete", () => {
+    const releaseWorkflow = readWorkflow(".github/workflows/release.yml");
+    const publishJob = releaseWorkflow.jobs.publish;
+
+    expect(publishJob.needs).toBe("release");
+    expect(publishJob.uses).toBe("./.github/workflows/publish.yml");
+    expect((publishJob.with as Record<string, string>).tag).toBe("v${{ inputs.version }}");
+    expect(JSON.stringify(releaseWorkflow)).not.toContain("gh workflow run publish.yml");
   });
 });

--- a/src/__tests__/workflows/publish.test.ts
+++ b/src/__tests__/workflows/publish.test.ts
@@ -86,4 +86,14 @@ describe("Create Release workflow", () => {
     expect((publishJob.with as Record<string, string>).tag).toBe("v${{ inputs.version }}");
     expect(JSON.stringify(releaseWorkflow)).not.toContain("gh workflow run publish.yml");
   });
+
+  it("marks suffixed versions as GitHub prereleases", () => {
+    const releaseWorkflow = readWorkflow(".github/workflows/release.yml");
+    const releaseSteps = releaseWorkflow.jobs.release.steps as WorkflowStep[];
+    const tagAndReleaseStep = findStep(releaseSteps, "Tag and release");
+
+    expect(tagAndReleaseStep.run).toContain('if [[ "$VERSION" == *-* ]]; then');
+    expect(tagAndReleaseStep.run).toContain("RELEASE_FLAGS+=(--prerelease)");
+    expect(tagAndReleaseStep.run).toContain('"${RELEASE_FLAGS[@]}"');
+  });
 });


### PR DESCRIPTION
## Summary

- Make Docker publishing a synchronous dependency of Create Release.
- Verify every expected GHCR manifest after pushing, with bounded propagation retries.
- Mark suffixed versions as GitHub prereleases so they cannot update stable aliases.
- Document verified releases and recovery of incomplete publications.

## Root cause

Create Release previously dispatched Docker publishing asynchronously, so it could report success before the registry publish failed. It also accepted prerelease versions without marking the GitHub Release as a pre-release.

## Validation

- npm test (96 files, 1,312 tests)
- npm run lint (two pre-existing warnings, no errors)
- Independent workflow review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Improvements**
  - Docker images are now published and verified as part of the release process, reducing the chance of incomplete releases.
  - Pre-release versions are automatically identified and marked correctly.
  - Failed image publication can be retried for an existing release without creating a new release.

- **Documentation**
  - Release guidance now explains image verification, expected tags, troubleshooting, and recovery steps.
  - Added planning and design documentation for the updated synchronous release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->