### PR TITLE
fix: healthcheck probes 127.0.0.1 instead of localhost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,8 +76,14 @@ EXPOSE 3000
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
 
+# Probe 127.0.0.1, not "localhost". The server binds $HOSTNAME (0.0.0.0), which
+# is IPv4-only, but Docker's /etc/hosts maps "localhost" to both 127.0.0.1 and
+# ::1. musl's resolver can return ::1 first, and BusyBox wget only ever tries
+# the first address it gets back — no fallback to the next one — so the probe
+# would be refused on [::1]:3000 and mark a perfectly healthy container as
+# unhealthy. $PORT is honored so overriding the listen port keeps the probe valid.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
-  CMD wget -qO- http://localhost:3000/api/health || exit 1
+  CMD wget -qO- "http://127.0.0.1:${PORT:-3000}/api/health" || exit 1
 
 ENTRYPOINT ["./docker-entrypoint.sh"]
 CMD ["node", "server.js"]

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ services:
       - ./data:/data
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      # Probe 127.0.0.1 rather than "localhost" — inside the container
+      # "localhost" also resolves to ::1, which nothing listens on.
+      test: ["CMD-SHELL", "wget -qO- \"http://127.0.0.1:$${PORT:-3000}/api/health\" || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,11 @@ services:
       # - /var/run/docker.sock:/var/run/docker.sock:ro
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+      # 127.0.0.1, not "localhost": the server binds 0.0.0.0 (IPv4-only) while
+      # "localhost" also resolves to ::1 inside the container, and BusyBox wget
+      # never falls back past the first address it resolves. $$PORT is escaped
+      # so the container's shell expands it, not Compose.
+      test: ["CMD-SHELL", "wget -qO- \"http://127.0.0.1:$${PORT:-3000}/api/health\" || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 3

--- a/src/__tests__/workflows/healthcheck.test.ts
+++ b/src/__tests__/workflows/healthcheck.test.ts
@@ -22,17 +22,29 @@ function readCompose(): Compose {
   return parseDocument(readRepoFile("docker-compose.yml")).toJS() as Compose;
 }
 
+// Returns the HEALTHCHECK instruction's command, so an unrelated CMD elsewhere
+// in the Dockerfile can't satisfy the assertions while the probe regresses.
 function dockerfileHealthcheck(): string {
-  const dockerfile = readRepoFile("Dockerfile");
-  const line = dockerfile
+  const instruction = readRepoFile("Dockerfile")
     .split("\n")
-    .find((candidate) => candidate.trimStart().startsWith("CMD wget"));
+    .filter((line) => !line.trimStart().startsWith("#"))
+    .join("\n")
+    // Collapse backslash continuations so each instruction is one line.
+    .replace(/\\\r?\n\s*/g, " ")
+    .split("\n")
+    .find((line) => line.trimStart().startsWith("HEALTHCHECK"));
 
-  if (!line) {
-    throw new Error("Missing HEALTHCHECK CMD in Dockerfile");
+  if (!instruction) {
+    throw new Error("Missing HEALTHCHECK instruction in Dockerfile");
   }
 
-  return line;
+  const command = /\sCMD\s+(.+?)\s*$/.exec(instruction)?.[1];
+
+  if (!command) {
+    throw new Error("HEALTHCHECK instruction has no CMD in Dockerfile");
+  }
+
+  return command;
 }
 
 describe("container healthcheck", () => {

--- a/src/__tests__/workflows/healthcheck.test.ts
+++ b/src/__tests__/workflows/healthcheck.test.ts
@@ -1,0 +1,68 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+import { parseDocument } from "yaml";
+
+// The container healthcheck probes the app over loopback. It must target
+// 127.0.0.1 explicitly: the Next.js standalone server binds $HOSTNAME
+// (0.0.0.0), which is IPv4-only, while Docker's /etc/hosts also maps
+// "localhost" to ::1. BusyBox wget uses only the first address the resolver
+// returns and never falls back, so a "localhost" probe can be refused on
+// [::1]:3000 and mark a healthy container unhealthy.
+
+function readRepoFile(path: string): string {
+  return readFileSync(resolve(process.cwd(), path), "utf8");
+}
+
+type Compose = {
+  services: Record<string, { healthcheck?: { test?: string[] } }>;
+};
+
+function readCompose(): Compose {
+  return parseDocument(readRepoFile("docker-compose.yml")).toJS() as Compose;
+}
+
+function dockerfileHealthcheck(): string {
+  const dockerfile = readRepoFile("Dockerfile");
+  const line = dockerfile
+    .split("\n")
+    .find((candidate) => candidate.trimStart().startsWith("CMD wget"));
+
+  if (!line) {
+    throw new Error("Missing HEALTHCHECK CMD in Dockerfile");
+  }
+
+  return line;
+}
+
+describe("container healthcheck", () => {
+  it("probes 127.0.0.1 in the Dockerfile, never localhost", () => {
+    const command = dockerfileHealthcheck();
+
+    expect(command).toContain("http://127.0.0.1:");
+    expect(command).not.toContain("localhost");
+  });
+
+  it("honors an overridden PORT in the Dockerfile probe", () => {
+    expect(dockerfileHealthcheck()).toContain("${PORT:-3000}");
+  });
+
+  it("probes 127.0.0.1 in docker-compose, never localhost", () => {
+    const test = readCompose().services.kokpit.healthcheck?.test;
+
+    expect(test).toBeDefined();
+    const command = (test as string[]).join(" ");
+
+    expect(command).toContain("http://127.0.0.1:");
+    expect(command).not.toContain("localhost");
+  });
+
+  it("lets the container shell expand PORT in docker-compose", () => {
+    const test = readCompose().services.kokpit.healthcheck?.test as string[];
+
+    // CMD-SHELL is required for expansion, and $$ escapes the variable so
+    // Compose passes it through instead of interpolating it at parse time.
+    expect(test[0]).toBe("CMD-SHELL");
+    expect(test.join(" ")).toContain("$${PORT:-3000}");
+  });
+});


### PR DESCRIPTION
## Problem

The container reports `unhealthy` even though the app serves requests normally on the published port.

## Root cause

The `runner` stage sets `ENV HOSTNAME="0.0.0.0"`, and the Next.js standalone server binds that address. `0.0.0.0` is **IPv4-only** — nothing ever listens on `[::1]:3000`.

The healthcheck probed `http://localhost:3000/api/health`. Inside a Docker container `/etc/hosts` maps `localhost` to *both* addresses:

```
127.0.0.1	localhost
::1		localhost ip6-localhost ip6-loopback
```

Alpine's musl resolver applies RFC 6724 sorting and can return `::1` first. BusyBox `wget` uses only the **first** address `getaddrinfo` returns and never falls back to the next one, so the probe gets `Connection refused` on `::1` and the container is marked unhealthy — while remaining perfectly reachable over IPv4 the whole time.

### Verification

Registry egress is blocked in this environment, so the image itself couldn't be built or pulled. The two mechanisms were confirmed independently against the real standalone build:

- Ran the standalone server with the same env the runner stage sets. It listens on `0.0.0.0:3000` only; `curl` to `[::1]:3000` fails to connect.
- Confirmed BusyBox `wget` does not retry past the first resolved address — given a hostname resolving to a dead address followed by a live listener, it fails on the first and never tries the second:

  ```
  wget: can't connect to remote host (127.0.0.2): Connection refused
  ```

  `curl` succeeds on the same name, which is why manual testing tends to look fine.

## Fix

Probe `127.0.0.1` explicitly, matching what the server actually binds.

Also honor `$PORT` in the probe. It was hardcoded to `3000`, so overriding the listen port produced the same false-unhealthy symptom by a second route. `docker-compose` needs `CMD-SHELL` for the expansion, with `$$` so Compose passes the variable through to the container shell instead of interpolating it at parse time — verified that the unescaped form flattens to `3000` at parse time while the escaped form passes through.

Applied to `Dockerfile`, `docker-compose.yml`, and the deployment snippet in `README.md`.

## Tests

Added `src/__tests__/workflows/healthcheck.test.ts`, following the existing infra-file assertion idiom in that directory. It pins that both healthchecks target `127.0.0.1`, never `localhost`, and that the `PORT` expansion stays intact including the `CMD-SHELL` + `$$` requirements in Compose.

Full gate: 97 files / 1316 tests pass, `type-check` clean, `lint` clean (2 pre-existing warnings, untouched).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PvoUwyZhP7xPukw1NrC52u)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container health checks by explicitly using IPv4 loopback, avoiding failures caused by IPv6 `localhost` resolution.
  * Health checks now respect the configured `PORT` environment variable, defaulting to port 3000.

* **Documentation**
  * Updated container setup instructions to reflect the more reliable health-check configuration.

* **Tests**
  * Added automated coverage to verify Docker and Compose health checks use the correct address and port handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->