### PR TITLE
Add configurable Tautulli activity widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,7 +363,7 @@ services:
   - name: Tautulli
     url: http://192.168.1.x:8181
     group: Media
-    size: large
+    size: tall
     widget:
       type: tautulli-activity
       config:

--- a/README.md
+++ b/README.md
@@ -350,6 +350,54 @@ The widget only contacts `/status/sessions` or `/library/sections` depending on 
 
 ---
 
+### Tautulli
+
+Displays current Plex activity from Tautulli.
+
+**Prerequisites:** Enable Tautulli's API and copy the generated API key.
+
+**YAML example:**
+
+```yaml
+services:
+  - name: Tautulli
+    url: http://192.168.1.x:8181
+    group: Media
+    size: large
+    widget:
+      type: tautulli-activity
+      config:
+        url: http://192.168.1.x:8181
+        api_key: <your-tautulli-api-key>
+        sections:
+          - summary
+          - sessions
+```
+
+**Config fields:**
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `url` | Yes | Base URL of the Tautulli instance, including any HTTP root |
+| `api_key` | Yes | Tautulli API key; used only by Kokpit's server |
+| `sections` | No | Non-empty list containing `summary`, `sessions`, or both; defaults to both |
+
+**Summary:**
+
+| Value | Description |
+| --- | --- |
+| Active | Total active streams |
+| Direct Play | Streams played directly |
+| Direct Stream | Streams direct streamed |
+| Transcoding | Streams currently being transcoded |
+| Bandwidth | Total active streaming bandwidth |
+
+**Sessions:** Each active session displays the username, media title and type, playback state, transcode mode, and progress.
+
+Usernames are intentionally displayed. Email, IP, machine/device IDs, file paths, player/platform details, and artwork are discarded server-side.
+
+---
+
 ### Sonarr
 
 Two widgets are available for Sonarr: a calendar showing upcoming episodes and a download queue monitor.

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -183,7 +183,9 @@ Mark tasks with `[x]` as you complete them. Claude Code will read this state.
   - Home automation: Home Assistant
   - Files / cloud: Nextcloud
   - Security: Vaultwarden, CrowdSec
-  - Analytics: Tautulli, Grafana embed widget
+  - Analytics:
+    - [x] Tautulli — configurable current activity widget (summary, active sessions, or both)
+    - [ ] Grafana embed widget
   - Finance: Actual Budget, Firefly III
 
 - [ ] `P2` **Keyboard shortcuts & global search**

--- a/docs/superpowers/plans/2026-07-25-tautulli-activity-widget.md
+++ b/docs/superpowers/plans/2026-07-25-tautulli-activity-widget.md
@@ -32,8 +32,8 @@ Testing Library, CSS custom properties.
 - Discard email, IP, machine/device, path, player/platform, and artwork fields.
 - Preserve configured reverse-proxy base paths and forward `AbortSignal`.
 - Never include the request URL, query string, or API key in an error.
-- Use `refreshInterval: 10_000`, `preferredSize: "large"`, and
-  `minSize: "wide"`.
+- Use `refreshInterval: 10_000`, `preferredSize: "tall"`, and
+  `minSize: "tall"`.
 - Custom CSS remains able to override widget styles without `!important`.
 - Follow TDD: demonstrate each focused test failing before production changes.
 
@@ -493,8 +493,8 @@ Append registration assertions to `tautulli.test.ts`:
 expect(widget.id).toBe("tautulli-activity");
 expect(widget.name).toBe("Tautulli Activity");
 expect(widget.refreshInterval).toBe(10_000);
-expect(widget.preferredSize).toBe("large");
-expect(widget.minSize).toBe("wide");
+expect(widget.preferredSize).toBe("tall");
+expect(widget.minSize).toBe("tall");
 expect(widget.serviceEditorPreset).toEqual({
   defaultName: "Tautulli",
   defaultIconUrl:
@@ -708,8 +708,8 @@ registerWidget<TautulliConfig, TautulliActivityData>({
   configSchema: TautulliConfigSchema,
   fetchData: fetchActivity,
   refreshInterval: 10_000,
-  preferredSize: "large",
-  minSize: "wide",
+  preferredSize: "tall",
+  minSize: "tall",
   component: TautulliActivityWidget,
   serviceEditorPreset: {
     defaultName: "Tautulli",
@@ -769,7 +769,7 @@ Append a dedicated CSS block. Use these layout constraints:
 .tautulli-activity-widget__summary {
   display: grid;
   flex-shrink: 0;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 4px;
 }
 
@@ -973,7 +973,7 @@ Immediately after the Plex example in `settings.example.yaml`, add:
 #   - name: Tautulli
 #     url: http://192.168.1.x:8181
 #     group: Media
-#     size: large
+#     size: tall
 #     widget:
 #       type: tautulli-activity
 #       config:
@@ -1102,3 +1102,173 @@ git log --oneline -5
 
 Expected: no whitespace errors, no uncommitted implementation changes, and
 separate API, UI, and documentation commits.
+
+---
+
+### Task 5: Tall one-column default and wrapped summary
+
+**Files:**
+
+- Modify: `src/integrations/tautulli/activityWidget.tsx`
+- Modify: `src/app/globals.css`
+- Modify: `src/__tests__/integrations/tautulli.test.ts`
+- Modify: `src/__tests__/integrations/TautulliActivityWidget.test.tsx`
+- Modify: `README.md`
+- Modify: `settings.example.yaml`
+
+**Interfaces:**
+
+- Consumes the existing `tautulli-activity` registration and summary markup.
+- Produces `preferredSize: "tall"` and `minSize: "tall"`.
+- Produces an explicit
+  `tautulli-activity-widget__stat--bandwidth` class on the Bandwidth summary
+  card for full-row placement.
+- Keeps the existing DTO, configuration keys, refresh behavior, and session
+  rendering unchanged.
+
+- [ ] **Step 1: Write the failing layout-contract tests**
+
+In the existing registration test in
+`src/__tests__/integrations/tautulli.test.ts`, change the size assertions to:
+
+```ts
+expect(widget?.preferredSize).toBe("tall");
+expect(widget?.minSize).toBe("tall");
+```
+
+In the summary-rendering test in
+`src/__tests__/integrations/TautulliActivityWidget.test.tsx`, add:
+
+```ts
+expect(screen.getByText("Bandwidth").closest(
+  ".tautulli-activity-widget__stat"
+)).toHaveClass("tautulli-activity-widget__stat--bandwidth");
+```
+
+The production change that makes these tests pass is the new tall registration
+plus the semantic Bandwidth modifier class.
+
+- [ ] **Step 2: Run the focused tests and verify the expected failures**
+
+Run:
+
+```bash
+npx vitest run \
+  src/__tests__/integrations/tautulli.test.ts \
+  src/__tests__/integrations/TautulliActivityWidget.test.tsx
+```
+
+Expected: FAIL because the widget still registers as `large`/`wide` and the
+Bandwidth card does not yet have its modifier class.
+
+- [ ] **Step 3: Change the registration and Bandwidth markup**
+
+In `src/integrations/tautulli/activityWidget.tsx`, change the registration to:
+
+```ts
+preferredSize: "tall",
+minSize: "tall",
+```
+
+Change the summary item metadata so the Bandwidth item can receive its modifier
+class without selecting it by position. The rendered Bandwidth card must
+produce:
+
+```tsx
+<div
+  className="tautulli-activity-widget__stat tautulli-activity-widget__stat--bandwidth"
+>
+  <span className="tautulli-activity-widget__value">
+    {formatBandwidth(data.summary.totalBandwidthKbps)}
+  </span>
+  <span className="tautulli-activity-widget__label">Bandwidth</span>
+</div>
+```
+
+The other four summary cards retain only
+`tautulli-activity-widget__stat`. Do not change labels, values, section
+selection, or session rendering.
+
+- [ ] **Step 4: Wrap summary cards for the narrow tile**
+
+In the existing `@layer tautulli-widget` block in `src/app/globals.css`, use:
+
+```css
+.tautulli-activity-widget__summary {
+  display: grid;
+  flex-shrink: 0;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 4px;
+}
+
+.tautulli-activity-widget__stat--bandwidth {
+  grid-column: 1 / -1;
+}
+```
+
+This yields two summary cards on row one, two on row two, and Bandwidth across
+row three. Keep the session list vertically scrollable and keep all Tautulli
+styles in the lower `tautulli-widget` cascade layer so user custom CSS still
+wins.
+
+- [ ] **Step 5: Align documentation examples with the new default shape**
+
+In the Tautulli YAML examples in `README.md` and `settings.example.yaml`,
+replace:
+
+```yaml
+size: large
+```
+
+with:
+
+```yaml
+size: tall
+```
+
+Do not change other widget examples or the runtime `settings.yaml`.
+
+- [ ] **Step 6: Run focused tests and static checks**
+
+Run:
+
+```bash
+npx vitest run \
+  src/__tests__/integrations/tautulli.test.ts \
+  src/__tests__/integrations/TautulliActivityWidget.test.tsx \
+  src/__tests__/integrations/sizeHints.test.ts
+npx eslint \
+  src/integrations/tautulli/activityWidget.tsx \
+  src/__tests__/integrations/tautulli.test.ts \
+  src/__tests__/integrations/TautulliActivityWidget.test.tsx
+npx tsc --noEmit
+git diff --check
+```
+
+Expected: all focused tests and static checks pass.
+
+- [ ] **Step 7: Render the dashboard at a normal four-column desktop layout**
+
+Use a temporary config with a four-column Media group, one Tautulli service
+without an explicit `size`, both sections selected, and representative session
+data. Confirm visually:
+
+- The tile occupies one grid column and two rows.
+- Summary cards render as two, two, then full-width Bandwidth.
+- Usernames, titles, state, media type, transcode decision, and progress remain
+  readable.
+- Additional sessions scroll within the tile rather than expanding it.
+- The mobile layout retains the existing full-width collapse.
+
+- [ ] **Step 8: Commit the layout refinement**
+
+```bash
+git add \
+  src/integrations/tautulli/activityWidget.tsx \
+  src/app/globals.css \
+  src/__tests__/integrations/tautulli.test.ts \
+  src/__tests__/integrations/TautulliActivityWidget.test.tsx \
+  README.md \
+  settings.example.yaml
+git commit -m "feat(tautulli): use tall activity layout"
+```

--- a/docs/superpowers/plans/2026-07-25-tautulli-activity-widget.md
+++ b/docs/superpowers/plans/2026-07-25-tautulli-activity-widget.md
@@ -1,0 +1,1104 @@
+# Tautulli Activity Widget Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use
+> superpowers:subagent-driven-development (recommended) or
+> superpowers:executing-plans to implement this plan task-by-task. Steps use
+> checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add one configurable Tautulli widget that displays aggregate current
+activity, a privacy-minimized active-session list with usernames, or both.
+
+**Architecture:** A dedicated server-side API module calls Tautulli API v2's
+`get_activity`, validates its envelope, normalizes mixed upstream types, and
+returns only the selected DTO sections. A registered React widget renders the
+summary and session list through the existing generic widget routes, while a
+small generic config-field default capability keeps the service editor's
+multiselect state aligned with the Zod default.
+
+**Tech Stack:** Next.js 15 App Router, React 19, TypeScript, Zod 4, Vitest,
+Testing Library, CSS custom properties.
+
+## Global Constraints
+
+- Widget ID is exactly `tautulli-activity`.
+- Configuration keys are exactly `url`, `api_key`, and `sections`.
+- `sections` accepts only `summary` and `sessions`, requires at least one, and
+  defaults to `["summary", "sessions"]`.
+- Authentication uses Tautulli's documented `apikey` query parameter and never
+  sends the API key to the browser.
+- Fetch only the read-only `get_activity` command; do not fetch watch history.
+- Browser-visible session data is limited to username, title, progress, state,
+  media type, and transcode decision.
+- Discard email, IP, machine/device, path, player/platform, and artwork fields.
+- Preserve configured reverse-proxy base paths and forward `AbortSignal`.
+- Never include the request URL, query string, or API key in an error.
+- Use `refreshInterval: 10_000`, `preferredSize: "large"`, and
+  `minSize: "wide"`.
+- Custom CSS remains able to override widget styles without `!important`.
+- Follow TDD: demonstrate each focused test failing before production changes.
+
+---
+
+## File Structure
+
+### New files
+
+- `src/integrations/tautulli/api.ts` — config schema, upstream validation,
+  error sanitization, data minimization, and `fetchActivity`.
+- `src/integrations/tautulli/activityWidget.tsx` — formatting, rendering, and
+  widget registration.
+- `src/__tests__/integrations/tautulli.test.ts` — API and registration tests.
+- `src/__tests__/integrations/TautulliActivityWidget.test.tsx` — component
+  tests.
+
+### Modified files
+
+- `src/widgets/index.ts` — add optional `defaultValue` config-field metadata.
+- `src/components/ServiceForm.tsx` — render a field's default only when saved
+  config has no value.
+- `src/__tests__/components/ServiceForm.test.tsx` — verify default sections,
+  deselection, and saved explicit selection.
+- `src/integrations/index.ts` — register the new widget by side-effect import.
+- `src/app/globals.css` — Tautulli summary, list, progress, empty, and error
+  styles.
+- `README.md` — prerequisites, YAML, sections, fields, and privacy behavior.
+- `settings.example.yaml` — commented Tautulli example.
+- `docs/Roadmap.md` — independently mark Tautulli complete while leaving
+  Grafana and Tier 2 incomplete.
+
+---
+
+### Task 1: Tautulli API client and privacy-minimized DTO
+
+**Files:**
+
+- Create: `src/integrations/tautulli/api.ts`
+- Create: `src/__tests__/integrations/tautulli.test.ts`
+
+**Interfaces:**
+
+- Produces:
+
+```ts
+export const TAUTULLI_SECTIONS = ["summary", "sessions"] as const;
+export type TautulliSection = (typeof TAUTULLI_SECTIONS)[number];
+
+export const TautulliConfigSchema = z.object({
+  url: z.string().url(),
+  api_key: z.string().min(1),
+  sections: z
+    .array(z.enum(TAUTULLI_SECTIONS))
+    .min(1)
+    .default(["summary", "sessions"]),
+});
+export type TautulliConfig = z.infer<typeof TautulliConfigSchema>;
+
+export interface TautulliSummary {
+  streamCount: number;
+  directPlayCount: number;
+  directStreamCount: number;
+  transcodeCount: number;
+  totalBandwidthKbps: number;
+}
+
+export interface TautulliSession {
+  username: string;
+  title: string;
+  progressPercent: number;
+  state: string;
+  mediaType: string;
+  transcodeDecision: string;
+}
+
+export interface TautulliActivityData {
+  summary?: TautulliSummary;
+  sessions?: TautulliSession[];
+}
+
+export async function fetchActivity(
+  config: TautulliConfig,
+  signal?: AbortSignal
+): Promise<TautulliActivityData>;
+```
+
+- Consumes only platform `fetch`, `URL`, `AbortSignal`, and Zod.
+
+- [ ] **Step 1: Write failing API tests**
+
+Create a node-environment test with a success envelope containing mixed numeric
+strings/numbers and deliberately sensitive fields:
+
+```ts
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchActivity,
+  TautulliConfigSchema,
+} from "@/integrations/tautulli/api";
+import type { TautulliConfig } from "@/integrations/tautulli/api";
+
+const BASE_CONFIG: TautulliConfig = {
+  url: "http://tautulli.local:8181",
+  api_key: "super-secret-key",
+  sections: ["summary", "sessions"],
+};
+
+const ACTIVITY_RESPONSE = {
+  response: {
+    result: "success",
+    message: null,
+    data: {
+      stream_count: "2",
+      stream_count_direct_play: 1,
+      stream_count_direct_stream: "0",
+      stream_count_transcode: 1,
+      total_bandwidth: "12500",
+      sessions: [
+        {
+          username: "alice",
+          user: "legacy-alice",
+          friendly_name: "Alice Friendly",
+          full_title: "The Expanse · S02E05",
+          title: "Home",
+          progress_percent: "42.8",
+          state: "playing",
+          media_type: "episode",
+          transcode_decision: "transcode",
+          email: "alice@example.test",
+          ip_address: "203.0.113.5",
+          machine_id: "private-machine",
+          file: "/media/private/file.mkv",
+          platform: "Private Device",
+          thumb: "/library/metadata/1/thumb/1",
+        },
+      ],
+    },
+  },
+};
+```
+
+Add tests that assert:
+
+```ts
+expect(await fetchActivity(BASE_CONFIG)).toEqual({
+  summary: {
+    streamCount: 2,
+    directPlayCount: 1,
+    directStreamCount: 0,
+    transcodeCount: 1,
+    totalBandwidthKbps: 12500,
+  },
+  sessions: [{
+    username: "alice",
+    title: "The Expanse · S02E05",
+    progressPercent: 42.8,
+    state: "playing",
+    mediaType: "episode",
+    transcodeDecision: "transcode",
+  }],
+});
+```
+
+Cover these exact cases in the same test file:
+
+```ts
+it("preserves a reverse-proxy HTTP root and sends documented query auth");
+it("forwards the AbortSignal");
+it("returns only summary when sections is summary-only");
+it("returns only sessions when sections is sessions-only");
+it("uses username, user, friendly_name, and neutral fallbacks in that order");
+it("uses full_title, title, and a neutral fallback in that order");
+it("clamps progress to zero through one hundred");
+it("normalizes missing or non-array sessions to an empty list");
+it("normalizes absent or non-finite optional metrics to zero");
+it("throws a status-only message for non-2xx responses");
+it("rejects an error envelope and redacts the configured API key");
+it("rejects invalid JSON with a Tautulli-specific message");
+it("rejects a malformed success envelope");
+it("defaults omitted sections to summary and sessions");
+it("rejects an empty sections array");
+it("rejects unknown section names");
+```
+
+For URL assertions, parse the first fetch argument and assert:
+
+```ts
+expect(url.pathname).toBe("/root/tautulli/api/v2");
+expect(url.searchParams.get("cmd")).toBe("get_activity");
+expect(url.searchParams.get("apikey")).toBe("super-secret-key");
+```
+
+For privacy, assert the serialized result contains none of:
+
+```ts
+expect(JSON.stringify(result)).not.toMatch(
+  /alice@example|203\.0\.113\.5|private-machine|private\/file|Private Device|thumb/
+);
+```
+
+- [ ] **Step 2: Run the API tests and confirm the expected failure**
+
+Run:
+
+```bash
+npx vitest run src/__tests__/integrations/tautulli.test.ts
+```
+
+Expected: FAIL because `@/integrations/tautulli/api` does not exist.
+
+- [ ] **Step 3: Implement the config and upstream schemas**
+
+In `api.ts`, implement:
+
+```ts
+import { z } from "zod";
+
+export const TAUTULLI_SECTIONS = ["summary", "sessions"] as const;
+export type TautulliSection = (typeof TAUTULLI_SECTIONS)[number];
+
+export const TautulliConfigSchema = z.object({
+  url: z.string().url(),
+  api_key: z.string().min(1),
+  sections: z
+    .array(z.enum(TAUTULLI_SECTIONS))
+    .min(1)
+    .default(["summary", "sessions"]),
+});
+export type TautulliConfig = z.infer<typeof TautulliConfigSchema>;
+
+const NumericValueSchema = z
+  .union([z.number(), z.string()])
+  .transform((value) => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  })
+  .catch(0);
+
+const NullableTextSchema = z.string().nullish();
+
+const RawSessionSchema = z.object({
+  username: NullableTextSchema,
+  user: NullableTextSchema,
+  friendly_name: NullableTextSchema,
+  full_title: NullableTextSchema,
+  title: NullableTextSchema,
+  progress_percent: NumericValueSchema.optional().default(0),
+  state: NullableTextSchema,
+  media_type: NullableTextSchema,
+  transcode_decision: NullableTextSchema,
+});
+
+const ActivityDataSchema = z.object({
+  stream_count: NumericValueSchema.optional().default(0),
+  stream_count_direct_play: NumericValueSchema.optional().default(0),
+  stream_count_direct_stream: NumericValueSchema.optional().default(0),
+  stream_count_transcode: NumericValueSchema.optional().default(0),
+  total_bandwidth: NumericValueSchema.optional().default(0),
+  sessions: z.array(RawSessionSchema).catch([]).optional().default([]),
+});
+
+const EnvelopeSchema = z.object({
+  response: z.object({
+    result: z.string(),
+    message: z.string().nullish(),
+    data: z.unknown(),
+  }),
+});
+```
+
+Define the exported DTO interfaces exactly as listed in this task's interface
+block.
+
+- [ ] **Step 4: Implement safe errors, URL construction, and mapping**
+
+Use these helpers and behavior:
+
+```ts
+function withTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url : `${url}/`;
+}
+
+function nonBlank(value: string | null | undefined, fallback: string): string {
+  return value?.trim() ? value : fallback;
+}
+
+function sanitizeApiMessage(
+  message: string | null | undefined,
+  apiKey: string
+): string {
+  const cleaned = (message ?? "")
+    .replaceAll(apiKey, "[redacted]")
+    .replace(/[\r\n]+/g, " ")
+    .trim()
+    .slice(0, 200);
+  return cleaned
+    ? `Tautulli API error: ${cleaned}`
+    : "Tautulli API request failed";
+}
+```
+
+`fetchActivity` must:
+
+```ts
+const url = new URL("api/v2", withTrailingSlash(config.url));
+url.searchParams.set("apikey", config.api_key);
+url.searchParams.set("cmd", "get_activity");
+
+const response = await fetch(url.toString(), { signal });
+if (!response.ok) {
+  throw new Error(`Tautulli responded with ${response.status}`);
+}
+```
+
+Catch only JSON decoding and convert it to
+`Tautulli returned invalid JSON`. Parse the envelope separately. If
+`result !== "success"`, throw `sanitizeApiMessage`. Parse `response.data` with
+`ActivityDataSchema`; convert its Zod failure to
+`Tautulli returned an invalid activity response`.
+
+Clamp session progress with:
+
+```ts
+Math.min(100, Math.max(0, raw.progress_percent))
+```
+
+Construct the result conditionally:
+
+```ts
+const selected = new Set(config.sections);
+return {
+  ...(selected.has("summary") ? { summary } : {}),
+  ...(selected.has("sessions") ? { sessions } : {}),
+};
+```
+
+- [ ] **Step 5: Run the focused API tests**
+
+Run:
+
+```bash
+npx vitest run src/__tests__/integrations/tautulli.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run focused static checks**
+
+Run:
+
+```bash
+npx eslint src/integrations/tautulli/api.ts src/__tests__/integrations/tautulli.test.ts
+npx tsc --noEmit
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 7: Commit the API task**
+
+```bash
+git add src/integrations/tautulli/api.ts src/__tests__/integrations/tautulli.test.ts
+git commit -m "feat(tautulli): add activity API client"
+```
+
+---
+
+### Task 2: Configurable widget UI, registration, defaults, and styles
+
+**Files:**
+
+- Create: `src/integrations/tautulli/activityWidget.tsx`
+- Create: `src/__tests__/integrations/TautulliActivityWidget.test.tsx`
+- Modify: `src/__tests__/integrations/tautulli.test.ts`
+- Modify: `src/widgets/index.ts`
+- Modify: `src/components/ServiceForm.tsx`
+- Modify: `src/__tests__/components/ServiceForm.test.tsx`
+- Modify: `src/integrations/index.ts`
+- Modify: `src/app/globals.css`
+
+**Interfaces:**
+
+- Consumes all Task 1 exports.
+- Adds to `WidgetConfigField`:
+
+```ts
+defaultValue?: string | number | string[];
+```
+
+- Produces:
+
+```ts
+export function formatBandwidth(kbps: number): string;
+export function TautulliActivityWidget(
+  props: WidgetProps<TautulliActivityData>
+): React.ReactElement;
+```
+
+- Registers `getWidget("tautulli-activity")`.
+
+- [ ] **Step 1: Write failing component tests**
+
+Create `TautulliActivityWidget.test.tsx` with this representative combined
+fixture:
+
+```ts
+const SAMPLE_DATA = {
+  summary: {
+    streamCount: 2,
+    directPlayCount: 1,
+    directStreamCount: 0,
+    transcodeCount: 1,
+    totalBandwidthKbps: 12_500,
+  },
+  sessions: [{
+    username: "alice",
+    title: "The Expanse · S02E05",
+    progressPercent: 42.8,
+    state: "playing",
+    mediaType: "episode",
+    transcodeDecision: "transcode",
+  }],
+};
+```
+
+Cover:
+
+```ts
+it("renders the five summary values and labels");
+it("formats bandwidth as Kbps, Mbps, and Gbps at decimal thresholds");
+it("renders username, state, title, media type, and transcode mode");
+it("renders an accessible clamped progress bar and rounded percentage");
+it("renders summary-only data without a session list");
+it("renders sessions-only data without a summary row");
+it('shows "No active streams" for an empty selected session list');
+it("shows loading when data is null");
+it("shows an initial error when data is null");
+it("keeps data visible with a stale error alert");
+it("renders the empty CSS state when data, loading, and error are absent");
+```
+
+Use accessible assertions:
+
+```ts
+expect(screen.getByRole("progressbar", { name: /alice progress/i }))
+  .toHaveAttribute("aria-valuenow", "43");
+expect(screen.queryByLabelText("Tautulli summary")).not.toBeInTheDocument();
+expect(screen.queryByLabelText("Active Tautulli sessions")).not.toBeInTheDocument();
+```
+
+- [ ] **Step 2: Add failing registration and service-form tests**
+
+Append registration assertions to `tautulli.test.ts`:
+
+```ts
+expect(widget.id).toBe("tautulli-activity");
+expect(widget.name).toBe("Tautulli Activity");
+expect(widget.refreshInterval).toBe(10_000);
+expect(widget.preferredSize).toBe("large");
+expect(widget.minSize).toBe("wide");
+expect(widget.serviceEditorPreset).toEqual({
+  defaultName: "Tautulli",
+  defaultIconUrl:
+    "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@main/svg/tautulli.svg",
+});
+expect(widget.configFields?.map((field) => field.key)).toEqual([
+  "url",
+  "api_key",
+  "sections",
+]);
+```
+
+Add a `ServiceForm – Tautulli defaults` test that:
+
+1. Selects `tautulli-activity`.
+2. Asserts name and icon are prefilled.
+3. Asserts the `Summary` and `Active sessions` checkboxes are checked before
+   user interaction.
+4. Fills URL and API key.
+5. Unchecks `Summary`.
+6. Attempts to uncheck `Active sessions` and confirms it remains checked
+   because a required multiselect cannot be empty.
+7. Saves and expects:
+
+```ts
+widget: {
+  type: "tautulli-activity",
+  config: {
+    url: "http://tautulli.local:8181",
+    api_key: "secret",
+    sections: ["sessions"],
+  },
+}
+```
+
+Add a second form test that leaves both default checkboxes untouched, saves
+after filling URL and API key, and verifies `sections` is omitted from the
+stored config while:
+
+```ts
+const parsed = getWidget("tautulli-activity")!.configSchema.safeParse(
+  saved.widget!.config
+);
+expect(parsed.success).toBe(true);
+if (!parsed.success) throw parsed.error;
+expect(parsed.data.sections).toEqual(["summary", "sessions"]);
+```
+
+This confirms the schema still applies both sections.
+
+- [ ] **Step 3: Run the UI tests and confirm the expected failures**
+
+Run:
+
+```bash
+npx vitest run \
+  src/__tests__/integrations/TautulliActivityWidget.test.tsx \
+  src/__tests__/integrations/tautulli.test.ts \
+  src/__tests__/components/ServiceForm.test.tsx
+```
+
+Expected: FAIL because the component/registration and default metadata do not
+exist.
+
+- [ ] **Step 4: Add generic config-field default rendering**
+
+In `src/widgets/index.ts`, extend `WidgetConfigField`:
+
+```ts
+/** Initial editor value when the saved widget config omits this key. */
+defaultValue?: string | number | string[];
+```
+
+In `WidgetConfigFields`, replace:
+
+```ts
+const value = config[field.key];
+```
+
+with:
+
+```ts
+const value = config[field.key] ?? field.defaultValue;
+```
+
+After computing `next` in the multiselect change handler, keep the final
+required option selected:
+
+```ts
+if (field.required && next.length === 0) return;
+onChange(field.key, next);
+```
+
+Do not mutate or materialize defaults in saved YAML until the user changes the
+field. Zod remains the source of truth when an untouched field is omitted.
+
+- [ ] **Step 5: Implement formatting, component, and registration**
+
+`formatBandwidth` uses decimal thresholds:
+
+```ts
+export function formatBandwidth(kbps: number): string {
+  if (kbps >= 1_000_000) return `${(kbps / 1_000_000).toFixed(1)} Gbps`;
+  if (kbps >= 1_000) return `${(kbps / 1_000).toFixed(1)} Mbps`;
+  return `${kbps.toFixed(0)} Kbps`;
+}
+```
+
+Implement `TautulliActivityWidget` with this outer state structure:
+
+```tsx
+if (!data) {
+  return (
+    <div className="tautulli-activity-widget tautulli-activity-widget--empty">
+      {loading && <span className="tautulli-activity-widget__hint">Loading&hellip;</span>}
+      {error && (
+        <span className="tautulli-activity-widget__hint tautulli-activity-widget__hint--error">
+          {error}
+        </span>
+      )}
+    </div>
+  );
+}
+
+return (
+  <div className="tautulli-activity-widget" aria-label="Tautulli activity">
+    {data.summary && (
+      <div className="tautulli-activity-widget__summary" aria-label="Tautulli summary">
+        {[
+          ["Active", String(data.summary.streamCount)],
+          ["Direct Play", String(data.summary.directPlayCount)],
+          ["Direct Stream", String(data.summary.directStreamCount)],
+          ["Transcoding", String(data.summary.transcodeCount)],
+          ["Bandwidth", formatBandwidth(data.summary.totalBandwidthKbps)],
+        ].map(([label, value]) => (
+          <div className="tautulli-activity-widget__stat" key={label}>
+            <span className="tautulli-activity-widget__value">{value}</span>
+            <span className="tautulli-activity-widget__label">{label}</span>
+          </div>
+        ))}
+      </div>
+    )}
+    {data.sessions && (
+      <div
+        className="tautulli-activity-widget__sessions"
+        aria-label="Active Tautulli sessions"
+      >
+        {data.sessions.length === 0
+          ? <span className="tautulli-activity-widget__no-sessions">No active streams</span>
+          : data.sessions.map((session, index) => {
+              const progress = Math.round(
+                Math.min(100, Math.max(0, session.progressPercent))
+              );
+              return (
+                <div
+                  className="tautulli-activity-widget__session"
+                  key={`${session.username}:${session.title}:${index}`}
+                >
+                  <div className="tautulli-activity-widget__session-heading">
+                    <span className="tautulli-activity-widget__username">
+                      {session.username}
+                    </span>
+                    <span>{formatLabel(session.state)}</span>
+                  </div>
+                  <div className="tautulli-activity-widget__session-media">
+                    <span className="tautulli-activity-widget__title">
+                      {session.title}
+                    </span>
+                    <span>
+                      {formatLabel(session.mediaType)} ·{" "}
+                      {formatLabel(session.transcodeDecision)}
+                    </span>
+                  </div>
+                  <div
+                    className="tautulli-activity-widget__progress"
+                    role="progressbar"
+                    aria-label={`${session.username} progress`}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    aria-valuenow={progress}
+                  >
+                    <span style={{ width: `${progress}%` }} />
+                  </div>
+                  <span className="tautulli-activity-widget__progress-label">
+                    {progress}%
+                  </span>
+                </div>
+              );
+            })}
+      </div>
+    )}
+    {error && (
+      <span className="tautulli-activity-widget__stale-error" role="alert">
+        {error}
+      </span>
+    )}
+  </div>
+);
+```
+
+Render strings as React text only. Use a local label formatter that converts
+underscores to spaces and title-cases the result, so `direct_play` displays as
+`Direct Play`.
+
+Register with:
+
+```ts
+registerWidget<TautulliConfig, TautulliActivityData>({
+  id: "tautulli-activity",
+  name: "Tautulli Activity",
+  configSchema: TautulliConfigSchema,
+  fetchData: fetchActivity,
+  refreshInterval: 10_000,
+  preferredSize: "large",
+  minSize: "wide",
+  component: TautulliActivityWidget,
+  serviceEditorPreset: {
+    defaultName: "Tautulli",
+    defaultIconUrl:
+      "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@main/svg/tautulli.svg",
+  },
+  configFields: [
+    {
+      key: "url",
+      label: "URL",
+      type: "url",
+      required: true,
+      placeholder: "http://192.168.1.x:8181",
+    },
+    {
+      key: "api_key",
+      label: "API Key",
+      type: "password",
+      required: true,
+    },
+    {
+      key: "sections",
+      label: "Display sections",
+      type: "multiselect",
+      required: true,
+      defaultValue: ["summary", "sessions"],
+      options: [
+        { value: "summary", label: "Summary" },
+        { value: "sessions", label: "Active sessions" },
+      ],
+      description: "Select at least one section.",
+    },
+  ],
+});
+```
+
+- [ ] **Step 6: Register the integration and add styles**
+
+Add this import to `src/integrations/index.ts`:
+
+```ts
+import "./tautulli/activityWidget";
+```
+
+Append a dedicated CSS block. Use these layout constraints:
+
+```css
+.tautulli-activity-widget {
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.tautulli-activity-widget__summary {
+  display: grid;
+  flex-shrink: 0;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 4px;
+}
+
+.tautulli-activity-widget__sessions {
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: column;
+  gap: 5px;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.tautulli-activity-widget__progress {
+  height: 3px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--color-surface-2);
+}
+
+.tautulli-activity-widget__progress > span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--color-accent);
+}
+```
+
+Add focused selectors for stat cards, values, labels, session cards, metadata
+rows, ellipsis, percentage text, no-sessions centering, stale errors, and
+loading/error hints using:
+
+```css
+.tautulli-activity-widget__stat,
+.tautulli-activity-widget__session {
+  min-width: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-surface-2);
+}
+
+.tautulli-activity-widget__stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 5px 3px;
+}
+
+.tautulli-activity-widget__value {
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--color-text);
+  font-size: 0.9rem;
+  font-weight: 700;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tautulli-activity-widget__label {
+  color: var(--color-text-muted);
+  font-size: 0.58rem;
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.tautulli-activity-widget__session {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 4px 8px;
+  padding: 6px;
+}
+
+.tautulli-activity-widget__session-heading,
+.tautulli-activity-widget__session-media {
+  display: flex;
+  grid-column: 1 / -1;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+  color: var(--color-text-muted);
+  font-size: 0.68rem;
+}
+
+.tautulli-activity-widget__username,
+.tautulli-activity-widget__title {
+  overflow: hidden;
+  color: var(--color-text);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tautulli-activity-widget__progress-label {
+  color: var(--color-text-muted);
+  font-size: 0.65rem;
+  line-height: 1;
+}
+
+.tautulli-activity-widget__no-sessions {
+  margin: auto;
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+}
+
+.tautulli-activity-widget__stale-error {
+  flex-shrink: 0;
+  color: #f87171;
+  font-size: 0.7rem;
+  text-align: center;
+}
+
+.tautulli-activity-widget--empty {
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+}
+
+.tautulli-activity-widget__hint {
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+}
+
+.tautulli-activity-widget__hint--error {
+  color: #f87171;
+}
+```
+
+Do not use `!important`, fixed pixel widths, or unthemed foreground colors
+except the existing `#f87171` error convention.
+
+- [ ] **Step 7: Run focused tests**
+
+Run:
+
+```bash
+npx vitest run \
+  src/__tests__/integrations/TautulliActivityWidget.test.tsx \
+  src/__tests__/integrations/tautulli.test.ts \
+  src/__tests__/components/ServiceForm.test.tsx \
+  src/__tests__/integrations/sizeHints.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run focused static checks**
+
+Run:
+
+```bash
+npx eslint \
+  src/integrations/tautulli/activityWidget.tsx \
+  src/widgets/index.ts \
+  src/components/ServiceForm.tsx \
+  src/__tests__/integrations/TautulliActivityWidget.test.tsx \
+  src/__tests__/integrations/tautulli.test.ts \
+  src/__tests__/components/ServiceForm.test.tsx
+npx tsc --noEmit
+```
+
+Expected: both commands exit 0.
+
+- [ ] **Step 9: Commit the widget UI task**
+
+```bash
+git add \
+  src/integrations/tautulli/activityWidget.tsx \
+  src/__tests__/integrations/TautulliActivityWidget.test.tsx \
+  src/__tests__/integrations/tautulli.test.ts \
+  src/widgets/index.ts \
+  src/components/ServiceForm.tsx \
+  src/__tests__/components/ServiceForm.test.tsx \
+  src/integrations/index.ts \
+  src/app/globals.css
+git commit -m "feat(tautulli): add configurable activity widget"
+```
+
+---
+
+### Task 3: User documentation, example configuration, and roadmap tracking
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `settings.example.yaml`
+- Modify: `docs/Roadmap.md`
+
+**Interfaces:**
+
+- Documents the exact Task 1 config and Task 2 UI behavior.
+- Does not modify runtime `settings.yaml`.
+
+- [ ] **Step 1: Add the commented example configuration**
+
+Immediately after the Plex example in `settings.example.yaml`, add:
+
+```yaml
+#
+#   - name: Tautulli
+#     url: http://192.168.1.x:8181
+#     group: Media
+#     size: large
+#     widget:
+#       type: tautulli-activity
+#       config:
+#         url: http://192.168.1.x:8181
+#         api_key: <your-tautulli-api-key>
+#         sections:
+#           - summary
+#           - sessions
+```
+
+- [ ] **Step 2: Add the README widget documentation**
+
+Immediately after the Plex section, add `### Tautulli` with:
+
+- Prerequisite: enable Tautulli's API and copy the generated API key.
+- The same YAML example as `settings.example.yaml`.
+- A config table:
+
+```markdown
+| Field | Required | Description |
+| --- | --- | --- |
+| `url` | Yes | Base URL of the Tautulli instance, including any HTTP root |
+| `api_key` | Yes | Tautulli API key; used only by Kokpit's server |
+| `sections` | No | Non-empty list containing `summary`, `sessions`, or both; defaults to both |
+```
+
+- A summary table listing Active, Direct Play, Direct Stream, Transcoding, and
+  Bandwidth.
+- A sessions description listing username, media title/type, playback state,
+  transcode mode, and progress.
+- A privacy paragraph stating that usernames are intentionally displayed while
+  email, IP, machine/device IDs, file paths, player/platform details, and
+  artwork are discarded server-side.
+
+- [ ] **Step 3: Make the roadmap item independently trackable**
+
+Replace:
+
+```markdown
+  - Analytics: Tautulli, Grafana embed widget
+```
+
+with:
+
+```markdown
+  - Analytics:
+    - [x] Tautulli — configurable current activity widget (summary, active sessions, or both)
+    - [ ] Grafana embed widget
+```
+
+Keep the parent `Extended integrations (Tier 2)` checkbox unchecked.
+
+- [ ] **Step 4: Verify documentation consistency**
+
+Run:
+
+```bash
+rg -n -C 4 "tautulli-activity|Tautulli" \
+  README.md settings.example.yaml docs/Roadmap.md
+git diff --check
+```
+
+Expected: all three files contain the exact widget ID and field names; no
+whitespace errors.
+
+- [ ] **Step 5: Commit documentation**
+
+```bash
+git add README.md settings.example.yaml docs/Roadmap.md
+git commit -m "docs: document Tautulli activity widget"
+```
+
+---
+
+### Task 4: Integrated verification
+
+**Files:**
+
+- Verify all changed files; modify only the smallest relevant file if a
+  verification failure identifies a real defect.
+
+**Interfaces:**
+
+- Consumes the complete Tautulli integration.
+- Produces a clean, passing branch ready for final review.
+
+- [ ] **Step 1: Run the complete unit suite**
+
+```bash
+npm test
+```
+
+Expected: all Vitest suites pass.
+
+- [ ] **Step 2: Run lint**
+
+```bash
+npm run lint
+```
+
+Expected: exit 0 with no ESLint errors.
+
+- [ ] **Step 3: Run TypeScript checking**
+
+```bash
+npm run type-check
+```
+
+Expected: exit 0 with no type errors.
+
+- [ ] **Step 4: Run the production build**
+
+```bash
+npm run build
+```
+
+Expected: Next.js production build exits 0.
+
+- [ ] **Step 5: Inspect the final diff and repository state**
+
+```bash
+git diff --check
+git status --short
+git log --oneline -5
+```
+
+Expected: no whitespace errors, no uncommitted implementation changes, and
+separate API, UI, and documentation commits.

--- a/docs/superpowers/plans/2026-07-25-tautulli-activity-widget.md
+++ b/docs/superpowers/plans/2026-07-25-tautulli-activity-widget.md
@@ -319,7 +319,8 @@ function withTrailingSlash(url: string): string {
 }
 
 function nonBlank(value: string | null | undefined, fallback: string): string {
-  return value?.trim() ? value : fallback;
+  const trimmed = value?.trim();
+  return trimmed || fallback;
 }
 
 function sanitizeApiMessage(
@@ -350,7 +351,9 @@ if (!response.ok) {
 }
 ```
 
-Catch only JSON decoding and convert it to
+At both the initial `fetch` stage and the response-body (`response.json()`)
+stage, sanitize `AbortError` failures to the safe `Tautulli request aborted`
+message. Catch only other JSON decoding failures and convert them to
 `Tautulli returned invalid JSON`. Parse the envelope separately. If
 `result !== "success"`, throw `sanitizeApiMessage`. Parse `response.data` with
 `ActivityDataSchema`; convert its Zod failure to

--- a/docs/superpowers/plans/2026-07-26-widget-secret-preservation-security.md
+++ b/docs/superpowers/plans/2026-07-26-widget-secret-preservation-security.md
@@ -1,0 +1,144 @@
+# Widget Secret Preservation Security Implementation Plan
+
+**Goal:** Replace reusable unsigned widget-secret coordinates with signed,
+destination-bound preservation that protects all credentialed widgets, and
+preserve Tautulli cancellation throughout response-body parsing.
+
+**Architecture:** A server-only HMAC reference authenticates the saved secret's
+source locator. Explicit widget registry metadata defines the non-secret fields
+that scope a credential. Both settings persistence and connection testing
+resolve a saved value only after comparing normalized scope from the current
+saved config with the submitted destination config. The editor uses the same
+client-safe normalization for immediate re-entry feedback, but the server is
+authoritative.
+
+**Tech stack:** Next.js 15 App Router, React 19, TypeScript, Node crypto, Zod 4,
+Vitest, Testing Library.
+
+## Global Constraints
+
+- Follow TDD: add and run failing focused tests before production changes.
+- Never return, render, log, encode, hash into a browser token, or include a
+  widget secret in an error.
+- Signing must use a purpose-derived key while preserving the existing JWT key.
+- A signature never substitutes for saved-versus-submitted scope comparison.
+- Resolution failures must happen before schema validation triggers a fetch.
+- The design applies to every registry-declared password field.
+- YAML remains the source of truth and stores literal secrets, never references.
+- Optimistic revision conflict checking remains ahead of secret resolution.
+- No destructive history rewrite; replace the flawed implementation with
+  follow-up commits on `codex/tautulli-activity-widget`.
+
+## Task 1: Server secret extraction and signed reference primitive
+
+**Files:**
+
+- Create `src/auth/serverSecret.ts`
+- Modify `src/auth/jwt.ts`
+- Modify `src/widgets/secretReference.ts`
+- Create `src/widgets/secretReference.server.ts`
+- Create `src/__tests__/widgets/secretReference.test.ts`
+- Modify `src/__tests__/auth/jwt.test.ts`
+
+- [ ] Add failing tests for valid signing/verification, no secret material,
+      purpose separation, malformed tokens, size/version/shape errors, payload
+      tampering, signature tampering, and persisted-key behavior.
+- [ ] Move the existing server-secret loading code without changing its
+      environment variable, file path, persistence, permissions, or bytes.
+- [ ] Keep the browser module crypto-free and implement strict server-only
+      HMAC signing/verification with a derived key and timing-safe comparison.
+- [ ] Run focused reference and JWT tests.
+
+## Task 2: Explicit scope metadata and normalization
+
+**Files:**
+
+- Modify `src/widgets/index.ts`
+- Create `src/widgets/credentialScope.ts`
+- Modify every integration registration containing a password config field
+- Add or extend `src/__tests__/widgets/configSecrets.test.ts`
+
+- [ ] Add failing tests proving every password widget declares a valid,
+      nonempty credential scope and invalid definitions fail registration.
+- [ ] Add client-safe canonical scope calculation for HTTP(S) URL fields and
+      exact text fields.
+- [ ] Declare `["url"]` for all credentialed widgets and
+      `["url", "username"]` for both qBittorrent widgets.
+- [ ] Run registry and scope tests.
+
+## Task 3: Destination-bound server resolution
+
+**Files:**
+
+- Modify `src/widgets/configSecrets.ts`
+- Modify `src/app/api/settings/route.ts`
+- Modify `src/app/api/widget/test/route.ts`
+- Modify `src/__tests__/api/settings.test.ts`
+- Modify `src/__tests__/api/widget-test.test.ts`
+- Add or extend a protected settings page test
+
+- [ ] Add failing tests for GET/PATCH/RSC redaction, unchanged preservation,
+      rename/reorder, display-only edits, canonical-equivalent URLs, endpoint
+      changes, qBittorrent username changes, literal replacement, forged and
+      tampered tokens, wrong source/type/field, different-scope copy, stable
+      error codes, no writes, and no outbound fetches.
+- [ ] Sign all browser references using current saved config.
+- [ ] Verify the locator and compare server-derived source/destination scope
+      before returning a saved value.
+- [ ] Preserve revision-check ordering and return bounded coded 400 errors.
+- [ ] Run focused config-secret and API route tests.
+
+## Task 4: Editor re-entry behavior
+
+**Files:**
+
+- Modify `src/components/ServiceForm.tsx`
+- Modify `src/__tests__/components/ServiceForm.test.tsx`
+- Modify `src/components/SettingsPanel.tsx` only if needed to surface the safe
+  server error without optimistic success
+
+- [ ] Add failing tests for blank saved-secret inputs, scope-change re-entry,
+      disabled testing, required replacement, canonical revert, qBittorrent
+      username binding, and unrelated-edit preservation.
+- [ ] Compare original/current normalized scope without parsing signed tokens.
+- [ ] Make a stale saved reference fail client validation and require a literal
+      credential while retaining it for canonical revert.
+- [ ] Ensure raw secrets and signed references are not rendered as input values.
+- [ ] Run focused component tests.
+
+## Task 5: Tautulli response-body abort preservation
+
+**Files:**
+
+- Modify `src/integrations/tautulli/api.ts`
+- Modify `src/__tests__/integrations/tautulli.test.ts`
+- Modify `src/__tests__/api/widget-test.test.ts` if needed for timeout lifecycle
+
+- [ ] Add a failing regression where `fetch` resolves but `response.json()`
+      rejects after cancellation.
+- [ ] Preserve a sanitized `AbortError` through both transport and body-read
+      catch paths without rethrowing upstream text.
+- [ ] Confirm the hard timeout still returns 504 and leaks no URL or API key.
+- [ ] Run focused Tautulli and widget-test suites.
+
+## Task 6: Review and verification
+
+- [ ] Run an independent security review focused on reference forgery/replay,
+      scope confusion, client/server boundary, and abort lifecycle.
+- [ ] Apply at most one bounded fix wave for review findings, then re-review.
+- [ ] Run `npm test`.
+- [ ] Run `npm run lint`.
+- [ ] Run `npm run type-check`.
+- [ ] Run `npm run build`.
+- [ ] Run `git diff --check` and confirm the worktree contains only intended
+      changes.
+- [ ] Commit the verified security correction.
+
+## Task 7: Visual verification
+
+- [ ] Start Kokpit with temporary mock Tautulli data.
+- [ ] Verify the approved one-column-by-two-row default tile at desktop and the
+      mobile full-width behavior.
+- [ ] Capture a fresh screenshot of the final implementation.
+- [ ] Stop temporary services and remove temporary config.
+

--- a/docs/superpowers/specs/2026-07-25-tautulli-activity-widget-design.md
+++ b/docs/superpowers/specs/2026-07-25-tautulli-activity-widget-design.md
@@ -240,8 +240,9 @@ The component follows existing widget state conventions:
 
 ## Error Handling
 
-- Network and abort behavior remains governed by the existing widget route and
-  hard-timeout wrapper.
+- At both the initial fetch and response-body read stages, sanitize AbortError
+  failures to `Tautulli request aborted`; the existing widget route and
+  hard-timeout wrapper continue to govern the surrounding network behavior.
 - Non-2xx responses fail even if a response body resembles a success envelope.
 - A 2xx response with `result: "error"` also fails.
 - Malformed JSON or missing envelope data fails with a Tautulli-specific

--- a/docs/superpowers/specs/2026-07-25-tautulli-activity-widget-design.md
+++ b/docs/superpowers/specs/2026-07-25-tautulli-activity-widget-design.md
@@ -1,0 +1,324 @@
+# Tautulli Activity Widget — Design Spec
+
+**Date:** 2026-07-25
+**Status:** Approved
+
+---
+
+## Overview
+
+Add one configurable Tautulli integration to Kokpit:
+
+- `tautulli-activity` — current playback activity with an optional aggregate
+  summary, an optional active-session list, or both.
+
+The widget uses Tautulli's read-only API v2 `get_activity` command. It does not
+fetch watch history. The default configuration displays both sections.
+
+Tautulli currently appears only inside the broad, incomplete Phase 4 Tier-2
+analytics item in `docs/Roadmap.md`; the detailed Phase 2 P0 item is Tdarr, a
+different product. The roadmap will therefore be restructured so Tautulli can
+be checked independently without marking Grafana or all Tier-2 integrations
+complete.
+
+---
+
+## User-Facing Configuration
+
+```yaml
+services:
+  - name: Tautulli
+    url: http://192.168.1.10:8181
+    widget:
+      type: tautulli-activity
+      config:
+        url: http://192.168.1.10:8181
+        api_key: YOUR_API_KEY
+        sections:
+          - summary
+          - sessions
+```
+
+The widget configuration schema is:
+
+```ts
+const TautulliConfigSchema = z.object({
+  url: z.string().url(),
+  api_key: z.string().min(1),
+  sections: z
+    .array(z.enum(["summary", "sessions"]))
+    .min(1)
+    .default(["summary", "sessions"]),
+});
+```
+
+The service editor exposes:
+
+- `url` as a required URL field.
+- `api_key` as a required password field.
+- `sections` as a "Display sections" multiselect with "Summary" and
+  "Active sessions" options.
+
+At least one section must be selected. Users can display the summary only, the
+session list only, or both. Existing YAML that omits `sections` receives the
+default of both sections at widget-validation time without rewriting the YAML.
+
+---
+
+## Files and Registration
+
+```text
+src/integrations/tautulli/
+  api.ts                 API configuration, upstream schemas, normalization,
+                         privacy filtering, and exported widget-facing types
+  activityWidget.tsx     component and "tautulli-activity" registration
+
+src/__tests__/integrations/
+  tautulli.test.ts
+  TautulliActivityWidget.test.tsx
+```
+
+`src/integrations/index.ts` will import
+`./tautulli/activityWidget` so the existing client and server widget registries
+discover it.
+
+No Tautulli-specific Next.js route or top-level config-schema change is
+required. The existing authenticated `/api/widget` and `/api/widget/test`
+routes validate widget configuration, keep credentials server-side, apply the
+hard timeout, and expose the registered widget automatically.
+
+The widget registration will use:
+
+```ts
+{
+  id: "tautulli-activity",
+  name: "Tautulli Activity",
+  refreshInterval: 10_000,
+  preferredSize: "large",
+  minSize: "wide"
+}
+```
+
+Its service-editor preset uses "Tautulli" as the default tile name and the
+verified Dashboard Icons asset:
+
+```text
+https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@main/svg/tautulli.svg
+```
+
+---
+
+## API Request and Authentication
+
+The server normalizes the configured base URL while preserving any reverse
+proxy base path, then sends:
+
+```text
+GET <base-url>/api/v2?apikey=<api-key>&cmd=get_activity
+```
+
+Tautulli documents API-key authentication through the `apikey` query
+parameter; the integration will not invent header authentication. The API key
+is used only by the server-side fetcher and is never returned to the browser,
+rendered into markup, or included in an error message.
+
+The fetcher:
+
+1. Preserves a configured HTTP root such as
+   `https://example.test/tautulli/`.
+2. Forwards the provided `AbortSignal`.
+3. Rejects non-2xx HTTP responses.
+4. Parses JSON and validates Tautulli's
+   `{ response: { result, message, data } }` envelope.
+5. Treats any result other than `success` as an API failure, even when the
+   HTTP status is 2xx.
+6. Accepts documented numeric fields supplied as either numbers or numeric
+   strings, applies finite-number fallbacks, and clamps progress to 0–100.
+7. Returns a minimized widget-facing object containing only the configured
+   sections.
+
+The request URL, query string, and API key must never appear in thrown errors.
+HTTP failures use `Tautulli responded with <status>`. Invalid JSON and invalid
+response shapes use bounded service-specific messages. An API-envelope message
+may be included only after removing line breaks, limiting it to 200 characters,
+and ensuring it cannot contain the configured API key.
+
+---
+
+## Widget-Facing Data
+
+```ts
+type TautulliSection = "summary" | "sessions";
+
+interface TautulliSummary {
+  streamCount: number;
+  directPlayCount: number;
+  directStreamCount: number;
+  transcodeCount: number;
+  totalBandwidthKbps: number;
+}
+
+interface TautulliSession {
+  username: string;
+  title: string;
+  progressPercent: number;
+  state: string;
+  mediaType: string;
+  transcodeDecision: string;
+}
+
+interface TautulliActivityData {
+  summary?: TautulliSummary;
+  sessions?: TautulliSession[];
+}
+```
+
+Summary values map from Tautulli's `stream_count`,
+`stream_count_direct_play`, `stream_count_direct_stream`,
+`stream_count_transcode`, and `total_bandwidth`.
+
+For each active session:
+
+- `username` resolves from `username`, then `user`, then `friendly_name`, then
+  `"Unknown user"`.
+- `title` resolves from `full_title`, then `title`, then `"Unknown title"`.
+- Missing `state`, `media_type`, or `transcode_decision` becomes `"unknown"`.
+- Missing or invalid progress becomes `0`.
+
+The session list is sourced only from `get_activity.response.data.sessions`.
+The aggregate stream count remains authoritative rather than being derived
+from the session array.
+
+Even though Tautulli returns richer session objects, Kokpit deliberately
+discards email addresses, IP addresses, machine and device identifiers, file
+paths, player/platform details, and artwork URLs before data crosses the
+server/client boundary.
+
+---
+
+## Presentation
+
+### Summary section
+
+Render one compact row containing:
+
+- Active
+- Direct Play
+- Direct Stream
+- Transcoding
+- Bandwidth
+
+Bandwidth is formatted from kilobits per second into `Kbps`, `Mbps`, or `Gbps`
+using decimal units. The row remains usable at the minimum `wide` tile size.
+
+### Active sessions section
+
+Render a vertically scrollable list. Each entry contains:
+
+- Username and playback state.
+- Media title and transcode mode.
+- A progress bar with a visible percentage.
+
+An empty list displays "No active streams." User-provided upstream strings are
+rendered as ordinary React text, not HTML.
+
+When both sections are enabled, the summary remains fixed above the scrollable
+session list. The default `large` tile size gives the list useful vertical
+space. A summary-only or sessions-only tile can be resized by the user while
+respecting the widget's `wide` minimum.
+
+The component follows existing widget state conventions:
+
+- No data plus loading: show a loading hint.
+- No data plus error: show the error.
+- Data plus a refresh error: keep the data visible and show an alert.
+- Data with an empty sessions array: show the explicit empty state.
+
+---
+
+## Error Handling
+
+- Network and abort behavior remains governed by the existing widget route and
+  hard-timeout wrapper.
+- Non-2xx responses fail even if a response body resembles a success envelope.
+- A 2xx response with `result: "error"` also fails.
+- Malformed JSON or missing envelope data fails with a Tautulli-specific
+  message rather than leaking parser internals.
+- A missing or non-array `sessions` field is normalized to an empty session
+  list because aggregate activity data remains independently useful.
+- Optional fields within an otherwise valid activity response use the
+  documented fallbacks instead of failing the entire widget.
+- Refresh failures preserve the last successful data through the existing
+  `useWidget` behavior.
+
+---
+
+## Testing
+
+### API and registration tests
+
+`src/__tests__/integrations/tautulli.test.ts` will verify:
+
+- Base URL and reverse-proxy HTTP-root normalization.
+- `cmd=get_activity` and query-parameter API-key authentication.
+- API-key absence from thrown error messages.
+- `AbortSignal` forwarding.
+- Successful parsing of numeric strings and numbers.
+- Summary field mapping and progress clamping.
+- Username, title, and optional-field fallbacks.
+- Privacy minimization of session records.
+- Summary-only, sessions-only, and combined returned data.
+- HTTP error, API-envelope error, malformed JSON, and malformed envelope
+  behavior.
+- Widget registration metadata, refresh interval, size hints, editor preset,
+  config fields, defaults, and rejection of empty or unknown section
+  selections.
+
+### Component tests
+
+`src/__tests__/integrations/TautulliActivityWidget.test.tsx` will verify:
+
+- Summary-only rendering and bandwidth formatting.
+- Sessions-only rendering.
+- Combined rendering.
+- Username, title, state, transcode mode, percentage, and progress semantics.
+- Empty active-session state.
+- Loading, initial error, and stale-data error states.
+- Absence of an unselected section.
+
+The focused tests run first during TDD. Completion verification runs the full
+unit suite, ESLint, and TypeScript checking.
+
+---
+
+## Documentation and Roadmap
+
+`README.md` will gain a Tautulli widget section covering:
+
+- API-key prerequisites.
+- The YAML example.
+- The three valid section combinations.
+- Displayed summary and session fields.
+- The fact that usernames are intentionally displayed.
+- The sensitive Tautulli fields that Kokpit intentionally discards.
+
+`settings.example.yaml` will gain a commented example with both sections
+enabled.
+
+The Phase 4 extended-integrations analytics line in `docs/Roadmap.md` will be
+expanded into independently trackable nested items. Tautulli will be marked
+complete with its delivered activity-widget scope; Grafana and the parent
+Tier-2 integration item will remain incomplete.
+
+---
+
+## Out of Scope
+
+- Watch history and recently watched lists.
+- Tautulli user email, IP, device, machine, path, player, platform, and artwork
+  fields.
+- API-key creation or management.
+- Configuration of Tautulli itself.
+- Shared fetch caching across multiple Tautulli widgets.
+- A second Tautulli widget.
+- Grafana or any other Tier-2 integration.

--- a/docs/superpowers/specs/2026-07-25-tautulli-activity-widget-design.md
+++ b/docs/superpowers/specs/2026-07-25-tautulli-activity-widget-design.md
@@ -94,8 +94,8 @@ The widget registration will use:
   id: "tautulli-activity",
   name: "Tautulli Activity",
   refreshInterval: 10_000,
-  preferredSize: "large",
-  minSize: "wide"
+  preferredSize: "tall",
+  minSize: "tall"
 }
 ```
 
@@ -200,16 +200,15 @@ server/client boundary.
 
 ### Summary section
 
-Render one compact row containing:
+Render five compact summary cells in three rows:
 
-- Active
-- Direct Play
-- Direct Stream
-- Transcoding
-- Bandwidth
+- Row one: Active and Direct Play.
+- Row two: Direct Stream and Transcoding.
+- Row three: Bandwidth spanning the full tile width.
 
 Bandwidth is formatted from kilobits per second into `Kbps`, `Mbps`, or `Gbps`
-using decimal units. The row remains usable at the minimum `wide` tile size.
+using decimal units. This arrangement remains readable at the minimum `tall`
+tile size (one column by two rows).
 
 ### Active sessions section
 
@@ -223,9 +222,12 @@ An empty list displays "No active streams." User-provided upstream strings are
 rendered as ordinary React text, not HTML.
 
 When both sections are enabled, the summary remains fixed above the scrollable
-session list. The default `large` tile size gives the list useful vertical
-space. A summary-only or sessions-only tile can be resized by the user while
-respecting the widget's `wide` minimum.
+session list. The default and minimum `tall` tile size (one column by two rows)
+gives the list useful vertical space while keeping the summary narrow-safe.
+The session list remains vertically scrollable below the summary. On mobile,
+the widget retains the project's existing full-width collapse. A summary-only
+or sessions-only tile can be resized by the user while respecting the
+widget's `tall` minimum.
 
 The component follows existing widget state conventions:
 

--- a/docs/superpowers/specs/2026-07-26-widget-secret-preservation-security-design.md
+++ b/docs/superpowers/specs/2026-07-26-widget-secret-preservation-security-design.md
@@ -1,0 +1,177 @@
+# Widget Secret Preservation Security Design
+
+**Date:** 2026-07-26  
+**Status:** Approved
+
+## Problem
+
+Kokpit must let users edit a configured widget without returning its saved
+password, token, or API key to the browser. The first server-side preservation
+implementation replaced secrets with unsigned source coordinates. Those
+coordinates could be replayed with a different widget URL, causing Kokpit to
+resolve the real secret and send it to an attacker-controlled server.
+
+The flaw is generic because secret fields are discovered from widget registry
+metadata. The correction must protect every password-bearing widget, not only
+Tautulli, and must remain safe when application authentication is disabled.
+
+## User-Facing Rules
+
+- Settings responses, server-rendered settings props, password inputs, and
+  connection-test responses never contain a saved widget secret.
+- A saved credential can be reused for saving or connection testing only while
+  its credential scope is unchanged.
+- Renaming or reordering a service does not require credential re-entry.
+- Changing presentation-only configuration, such as Tautulli sections or
+  Netdata history length, does not require credential re-entry.
+- Changing a widget's endpoint URL requires the credential to be entered again.
+- Changing qBittorrent's username also requires the password to be entered
+  again.
+- Returning a changed scope to its original normalized value makes the saved
+  credential reusable again.
+- Entering a literal replacement credential permits a new endpoint or username.
+
+## Signed Browser Reference
+
+The browser-safe module keeps only the reserved reference prefix and a predicate
+that recognizes it. Signing and verification live in a server-only module so
+Node crypto and server-secret access cannot enter the client bundle.
+
+A reference has this conceptual payload:
+
+```ts
+{
+  v: 1;
+  serviceName: string;
+  widgetType: string;
+  fieldKey: string;
+}
+```
+
+The encoded payload is authenticated with HMAC-SHA256. The HMAC key is derived
+from Kokpit's existing server/session secret with the fixed purpose string
+`kokpit/widget-secret-reference/v1`. The JWT key itself remains unchanged so
+existing sessions survive the refactor. Tokens contain no secret, secret hash,
+scope value, URL, expiry, or user identity.
+
+Verification is fail-closed:
+
+- The reserved prefix with malformed content is an invalid reference, not a
+  literal password.
+- The version and exact payload shape are validated.
+- Oversized tokens are rejected.
+- The MAC is checked with a timing-safe comparison before any locator is used.
+- Widget type and field claims must match the submitted destination field.
+- The referenced source service must still contain a real, non-reference saved
+  value.
+
+A signed locator alone is not sufficient. It is intentionally reusable, so
+destination-scope comparison is mandatory before resolving the secret.
+
+## Explicit Credential Scope Metadata
+
+`WidgetDefinition` receives a required `credentialScopeFields` declaration when
+the widget has any password field. Registration fails if the declaration is
+missing, empty, references a missing field, or references another password
+field.
+
+All current password-bearing widgets declare `["url"]`. The two qBittorrent
+widgets declare `["url", "username"]`.
+
+This invariant ensures a future credentialed widget cannot silently opt out of
+destination binding.
+
+## Scope Normalization
+
+Scope is calculated only from the current server-side registry definition and
+the supplied widget config. Scope values from the reference are never trusted.
+
+- URL fields must be strings containing HTTP or HTTPS URLs.
+- URLs are trimmed and parsed through `URL`.
+- Scheme/host casing, default ports, and root slashes use the platform's
+  canonical serialization.
+- Fragments are discarded because they are not sent in HTTP requests.
+- Path and query remain part of the scope because they can change the API
+  target.
+- Text fields such as qBittorrent username compare exact string values because
+  the upstream service may treat case or whitespace as significant.
+- Missing or invalid scope values never match.
+
+The same client-safe normalizer drives editor feedback, while the server remains
+the authority.
+
+## Server Resolution
+
+For each saved-secret reference, the server:
+
+1. Verifies the reference signature and payload.
+2. Confirms widget type and password field.
+3. Locates the source service in the current saved YAML configuration.
+4. Confirms the source contains a real saved secret.
+5. Calculates scope from the saved source config.
+6. Calculates scope from the submitted destination config.
+7. Resolves the secret only when both normalized scopes match exactly.
+
+This occurs before schema validation and before any outbound request.
+
+`PATCH /api/settings` keeps optimistic revision checking before secret
+resolution. Successful rename/reorder operations receive newly issued
+references using the new saved service name. A copied reference can only be
+used at the same normalized destination; it cannot redirect a credential.
+
+`POST /api/widget/test` applies the identical resolver. Invalid, forged,
+tampered, cross-widget, cross-field, or scope-mismatched references return a
+bounded 400 response and perform no network call.
+
+Public errors use stable codes:
+
+- `widget_secret_reference_invalid`
+- `widget_secret_scope_changed`
+
+Messages instruct the user to re-enter the credential without including the
+reference, source service, saved config, URL, or secret.
+
+## Editor Behavior
+
+The editor retains the reference in React state while rendering an empty
+password input with a saved-value placeholder. It compares the original and
+current normalized credential scopes:
+
+- Matching scope: the saved reference satisfies required-field validation and
+  connection testing is available.
+- Changed scope: the password input becomes required, shows a re-entry hint,
+  the stale reference does not satisfy client widget validation, and connection
+  testing is disabled until a literal replacement is typed.
+- Reverted scope: the original reference becomes usable again.
+
+Unrelated service and display fields do not affect this state.
+
+## Tautulli Abort Semantics
+
+Tautulli must preserve cancellation both while awaiting `fetch()` and while
+reading `response.json()`. If the signal is aborted or the caught error is named
+`AbortError`, the client throws a sanitized error named `AbortError` with the
+message `Tautulli request aborted`. Other transport and JSON failures keep their
+bounded service-specific messages. Upstream error text is never rethrown because
+it may contain the credential-bearing request URL.
+
+## Required Security Tests
+
+- Valid signed-reference round trip and purpose-separated signing key.
+- Malformed, oversized, forged, payload-tampered, and signature-tampered
+  references fail closed.
+- Every registered password widget has valid explicit credential scope.
+- GET, PATCH, server-rendered settings, DOM, and test responses contain no raw
+  saved credential.
+- Rename, reorder, display-only changes, and canonical-equivalent URLs preserve
+  credentials.
+- Host, scheme, port, path, or query changes reject saved references.
+- qBittorrent username changes reject saved passwords.
+- Literal replacement credentials work with a changed scope.
+- Cross-widget, cross-field, and different-scope copied references fail.
+- Every resolution failure occurs before `fetch`.
+- Authentication-disabled requests cannot redirect a saved credential.
+- Revision mismatch remains ahead of reference resolution.
+- Tautulli response-body cancellation preserves sanitized `AbortError`
+  semantics.
+

--- a/e2e/tests/plex-widget.spec.ts
+++ b/e2e/tests/plex-widget.spec.ts
@@ -204,7 +204,7 @@ test("Test connection button reports success and failure", async ({
   await page.fill("#sf-widget-token", "test-token-2");
   await expect(page.getByText("Connection OK")).toBeHidden();
   await testBtn.click();
-  await expect(page.getByText(/Plex responded with 503/)).toBeVisible({
+  await expect(page.getByText("Connection test failed")).toBeVisible({
     timeout: 15_000,
   });
 });

--- a/settings.example.yaml
+++ b/settings.example.yaml
@@ -85,7 +85,7 @@ services: []
 #   - name: Tautulli
 #     url: http://192.168.1.x:8181
 #     group: Media
-#     size: large
+#     size: tall
 #     widget:
 #       type: tautulli-activity
 #       config:

--- a/settings.example.yaml
+++ b/settings.example.yaml
@@ -82,6 +82,19 @@ services: []
 #           - streams
 #           - transcodes
 #
+#   - name: Tautulli
+#     url: http://192.168.1.x:8181
+#     group: Media
+#     size: large
+#     widget:
+#       type: tautulli-activity
+#       config:
+#         url: http://192.168.1.x:8181
+#         api_key: <your-tautulli-api-key>
+#         sections:
+#           - summary
+#           - sessions
+#
 #   - name: qBittorrent Stats
 #     url: http://192.168.1.x:8080
 #     widget:

--- a/src/__tests__/api/settings.test.ts
+++ b/src/__tests__/api/settings.test.ts
@@ -84,6 +84,10 @@ services:
         password: qbittorrent-secret-value
 `.trim();
 
+type MutableSecretTestService = {
+  widget: { config: Record<string, unknown> };
+};
+
 function patch(body: unknown, headers: Record<string, string> = {}) {
   return new NextRequest("http://localhost/api/settings", {
     method: "PATCH",
@@ -474,6 +478,8 @@ describe("/api/settings – widget password fields", () => {
     const getRes = await GET();
     const revision = getRes.headers.get("X-Config-Revision")!;
     const redacted = await getRes.json();
+    redacted.services[0].widget.config.url =
+      "http://new-tautulli.local:8181";
     redacted.services[0].widget.config.api_key = "replacement-secret-value";
 
     const res = await PATCH(
@@ -483,11 +489,73 @@ describe("/api/settings – widget password fields", () => {
 
     expect(res.status).toBe(200);
     expect(storedYaml).toContain("api_key: replacement-secret-value");
+    expect(storedYaml).toContain("url: http://new-tautulli.local:8181");
     expect(storedYaml).not.toContain("api_key: tautulli-secret-value");
     expect(storedYaml).toContain("password: qbittorrent-secret-value");
     expect(responseText).not.toContain("replacement-secret-value");
     expect(responseText).not.toContain("qbittorrent-secret-value");
     expect(responseText).toContain("__KOKPIT_WIDGET_SECRET_REF__:");
+  });
+
+  it("preserves a saved secret across display-only and canonical-equivalent URL edits", async () => {
+    const { GET, PATCH } = await import("../../app/api/settings/route");
+    const getRes = await GET();
+    const revision = getRes.headers.get("X-Config-Revision")!;
+    const redacted = await getRes.json();
+    redacted.services[0].widget.config.url =
+      " HTTP://TAUTULLI.LOCAL:8181/#dashboard ";
+    redacted.services[0].widget.config.sections = ["sessions"];
+
+    const res = await PATCH(
+      patch({ services: redacted.services }, { "If-Match": revision })
+    );
+
+    expect(res.status).toBe(200);
+    expect(storedYaml).toContain("api_key: tautulli-secret-value");
+    expect(storedYaml).not.toContain("__KOKPIT_WIDGET_SECRET_REF__:");
+  });
+
+  it.each([
+    ["endpoint", (services: MutableSecretTestService[]) => {
+      services[0].widget.config.url = "http://attacker.invalid:8181";
+    }],
+    ["qBittorrent username", (services: MutableSecretTestService[]) => {
+      services[1].widget.config.username = "other-admin";
+    }],
+  ])("rejects a saved secret when %s scope changes and writes nothing", async (_label, change) => {
+    const { GET, PATCH } = await import("../../app/api/settings/route");
+    const getRes = await GET();
+    const revision = getRes.headers.get("X-Config-Revision")!;
+    const redacted = await getRes.json();
+    change(redacted.services);
+    vi.mocked(writeFileSync).mockClear();
+
+    const res = await PATCH(
+      patch({ services: redacted.services }, { "If-Match": revision })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.code).toBe("widget_secret_scope_changed");
+    expect(JSON.stringify(body)).not.toContain("attacker.invalid");
+    expect(JSON.stringify(body)).not.toContain("tautulli-secret-value");
+    expect(writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed references with a stable safe code and no write", async () => {
+    const { GET, PATCH } = await import("../../app/api/settings/route");
+    const redacted = await (await GET()).json();
+    redacted.services[0].widget.config.api_key =
+      "__KOKPIT_WIDGET_SECRET_REF__:malformed";
+    vi.mocked(writeFileSync).mockClear();
+
+    const res = await PATCH(patch({ services: redacted.services }));
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body.code).toBe("widget_secret_reference_invalid");
+    expect(JSON.stringify(body)).not.toContain("malformed");
+    expect(writeFileSync).not.toHaveBeenCalled();
   });
 
   it("keeps the revision-conflict check ahead of secret resolution", async () => {

--- a/src/__tests__/api/settings.test.ts
+++ b/src/__tests__/api/settings.test.ts
@@ -22,6 +22,10 @@ vi.mock("next/headers", () => ({
 process.env.KOKPIT_AUTH_DISABLED = "true";
 
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  WIDGET_SECRET_REFERENCE_KEY,
+  WIDGET_SECRET_REFERENCE_PREFIX,
+} from "@/widgets/secretReference";
 
 const BASE_YAML = `
 schema_version: 1
@@ -161,6 +165,24 @@ describe("PATCH /api/settings – validation", () => {
 });
 
 describe("PATCH /api/settings – layout", () => {
+  it("returns a bounded 500 when secret resolution fails unexpectedly", async () => {
+    vi.doMock("@/widgets/configSecrets", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("@/widgets/configSecrets")>()),
+      resolveServiceWidgetSecrets: () => {
+        throw new Error("leaked internal secret resolver detail");
+      },
+    }));
+    try {
+      const { PATCH } = await import("../../app/api/settings/route");
+      const res = await PATCH(patch({ services: [] }));
+
+      expect(res.status).toBe(500);
+      expect(await res.json()).toEqual({ error: "Failed to save settings" });
+    } finally {
+      vi.doUnmock("@/widgets/configSecrets");
+    }
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
@@ -447,12 +469,16 @@ describe("/api/settings – widget password fields", () => {
     expect(res.status).toBe(200);
     expect(serialized).not.toContain("tautulli-secret-value");
     expect(serialized).not.toContain("qbittorrent-secret-value");
-    expect(json.services[0].widget.config.api_key).toMatch(
-      /^__KOKPIT_WIDGET_SECRET_REF__:/
-    );
-    expect(json.services[1].widget.config.password).toMatch(
-      /^__KOKPIT_WIDGET_SECRET_REF__:/
-    );
+    expect(json.services[0].widget.config.api_key).toMatchObject({
+      [WIDGET_SECRET_REFERENCE_KEY]: expect.stringMatching(
+        new RegExp(`^${WIDGET_SECRET_REFERENCE_PREFIX}`)
+      ),
+    });
+    expect(json.services[1].widget.config.password).toMatchObject({
+      [WIDGET_SECRET_REFERENCE_KEY]: expect.stringMatching(
+        new RegExp(`^${WIDGET_SECRET_REFERENCE_PREFIX}`)
+      ),
+    });
     expect(json.services[0].widget.config.url).toBe(
       "http://tautulli.local:8181"
     );
@@ -595,8 +621,9 @@ describe("/api/settings – widget password fields", () => {
   it("rejects malformed references with a stable safe code and no write", async () => {
     const { GET, PATCH } = await import("../../app/api/settings/route");
     const redacted = await (await GET()).json();
-    redacted.services[0].widget.config.api_key =
-      "__KOKPIT_WIDGET_SECRET_REF__:malformed";
+    redacted.services[0].widget.config.api_key = {
+      [WIDGET_SECRET_REFERENCE_KEY]: `${WIDGET_SECRET_REFERENCE_PREFIX}malformed`,
+    };
     vi.mocked(writeFileSync).mockClear();
 
     const res = await PATCH(patch({ services: redacted.services }));
@@ -611,8 +638,9 @@ describe("/api/settings – widget password fields", () => {
   it("keeps the revision-conflict check ahead of secret resolution", async () => {
     const { GET, PATCH } = await import("../../app/api/settings/route");
     const redacted = await (await GET()).json();
-    redacted.services[0].widget.config.api_key =
-      "__KOKPIT_WIDGET_SECRET_REF__:malformed";
+    redacted.services[0].widget.config.api_key = {
+      [WIDGET_SECRET_REFERENCE_KEY]: `${WIDGET_SECRET_REFERENCE_PREFIX}malformed`,
+    };
 
     const res = await PATCH(
       patch({ services: redacted.services }, { "If-Match": "stale-revision" })

--- a/src/__tests__/api/settings.test.ts
+++ b/src/__tests__/api/settings.test.ts
@@ -54,6 +54,36 @@ layout:
 services: []
 `.trim();
 
+const SECRET_YAML = `
+schema_version: 1
+auth:
+  enabled: false
+  session_ttl_hours: 24
+appearance:
+  theme: dark
+layout:
+  columns: 4
+  row_height: 120
+services:
+  - name: Tautulli
+    url: http://tautulli.local:8181
+    widget:
+      type: tautulli-activity
+      config:
+        url: http://tautulli.local:8181
+        api_key: tautulli-secret-value
+        sections:
+          - summary
+  - name: Downloads
+    url: http://qbittorrent.local:8080
+    widget:
+      type: qbittorrent-stats
+      config:
+        url: http://qbittorrent.local:8080
+        username: admin
+        password: qbittorrent-secret-value
+`.trim();
+
 function patch(body: unknown, headers: Record<string, string> = {}) {
   return new NextRequest("http://localhost/api/settings", {
     method: "PATCH",
@@ -367,6 +397,112 @@ describe("GET /api/settings", () => {
     const res = await GET();
     const rev = res.headers.get("X-Config-Revision");
     expect(rev).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("/api/settings – widget password fields", () => {
+  let storedYaml: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    storedYaml = SECRET_YAML;
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockImplementation(() => storedYaml);
+    vi.mocked(writeFileSync).mockImplementation((_path, value) => {
+      storedYaml = String(value);
+    });
+  });
+
+  it("redacts every metadata-declared password from GET without changing non-secret config", async () => {
+    const { GET } = await import("../../app/api/settings/route");
+
+    const res = await GET();
+    const json = await res.json();
+    const serialized = JSON.stringify(json);
+
+    expect(res.status).toBe(200);
+    expect(serialized).not.toContain("tautulli-secret-value");
+    expect(serialized).not.toContain("qbittorrent-secret-value");
+    expect(json.services[0].widget.config.api_key).toMatch(
+      /^__KOKPIT_WIDGET_SECRET_REF__:/
+    );
+    expect(json.services[1].widget.config.password).toMatch(
+      /^__KOKPIT_WIDGET_SECRET_REF__:/
+    );
+    expect(json.services[0].widget.config.url).toBe(
+      "http://tautulli.local:8181"
+    );
+    expect(json.services[1].widget.config.username).toBe("admin");
+    expect(writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it("preserves unchanged secrets through rename and reorder with an optimistic revision", async () => {
+    const { GET, PATCH } = await import("../../app/api/settings/route");
+    const getRes = await GET();
+    const revision = getRes.headers.get("X-Config-Revision")!;
+    const redacted = await getRes.json();
+    const [tautulli, downloads] = redacted.services;
+
+    const res = await PATCH(
+      patch(
+        {
+          services: [
+            { ...downloads, name: "Downloads Renamed" },
+            { ...tautulli, name: "Tautulli Renamed" },
+          ],
+        },
+        { "If-Match": revision }
+      )
+    );
+    const responseText = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(storedYaml).toContain("name: Downloads Renamed");
+    expect(storedYaml).toContain("name: Tautulli Renamed");
+    expect(storedYaml).toContain("password: qbittorrent-secret-value");
+    expect(storedYaml).toContain("api_key: tautulli-secret-value");
+    expect(storedYaml).not.toContain("__KOKPIT_WIDGET_SECRET_REF__:");
+    expect(responseText).not.toContain("qbittorrent-secret-value");
+    expect(responseText).not.toContain("tautulli-secret-value");
+    expect(responseText).toContain("__KOKPIT_WIDGET_SECRET_REF__:");
+    expect(res.headers.get("X-Config-Revision")).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("writes an explicit replacement and redacts it from the PATCH response", async () => {
+    const { GET, PATCH } = await import("../../app/api/settings/route");
+    const getRes = await GET();
+    const revision = getRes.headers.get("X-Config-Revision")!;
+    const redacted = await getRes.json();
+    redacted.services[0].widget.config.api_key = "replacement-secret-value";
+
+    const res = await PATCH(
+      patch({ services: redacted.services }, { "If-Match": revision })
+    );
+    const responseText = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(storedYaml).toContain("api_key: replacement-secret-value");
+    expect(storedYaml).not.toContain("api_key: tautulli-secret-value");
+    expect(storedYaml).toContain("password: qbittorrent-secret-value");
+    expect(responseText).not.toContain("replacement-secret-value");
+    expect(responseText).not.toContain("qbittorrent-secret-value");
+    expect(responseText).toContain("__KOKPIT_WIDGET_SECRET_REF__:");
+  });
+
+  it("keeps the revision-conflict check ahead of secret resolution", async () => {
+    const { GET, PATCH } = await import("../../app/api/settings/route");
+    const redacted = await (await GET()).json();
+    redacted.services[0].widget.config.api_key =
+      "__KOKPIT_WIDGET_SECRET_REF__:malformed";
+
+    const res = await PATCH(
+      patch({ services: redacted.services }, { "If-Match": "stale-revision" })
+    );
+
+    expect(res.status).toBe(409);
+    expect((await res.json()).code).toBe("revision_mismatch");
+    expect(writeFileSync).not.toHaveBeenCalled();
   });
 });
 

--- a/src/__tests__/api/settings.test.ts
+++ b/src/__tests__/api/settings.test.ts
@@ -396,7 +396,7 @@ describe("GET /api/settings", () => {
     expect(json.layout.mobile?.row_height).toBe(80);
   });
 
-  it("returns a stable X-Config-Revision header (sha256 hex)", async () => {
+  it("returns a stable X-Config-Revision header (HMAC-SHA256 hex)", async () => {
     const { GET } = await import("../../app/api/settings/route");
     const res = await GET();
     const rev = res.headers.get("X-Config-Revision");

--- a/src/__tests__/api/settings.test.ts
+++ b/src/__tests__/api/settings.test.ts
@@ -84,6 +84,25 @@ services:
         password: qbittorrent-secret-value
 `.trim();
 
+const UNKNOWN_WIDGET_SECRET_YAML = `
+schema_version: 1
+auth:
+  enabled: false
+  session_ttl_hours: 24
+appearance:
+  theme: dark
+layout:
+  columns: 4
+  row_height: 120
+services:
+  - name: Retired integration
+    widget:
+      type: removed-widget
+      config:
+        endpoint: https://retired.local
+        api_key: unknown-widget-secret-value
+`.trim();
+
 type MutableSecretTestService = {
   widget: { config: Record<string, unknown> };
 };
@@ -439,6 +458,37 @@ describe("/api/settings – widget password fields", () => {
     );
     expect(json.services[1].widget.config.username).toBe("admin");
     expect(writeFileSync).not.toHaveBeenCalled();
+  });
+
+  it("hides and preserves complete configs for unregistered widget types", async () => {
+    storedYaml = UNKNOWN_WIDGET_SECRET_YAML;
+    const { GET, PATCH } = await import("../../app/api/settings/route");
+    const getRes = await GET();
+    const revision = getRes.headers.get("X-Config-Revision")!;
+    const redacted = await getRes.json();
+    const serialized = JSON.stringify(redacted);
+
+    expect(serialized).not.toContain("unknown-widget-secret-value");
+    expect(serialized).not.toContain("retired.local");
+    expect(redacted.services[0].widget.config).toEqual({
+      __kokpit_widget_config_reference__: expect.stringMatching(
+        /^__KOKPIT_WIDGET_CONFIG_REF__:/
+      ),
+    });
+
+    redacted.services[0].name = "Retired integration renamed";
+    const res = await PATCH(
+      patch({ services: redacted.services }, { "If-Match": revision })
+    );
+    const responseText = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(storedYaml).toContain("name: Retired integration renamed");
+    expect(storedYaml).toContain("endpoint: https://retired.local");
+    expect(storedYaml).toContain("api_key: unknown-widget-secret-value");
+    expect(storedYaml).not.toContain("__KOKPIT_WIDGET_CONFIG_REF__:");
+    expect(responseText).not.toContain("unknown-widget-secret-value");
+    expect(responseText).not.toContain("retired.local");
   });
 
   it("preserves unchanged secrets through rename and reorder with an optimistic revision", async () => {

--- a/src/__tests__/api/widget-test.test.ts
+++ b/src/__tests__/api/widget-test.test.ts
@@ -210,6 +210,64 @@ describe("POST /api/widget/test", () => {
     expect(responseText).not.toContain("saved-tautulli-secret");
   });
 
+  it("rejects an endpoint-changed saved reference before fetch with a safe code", async () => {
+    vi.mocked(readFileSync).mockReturnValue(TAUTULLI_SECRET_YAML);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { GET } = await import("../../app/api/settings/route");
+    const settings = await (await GET()).json();
+    const redactedConfig = settings.services[0].widget.config;
+    redactedConfig.url = "http://attacker.invalid:8181";
+
+    const { POST } = await import("../../app/api/widget/test/route");
+    const res = await POST(
+      post({ type: "tautulli-activity", config: redactedConfig })
+    );
+    const body = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(body).toMatchObject({
+      ok: false,
+      code: "widget_secret_scope_changed",
+    });
+    expect(JSON.stringify(body)).not.toContain("attacker.invalid");
+    expect(JSON.stringify(body)).not.toContain("saved-tautulli-secret");
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects forged and cross-widget references before fetch", async () => {
+    vi.mocked(readFileSync).mockReturnValue(TAUTULLI_SECRET_YAML);
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const { GET } = await import("../../app/api/settings/route");
+    const settings = await (await GET()).json();
+    const reference = settings.services[0].widget.config.api_key as string;
+    const forged =
+      reference.slice(0, -1) + (reference.endsWith("A") ? "B" : "A");
+
+    const { POST } = await import("../../app/api/widget/test/route");
+    for (const [type, config] of [
+      [
+        "tautulli-activity",
+        { ...settings.services[0].widget.config, api_key: forged },
+      ],
+      [
+        "plex",
+        {
+          url: "http://tautulli.local:8181",
+          token: reference,
+        },
+      ],
+    ] as const) {
+      const res = await POST(post({ type, config }));
+      const body = await res.json();
+      expect(res.status).toBe(400);
+      expect(body.code).toBe("widget_secret_reference_invalid");
+      expect(JSON.stringify(body)).not.toContain("saved-tautulli-secret");
+    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
   it("returns 504 when the connection test exceeds the 5s timeout", async () => {
     vi.useFakeTimers();
     // A fetch that never settles until its signal aborts — the route's

--- a/src/__tests__/api/widget-test.test.ts
+++ b/src/__tests__/api/widget-test.test.ts
@@ -21,6 +21,7 @@ vi.mock("next/headers", () => ({
 process.env.KOKPIT_AUTH_DISABLED = "true";
 
 import { existsSync, readFileSync } from "node:fs";
+import { WIDGET_SECRET_REFERENCE_KEY } from "@/widgets/secretReference";
 import "@/integrations";
 import { getAllWidgets } from "@/widgets";
 
@@ -101,6 +102,29 @@ afterEach(async () => {
 });
 
 describe("POST /api/widget/test", () => {
+  it("returns a bounded 500 when secret resolution fails unexpectedly", async () => {
+    vi.doMock("@/widgets/configSecrets", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("@/widgets/configSecrets")>()),
+      resolveWidgetConfigSecrets: () => {
+        throw new Error("leaked internal secret resolver detail");
+      },
+    }));
+    try {
+      const { POST } = await import("../../app/api/widget/test/route");
+      const res = await POST(post({ type: "plex", config: {} }));
+      const body = await res.json();
+
+      expect(res.status).toBe(500);
+      expect(body).toEqual({
+        ok: false,
+        error: "Connection test failed",
+      });
+      expect(JSON.stringify(body)).not.toContain("leaked");
+    } finally {
+      vi.doUnmock("@/widgets/configSecrets");
+    }
+  });
+
   it("returns 401 when auth is enabled and no session cookie is present", async () => {
     vi.stubEnv("KOKPIT_AUTH_DISABLED", "false");
     vi.mocked(readFileSync).mockReturnValue(AUTH_YAML);
@@ -265,9 +289,15 @@ describe("POST /api/widget/test", () => {
     vi.stubGlobal("fetch", fetchMock);
     const { GET } = await import("../../app/api/settings/route");
     const settings = await (await GET()).json();
-    const reference = settings.services[0].widget.config.api_key as string;
-    const forged =
-      reference.slice(0, -1) + (reference.endsWith("A") ? "B" : "A");
+    const reference = settings.services[0].widget.config.api_key as Record<
+      string,
+      string
+    >;
+    const token = reference[WIDGET_SECRET_REFERENCE_KEY];
+    const forged = {
+      [WIDGET_SECRET_REFERENCE_KEY]:
+        token.slice(0, -1) + (token.endsWith("A") ? "B" : "A"),
+    };
 
     const { POST } = await import("../../app/api/widget/test/route");
     for (const [type, config] of [

--- a/src/__tests__/api/widget-test.test.ts
+++ b/src/__tests__/api/widget-test.test.ts
@@ -47,6 +47,20 @@ services: []
 
 const AUTH_YAML = BASE_YAML.replace("enabled: false", "enabled: true");
 
+const TAUTULLI_SECRET_YAML = BASE_YAML.replace(
+  "services: []",
+  `services:
+  - name: Tautulli
+    url: http://tautulli.local:8181
+    widget:
+      type: tautulli-activity
+      config:
+        url: http://tautulli.local:8181
+        api_key: saved-tautulli-secret
+        sections:
+          - summary`
+);
+
 function post(body: unknown) {
   return new Request("http://localhost/api/widget/test", {
     method: "POST",
@@ -155,6 +169,47 @@ describe("POST /api/widget/test", () => {
     expect(json).toEqual({ ok: true });
   });
 
+  it("resolves a redacted saved password server-side for a connection test", async () => {
+    vi.mocked(readFileSync).mockReturnValue(TAUTULLI_SECRET_YAML);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((input: string | URL | Request) => {
+        const url = new URL(String(input));
+        if (url.searchParams.get("apikey") !== "saved-tautulli-secret") {
+          return Promise.reject(new Error("saved secret was not resolved"));
+        }
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              response: {
+                result: "success",
+                message: null,
+                data: { stream_count: 0, sessions: [] },
+              },
+            }),
+        } as Response);
+      })
+    );
+    const { GET } = await import("../../app/api/settings/route");
+    const settings = await (await GET()).json();
+    const redactedConfig = settings.services[0].widget.config;
+    expect(JSON.stringify(redactedConfig)).not.toContain(
+      "saved-tautulli-secret"
+    );
+
+    const { POST } = await import("../../app/api/widget/test/route");
+    const res = await POST(
+      post({ type: "tautulli-activity", config: redactedConfig })
+    );
+    const responseText = await res.text();
+
+    expect(res.status).toBe(200);
+    expect(responseText).toBe('{"ok":true}');
+    expect(responseText).not.toContain("saved-tautulli-secret");
+  });
+
   it("returns 504 when the connection test exceeds the 5s timeout", async () => {
     vi.useFakeTimers();
     // A fetch that never settles until its signal aborts — the route's
@@ -202,6 +257,44 @@ describe("POST /api/widget/test", () => {
     const res = await resPromise;
     expect(res.status).toBe(504);
     expect((await res.json()).error).toMatch(/timed out/i);
+  });
+
+  it("keeps the hard-timeout response for an aborted Tautulli request", async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation(
+        (_url: string, opts?: { signal?: AbortSignal }) =>
+          new Promise((_resolve, reject) => {
+            opts?.signal?.addEventListener("abort", () =>
+              reject(
+                new Error(
+                  "aborted http://tautulli.test/api/v2?apikey=tautulli-secret"
+                )
+              )
+            );
+          })
+      )
+    );
+    const { POST } = await import("../../app/api/widget/test/route");
+    const resPromise = POST(
+      post({
+        type: "tautulli-activity",
+        config: {
+          url: "http://tautulli.test",
+          api_key: "tautulli-secret",
+        },
+      })
+    );
+
+    await vi.advanceTimersByTimeAsync(5001);
+    const res = await resPromise;
+    const responseText = await res.text();
+
+    expect(res.status).toBe(504);
+    expect(responseText).toContain("Connection test timed out");
+    expect(responseText).not.toContain("tautulli-secret");
+    expect(responseText).not.toContain("apikey=");
   });
 
   it("returns 500 with the error message when the widget fetch fails", async () => {

--- a/src/__tests__/api/widget-test.test.ts
+++ b/src/__tests__/api/widget-test.test.ts
@@ -61,6 +61,17 @@ const TAUTULLI_SECRET_YAML = BASE_YAML.replace(
           - summary`
 );
 
+const UNRAID_SECRET_YAML = BASE_YAML.replace(
+  "services: []",
+  `services:
+  - name: Unraid
+    widget:
+      type: unraid-stats
+      config:
+        url: http://unraid.local
+        api_key: saved-unraid-secret`
+);
+
 function post(body: unknown) {
   return new Request("http://localhost/api/widget/test", {
     method: "POST",
@@ -355,7 +366,7 @@ describe("POST /api/widget/test", () => {
     expect(responseText).not.toContain("apikey=");
   });
 
-  it("returns 500 with the error message when the widget fetch fails", async () => {
+  it("returns a bounded 500 when the widget fetch fails", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({ ok: false, status: 503 } as Response)
@@ -370,6 +381,38 @@ describe("POST /api/widget/test", () => {
     expect(res.status).toBe(500);
     const json = await res.json();
     expect(json.ok).toBe(false);
-    expect(json.error).toMatch(/503/);
+    expect(json.error).toBe("Connection test failed");
+  });
+
+  it("does not reflect a saved secret from an upstream connection-test error", async () => {
+    vi.mocked(readFileSync).mockReturnValue(UNRAID_SECRET_YAML);
+    const rawMessage =
+      "upstream rejected Authorization: Bearer saved-unraid-secret";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({ errors: [{ message: rawMessage }] }),
+      } as Response)
+    );
+    const { GET } = await import("../../app/api/settings/route");
+    const settings = await (await GET()).json();
+    const redactedConfig = settings.services[0].widget.config;
+    expect(JSON.stringify(redactedConfig)).not.toContain(
+      "saved-unraid-secret"
+    );
+
+    const { POST } = await import("../../app/api/widget/test/route");
+    const res = await POST(
+      post({ type: "unraid-stats", config: redactedConfig })
+    );
+    const responseText = await res.text();
+
+    expect(res.status).toBe(500);
+    expect(responseText).toContain("Connection test failed");
+    expect(responseText).not.toContain(rawMessage);
+    expect(responseText).not.toContain("saved-unraid-secret");
   });
 });

--- a/src/__tests__/api/widget.test.ts
+++ b/src/__tests__/api/widget.test.ts
@@ -54,6 +54,12 @@ services:
       config:
         url: http://tautulli.test:8181
         api_key: tautulli-route-secret
+  - name: Unraid
+    widget:
+      type: unraid-stats
+      config:
+        url: http://unraid.test
+        api_key: saved-unraid-secret
 `.trim();
 
 const AUTH_ENABLED_YAML = SERVICES_YAML.replace("enabled: false", "enabled: true");
@@ -130,7 +136,7 @@ describe("GET /api/widget", () => {
     expect(json.data.streams).toBe(3);
   });
 
-  it("returns 500 with the error message when the widget fetch fails", async () => {
+  it("returns a bounded 500 when the widget fetch fails", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue({ ok: false, status: 502 } as Response)
@@ -138,7 +144,30 @@ describe("GET /api/widget", () => {
     const { GET } = await import("../../app/api/widget/route");
     const res = await GET(get({ type: "plex", service: "Plex" }));
     expect(res.status).toBe(500);
-    expect((await res.json()).error).toMatch(/502/);
+    expect((await res.json()).error).toBe("Widget fetch failed");
+  });
+
+  it("does not reflect a saved secret from an upstream widget error", async () => {
+    const rawMessage =
+      "upstream rejected Authorization: Bearer saved-unraid-secret";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve({ errors: [{ message: rawMessage }] }),
+      } as Response)
+    );
+    const { GET } = await import("../../app/api/widget/route");
+
+    const res = await GET(get({ type: "unraid-stats", service: "Unraid" }));
+    const responseText = await res.text();
+
+    expect(res.status).toBe(500);
+    expect(responseText).toContain("Widget fetch failed");
+    expect(responseText).not.toContain(rawMessage);
+    expect(responseText).not.toContain("saved-unraid-secret");
   });
 
   it("does not return Tautulli network rejection details from the generic route", async () => {
@@ -156,7 +185,7 @@ describe("GET /api/widget", () => {
     const responseText = await res.text();
 
     expect(res.status).toBe(500);
-    expect(responseText).toContain("Tautulli network request failed");
+    expect(responseText).toContain("Widget fetch failed");
     expect(responseText).not.toContain(leakedUrl);
     expect(responseText).not.toContain("apikey=");
     expect(responseText).not.toContain("tautulli-route-secret");

--- a/src/__tests__/api/widget.test.ts
+++ b/src/__tests__/api/widget.test.ts
@@ -48,6 +48,12 @@ services:
   - name: Mystery
     widget:
       type: not-a-real-widget
+  - name: Tautulli
+    widget:
+      type: tautulli-activity
+      config:
+        url: http://tautulli.test:8181
+        api_key: tautulli-route-secret
 `.trim();
 
 const AUTH_ENABLED_YAML = SERVICES_YAML.replace("enabled: false", "enabled: true");
@@ -133,6 +139,27 @@ describe("GET /api/widget", () => {
     const res = await GET(get({ type: "plex", service: "Plex" }));
     expect(res.status).toBe(500);
     expect((await res.json()).error).toMatch(/502/);
+  });
+
+  it("does not return Tautulli network rejection details from the generic route", async () => {
+    const leakedUrl =
+      "http://tautulli.test:8181/api/v2?apikey=tautulli-route-secret&cmd=get_activity";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error(`fetch failed for ${leakedUrl}`))
+    );
+    const { GET } = await import("../../app/api/widget/route");
+
+    const res = await GET(
+      get({ type: "tautulli-activity", service: "Tautulli" })
+    );
+    const responseText = await res.text();
+
+    expect(res.status).toBe(500);
+    expect(responseText).toContain("Tautulli network request failed");
+    expect(responseText).not.toContain(leakedUrl);
+    expect(responseText).not.toContain("apikey=");
+    expect(responseText).not.toContain("tautulli-route-secret");
   });
 
   it("returns 504 even when the widget ignores its abort signal", async () => {

--- a/src/__tests__/auth/jwt.test.ts
+++ b/src/__tests__/auth/jwt.test.ts
@@ -2,6 +2,7 @@
 import fs from "fs";
 import os from "os";
 import path from "path";
+import { jwtVerify } from "jose";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 beforeAll(() => {
@@ -15,6 +16,17 @@ describe("signJWT()", () => {
     const token = await signJWT("user-123", 24);
     expect(typeof token).toBe("string");
     expect(token.split(".")).toHaveLength(3);
+  });
+
+  it("continues signing sessions with the raw existing server secret bytes", async () => {
+    const { signJWT } = await import("../../auth/jwt");
+    const token = await signJWT("unchanged-key-user", 24);
+    const { payload } = await jwtVerify(
+      token,
+      new TextEncoder().encode(process.env.KOKPIT_SESSION_SECRET!)
+    );
+
+    expect(payload.userId).toBe("unchanged-key-user");
   });
 });
 

--- a/src/__tests__/auth/serverSecret.test.ts
+++ b/src/__tests__/auth/serverSecret.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment node
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const fs = vi.hoisted(() => ({
+  mkdirSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+vi.mock("fs", () => ({ ...fs }));
+
+describe("getServerSecret", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    delete process.env.KOKPIT_SESSION_SECRET;
+    process.env.KOKPIT_DB_PATH = "data/users.db";
+  });
+
+  afterEach(() => {
+    delete process.env.KOKPIT_SESSION_SECRET;
+    delete process.env.KOKPIT_DB_PATH;
+  });
+
+  it("uses an exclusive write and reads the secret written by a competing process", async () => {
+    fs.readFileSync
+      .mockImplementationOnce(() => {
+        throw Object.assign(new Error("missing"), { code: "ENOENT" });
+      })
+      .mockReturnValue("winner-secret\n");
+    fs.writeFileSync.mockImplementation(() => {
+      throw Object.assign(new Error("already exists"), { code: "EEXIST" });
+    });
+
+    const { getServerSecret } = await import("@/auth/serverSecret");
+
+    expect(new TextDecoder().decode(getServerSecret())).toBe("winner-secret");
+    expect(fs.writeFileSync).toHaveBeenCalledWith(
+      "data/.session_secret",
+      expect.any(String),
+      expect.objectContaining({ flag: "wx", mode: 0o600 })
+    );
+  });
+
+  it("rejects whitespace-only persisted and environment secrets", async () => {
+    fs.readFileSync.mockReturnValue(" \n\t");
+    const { getServerSecret } = await import("@/auth/serverSecret");
+    expect(() => getServerSecret()).toThrow(/must not be empty/i);
+
+    vi.resetModules();
+    process.env.KOKPIT_SESSION_SECRET = "  ";
+    const { getServerSecret: getEnvSecret } = await import("@/auth/serverSecret");
+    expect(() => getEnvSecret()).toThrow(/must not be empty/i);
+  });
+});

--- a/src/__tests__/components/ServiceForm.test.tsx
+++ b/src/__tests__/components/ServiceForm.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import ServiceForm from "@/components/ServiceForm";
 import "@/integrations";
-import { getWidgetsWithServiceEditorPreset } from "@/widgets";
+import { getWidget, getWidgetsWithServiceEditorPreset } from "@/widgets";
 
 // Every selectable tile type, with what its schema says about an empty
 // config. Derived from the registry so new integrations are covered
@@ -542,6 +542,78 @@ describe("ServiceForm – optional widget config", () => {
     });
     expect(screen.getByText(/widget configured/i)).toBeInTheDocument();
     expect(screen.queryByText(/widget not configured/i)).not.toBeInTheDocument();
+  });
+});
+
+describe("ServiceForm – Tautulli defaults", () => {
+  function selectTautulli(onSave = vi.fn()) {
+    render(
+      <ServiceForm service={null} existingGroups={[]} onSave={onSave} onClose={noop} />
+    );
+    fireEvent.change(screen.getByLabelText("Tile type"), {
+      target: { value: "tautulli-activity" },
+    });
+    return onSave;
+  }
+
+  function fillTautulliConfig() {
+    fireEvent.change(screen.getByLabelText(/^URL \*$/), {
+      target: { value: "http://tautulli.local:8181" },
+    });
+    fireEvent.change(screen.getByLabelText(/^API Key \*$/), {
+      target: { value: "secret" },
+    });
+  }
+
+  it("pre-fills defaults and preserves the final required display section", () => {
+    const onSave = selectTautulli();
+
+    expect(screen.getByLabelText("Name *")).toHaveValue("Tautulli");
+    expect(screen.getByLabelText("Icon URL")).toHaveValue(
+      "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@main/svg/tautulli.svg"
+    );
+    expect(screen.getByLabelText("Summary")).toBeChecked();
+    expect(screen.getByLabelText("Active sessions")).toBeChecked();
+    fillTautulliConfig();
+    fireEvent.click(screen.getByLabelText("Summary"));
+    expect(screen.getByLabelText("Summary")).not.toBeChecked();
+    fireEvent.click(screen.getByLabelText("Active sessions"));
+    expect(screen.getByLabelText("Active sessions")).toBeChecked();
+    fireEvent.click(screen.getByText("Save"));
+
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({
+      widget: {
+        type: "tautulli-activity",
+        config: {
+          url: "http://tautulli.local:8181",
+          api_key: "secret",
+          sections: ["sessions"],
+        },
+        refresh_interval_ms: undefined,
+      },
+    }));
+  });
+
+  it("keeps untouched display defaults out of saved config and lets the schema apply them", () => {
+    const onSave = selectTautulli();
+    fillTautulliConfig();
+    fireEvent.click(screen.getByText("Save"));
+
+    const saved = onSave.mock.calls[0][0];
+    expect(saved.widget).toEqual({
+      type: "tautulli-activity",
+      config: {
+        url: "http://tautulli.local:8181",
+        api_key: "secret",
+      },
+      refresh_interval_ms: undefined,
+    });
+    const parsed = getWidget("tautulli-activity")!.configSchema.safeParse(
+      saved.widget!.config
+    );
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) throw parsed.error;
+    expect(parsed.data.sections).toEqual(["summary", "sessions"]);
   });
 });
 

--- a/src/__tests__/components/ServiceForm.test.tsx
+++ b/src/__tests__/components/ServiceForm.test.tsx
@@ -24,6 +24,8 @@ beforeEach(() => {
 });
 
 const noop = vi.fn();
+const SAVED_TAUTULLI_SECRET =
+  '__KOKPIT_WIDGET_SECRET_REF__:["Tautulli","tautulli-activity","api_key"]';
 
 describe("ServiceForm – rendering", () => {
   it('shows "Add Service" for a new service', () => {
@@ -615,6 +617,77 @@ describe("ServiceForm – Tautulli defaults", () => {
     if (!parsed.success) throw parsed.error;
     expect(parsed.data.sections).toEqual(["summary", "sessions"]);
   });
+
+  it("keeps a saved secret out of the password input and preserves its token when unchanged", () => {
+    const onSave = vi.fn();
+    render(
+      <ServiceForm
+        service={{
+          name: "Tautulli",
+          widget: {
+            type: "tautulli-activity",
+            config: {
+              url: "http://tautulli.local:8181",
+              api_key: SAVED_TAUTULLI_SECRET,
+              sections: ["summary"],
+            },
+          },
+        }}
+        existingGroups={[]}
+        onSave={onSave}
+        onClose={noop}
+      />
+    );
+
+    expect(screen.getByLabelText(/^API Key \*$/)).toHaveValue("");
+    expect(document.body.innerHTML).not.toContain(SAVED_TAUTULLI_SECRET);
+    fireEvent.click(screen.getByText("Save"));
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        widget: expect.objectContaining({
+          config: expect.objectContaining({
+            api_key: SAVED_TAUTULLI_SECRET,
+          }),
+        }),
+      })
+    );
+  });
+
+  it("replaces a saved secret when a new password is entered", () => {
+    const onSave = vi.fn();
+    render(
+      <ServiceForm
+        service={{
+          name: "Tautulli",
+          widget: {
+            type: "tautulli-activity",
+            config: {
+              url: "http://tautulli.local:8181",
+              api_key: SAVED_TAUTULLI_SECRET,
+            },
+          },
+        }}
+        existingGroups={[]}
+        onSave={onSave}
+        onClose={noop}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/^API Key \*$/), {
+      target: { value: "new-tautulli-secret" },
+    });
+    fireEvent.click(screen.getByText("Save"));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        widget: expect.objectContaining({
+          config: expect.objectContaining({
+            api_key: "new-tautulli-secret",
+          }),
+        }),
+      })
+    );
+  });
 });
 
 describe("ServiceForm – test connection", () => {
@@ -669,6 +742,45 @@ describe("ServiceForm – test connection", () => {
       type: "plex",
       config: { url: "http://plex.local:32400", token: "secret" },
     });
+  });
+
+  it("posts the opaque saved-secret token without putting it in the password input", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ ok: true }),
+    } as Response);
+    vi.stubGlobal("fetch", fetchMock);
+    render(
+      <ServiceForm
+        service={{
+          name: "Tautulli",
+          widget: {
+            type: "tautulli-activity",
+            config: {
+              url: "http://tautulli.local:8181",
+              api_key: SAVED_TAUTULLI_SECRET,
+            },
+          },
+        }}
+        existingGroups={[]}
+        onSave={noop}
+        onClose={noop}
+      />
+    );
+
+    expect(screen.getByLabelText(/^API Key \*$/)).toHaveValue("");
+    fireEvent.click(screen.getByText("Test connection"));
+    await waitFor(() =>
+      expect(screen.getByText("Connection OK")).toBeInTheDocument()
+    );
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body).toEqual({
+      type: "tautulli-activity",
+      config: {
+        url: "http://tautulli.local:8181",
+        api_key: SAVED_TAUTULLI_SECRET,
+      },
+    });
+    expect(document.body.innerHTML).not.toContain(SAVED_TAUTULLI_SECRET);
   });
 
   it("shows the server error message when the test fails", async () => {

--- a/src/__tests__/components/ServiceForm.test.tsx
+++ b/src/__tests__/components/ServiceForm.test.tsx
@@ -3,6 +3,10 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import ServiceForm from "@/components/ServiceForm";
 import "@/integrations";
 import { getWidget, getWidgetsWithServiceEditorPreset } from "@/widgets";
+import {
+  WIDGET_SECRET_REFERENCE_KEY,
+  WIDGET_SECRET_REFERENCE_PREFIX,
+} from "@/widgets/secretReference";
 
 // Every selectable tile type, with what its schema says about an empty
 // config. Derived from the registry so new integrations are covered
@@ -24,8 +28,11 @@ beforeEach(() => {
 });
 
 const noop = vi.fn();
-const SAVED_TAUTULLI_SECRET =
-  '__KOKPIT_WIDGET_SECRET_REF__:["Tautulli","tautulli-activity","api_key"]';
+const SAVED_TAUTULLI_SECRET_TOKEN =
+  `${WIDGET_SECRET_REFERENCE_PREFIX}["Tautulli","tautulli-activity","api_key"]`;
+const SAVED_TAUTULLI_SECRET = {
+  [WIDGET_SECRET_REFERENCE_KEY]: SAVED_TAUTULLI_SECRET_TOKEN,
+};
 
 describe("ServiceForm – rendering", () => {
   it('shows "Add Service" for a new service', () => {
@@ -1079,7 +1086,7 @@ describe("ServiceForm – Tautulli defaults", () => {
     );
 
     expect(screen.getByLabelText(/^API Key \*$/)).toHaveValue("");
-    expect(document.body.innerHTML).not.toContain(SAVED_TAUTULLI_SECRET);
+    expect(document.body.innerHTML).not.toContain(SAVED_TAUTULLI_SECRET_TOKEN);
     fireEvent.click(screen.getByText("Save"));
     expect(onSave).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1168,6 +1175,70 @@ describe("ServiceForm – Tautulli defaults", () => {
         }),
       })
     );
+  });
+
+  it("restores a saved credential reference when a replacement is erased", () => {
+    const onSave = vi.fn();
+    render(
+      <ServiceForm
+        service={{
+          name: "Tautulli",
+          widget: {
+            type: "tautulli-activity",
+            config: {
+              url: "http://tautulli.local:8181",
+              api_key: SAVED_TAUTULLI_SECRET,
+            },
+          },
+        }}
+        existingGroups={[]}
+        onSave={onSave}
+        onClose={noop}
+      />
+    );
+
+    const apiKey = screen.getByLabelText(/^API Key \*$/);
+    fireEvent.change(apiKey, { target: { value: "replacement" } });
+    fireEvent.change(apiKey, { target: { value: "" } });
+    fireEvent.click(screen.getByText("Save"));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        widget: expect.objectContaining({
+          config: expect.objectContaining({ api_key: SAVED_TAUTULLI_SECRET }),
+        }),
+      })
+    );
+  });
+
+  it("announces a stale saved credential to assistive technology", () => {
+    render(
+      <ServiceForm
+        service={{
+          name: "Tautulli",
+          widget: {
+            type: "tautulli-activity",
+            config: {
+              url: "http://tautulli.local:8181",
+              api_key: SAVED_TAUTULLI_SECRET,
+            },
+          },
+        }}
+        existingGroups={[]}
+        onSave={noop}
+        onClose={noop}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/^URL \*$/), {
+      target: { value: "http://other-tautulli.local:8181" },
+    });
+
+    const apiKey = screen.getByLabelText(/^API Key \*$/);
+    const alert = screen.getByText(/saved for a different connection/i);
+    expect(apiKey).toHaveAttribute("aria-invalid", "true");
+    expect(apiKey).toHaveAttribute("aria-describedby", alert.id);
+    expect(alert).toHaveTextContent(/saved for a different connection/i);
   });
 
   it("keeps a saved credential valid when its canonical destination is restored or unrelated fields change", () => {
@@ -1423,7 +1494,7 @@ describe("ServiceForm – test connection", () => {
         api_key: SAVED_TAUTULLI_SECRET,
       },
     });
-    expect(document.body.innerHTML).not.toContain(SAVED_TAUTULLI_SECRET);
+    expect(document.body.innerHTML).not.toContain(SAVED_TAUTULLI_SECRET_TOKEN);
   });
 
   it("shows the server error message when the test fails", async () => {

--- a/src/__tests__/components/ServiceForm.test.tsx
+++ b/src/__tests__/components/ServiceForm.test.tsx
@@ -688,6 +688,145 @@ describe("ServiceForm – Tautulli defaults", () => {
       })
     );
   });
+
+  it("requires re-entering a saved credential after its destination changes, then accepts a replacement", () => {
+    const onSave = vi.fn();
+    render(
+      <ServiceForm
+        service={{
+          name: "Tautulli",
+          widget: {
+            type: "tautulli-activity",
+            config: {
+              url: "http://tautulli.local:8181",
+              api_key: SAVED_TAUTULLI_SECRET,
+            },
+          },
+        }}
+        existingGroups={[]}
+        onSave={onSave}
+        onClose={noop}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/^URL \*$/), {
+      target: { value: "http://other-tautulli.local:8181" },
+    });
+    const apiKey = screen.getByLabelText(/^API Key \*$/);
+    expect(apiKey).toBeRequired();
+    expect(screen.getByText(/re-enter.*credential/i)).toBeInTheDocument();
+    expect(screen.getByText("Test connection")).toBeDisabled();
+    fireEvent.click(screen.getByText("Save"));
+    expect(onSave).not.toHaveBeenCalled();
+
+    fireEvent.change(apiKey, { target: { value: "replacement" } });
+    expect(screen.getByText("Test connection")).toBeEnabled();
+    fireEvent.click(screen.getByText("Save"));
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        widget: expect.objectContaining({
+          config: expect.objectContaining({ api_key: "replacement" }),
+        }),
+      })
+    );
+  });
+
+  it("keeps a saved credential valid when its canonical destination is restored or unrelated fields change", () => {
+    render(
+      <ServiceForm
+        service={{
+          name: "Tautulli",
+          widget: {
+            type: "tautulli-activity",
+            config: {
+              url: "http://tautulli.local:8181",
+              api_key: SAVED_TAUTULLI_SECRET,
+              sections: ["summary"],
+            },
+          },
+        }}
+        existingGroups={[]}
+        onSave={noop}
+        onClose={noop}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText(/^URL \*$/), {
+      target: { value: "http://other-tautulli.local:8181" },
+    });
+    expect(screen.getByText("Test connection")).toBeDisabled();
+    fireEvent.change(screen.getByLabelText(/^URL \*$/), {
+      target: { value: "HTTP://TAUTULLI.local:8181/" },
+    });
+    fireEvent.click(screen.getByLabelText("Active sessions"));
+    fireEvent.change(screen.getByLabelText("Name *"), {
+      target: { value: "Renamed Tautulli" },
+    });
+    fireEvent.change(screen.getByLabelText("Icon URL"), {
+      target: { value: "https://example.test/icon.svg" },
+    });
+    fireEvent.change(screen.getByLabelText("Group"), { target: { value: "Media" } });
+    fireEvent.change(screen.getByLabelText("Size"), { target: { value: "large" } });
+    fireEvent.change(screen.getByLabelText("Refresh interval (ms)"), {
+      target: { value: "15000" },
+    });
+
+    expect(screen.queryByText(/re-enter.*credential/i)).not.toBeInTheDocument();
+    expect(screen.getByText("Test connection")).toBeEnabled();
+  });
+
+  it("binds a saved qBittorrent password to both URL and username", () => {
+    render(
+      <ServiceForm
+        service={{
+          name: "qBittorrent",
+          widget: {
+            type: "qbittorrent-stats",
+            config: {
+              url: "http://qbit.local:8080",
+              username: "admin",
+              password: SAVED_TAUTULLI_SECRET,
+            },
+          },
+        }}
+        existingGroups={[]}
+        onSave={noop}
+        onClose={noop}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Username *"), {
+      target: { value: "other-admin" },
+    });
+    expect(screen.getByText(/re-enter.*credential/i)).toBeInTheDocument();
+    expect(screen.getByLabelText("Password *")).toBeRequired();
+    expect(screen.getByText("Test connection")).toBeDisabled();
+  });
+
+  it("makes an originally optional saved token required when its scope changes", () => {
+    render(
+      <ServiceForm
+        service={{
+          name: "CPU",
+          widget: {
+            type: "netdata-cpu",
+            config: {
+              url: "http://netdata.local:19999",
+              api_token: SAVED_TAUTULLI_SECRET,
+            },
+          },
+        }}
+        existingGroups={[]}
+        onSave={noop}
+        onClose={noop}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Netdata URL *"), {
+      target: { value: "http://other-netdata.local:19999" },
+    });
+    expect(screen.getByLabelText("API Token *")).toBeRequired();
+  });
 });
 
 describe("ServiceForm – test connection", () => {

--- a/src/__tests__/components/ServiceForm.test.tsx
+++ b/src/__tests__/components/ServiceForm.test.tsx
@@ -827,6 +827,71 @@ describe("ServiceForm – Tautulli defaults", () => {
     });
     expect(screen.getByLabelText("API Token *")).toBeRequired();
   });
+
+  it("clears an optional saved credential, including after its destination changes", () => {
+    const onSave = vi.fn();
+    render(
+      <ServiceForm
+        service={{
+          name: "CPU",
+          widget: {
+            type: "netdata-cpu",
+            config: {
+              url: "http://netdata.local:19999",
+              api_token: SAVED_TAUTULLI_SECRET,
+            },
+          },
+        }}
+        existingGroups={[]}
+        onSave={onSave}
+        onClose={noop}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText("Netdata URL *"), {
+      target: { value: "http://other-netdata.local:19999" },
+    });
+    expect(screen.getByLabelText("API Token *")).toBeRequired();
+    expect(screen.getByText(/re-enter.*credential/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Clear saved credential"));
+
+    expect(screen.queryByText(/re-enter.*credential/i)).not.toBeInTheDocument();
+    expect(screen.getByLabelText("API Token")).not.toBeRequired();
+    expect(screen.queryByText("Clear saved credential")).not.toBeInTheDocument();
+    expect(screen.getByText("Test connection")).toBeEnabled();
+
+    fireEvent.click(screen.getByText("Save"));
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        widget: expect.objectContaining({
+          config: { url: "http://other-netdata.local:19999" },
+        }),
+      })
+    );
+  });
+
+  it("does not offer to clear a required saved credential", () => {
+    render(
+      <ServiceForm
+        service={{
+          name: "Tautulli",
+          widget: {
+            type: "tautulli-activity",
+            config: {
+              url: "http://tautulli.local:8181",
+              api_key: SAVED_TAUTULLI_SECRET,
+            },
+          },
+        }}
+        existingGroups={[]}
+        onSave={noop}
+        onClose={noop}
+      />
+    );
+
+    expect(screen.queryByText("Clear saved credential")).not.toBeInTheDocument();
+  });
 });
 
 describe("ServiceForm – test connection", () => {

--- a/src/__tests__/components/SettingsPage.test.tsx
+++ b/src/__tests__/components/SettingsPage.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment node
+import { existsSync, readFileSync } from "node:fs";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs", () => {
+  const readFileSync = vi.fn();
+  const existsSync = vi.fn().mockReturnValue(true);
+  return {
+    default: { readFileSync, existsSync },
+    readFileSync,
+    existsSync,
+  };
+});
+vi.mock("@/components/SettingsPanel", () => ({
+  default: () => null,
+}));
+
+const SECRET_YAML = `
+schema_version: 1
+auth:
+  enabled: false
+  session_ttl_hours: 24
+appearance:
+  theme: dark
+layout:
+  columns: 4
+  row_height: 120
+services:
+  - name: Tautulli
+    widget:
+      type: tautulli-activity
+      config:
+        url: http://tautulli.local:8181
+        api_key: rsc-saved-secret
+`.trim();
+
+describe("protected settings server component", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.mocked(existsSync).mockReturnValue(true);
+    vi.mocked(readFileSync).mockReturnValue(SECRET_YAML);
+  });
+
+  it("passes only a signed reference, never a raw saved credential", async () => {
+    const { default: SettingsPage } = await import(
+      "@/app/(protected)/settings/page"
+    );
+    const serialized = JSON.stringify(SettingsPage());
+
+    expect(serialized).not.toContain("rsc-saved-secret");
+    expect(serialized).toContain("__KOKPIT_WIDGET_SECRET_REF__:");
+  });
+});

--- a/src/__tests__/components/SettingsPanel.test.tsx
+++ b/src/__tests__/components/SettingsPanel.test.tsx
@@ -759,6 +759,62 @@ describe("SettingsPanel - groups tab", () => {
     expect(servicesTab).toBeEnabled();
   });
 
+  it("uses redacted service state returned by a successful group cascade", async () => {
+    const initial = groupsConfig();
+    initial.services[0] = {
+      ...initial.services[0],
+      widget: {
+        type: "tautulli-activity",
+        config: {
+          url: "http://tautulli.local:8181",
+          api_key: "literal-replacement",
+        },
+      },
+    };
+    const responseConfig = {
+      ...initial,
+      groups: [{ name: "Movies" }, { name: "Infra" }],
+      services: initial.services.map((service) =>
+        service.name === "Jellyfin"
+          ? {
+              ...service,
+              group: "Movies",
+              widget: {
+                ...service.widget!,
+                config: {
+                  ...service.widget!.config,
+                  api_key: "server-redacted-reference",
+                },
+              },
+            }
+          : service
+      ),
+    };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse(responseConfig))
+    );
+    render(<SettingsPanel config={initial} />);
+    fireEvent.click(screen.getByRole("button", { name: "Groups" }));
+    const input = screen.getByLabelText("Group name for Media");
+    fireEvent.change(input, { target: { value: "Movies" } });
+    fireEvent.blur(input);
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Services" }));
+    const row = screen.getByText("Jellyfin").closest("tr")!;
+    fireEvent.click(within(row).getByRole("button", { name: "Edit" }));
+    const props = JSON.parse(
+      screen.getByTestId("service-form-stub-props").textContent!
+    );
+    expect(props.service.widget.config.api_key).toBe(
+      "server-redacted-reference"
+    );
+  });
+
   it("deleting a group clears members' group and bookmark placement references", async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({}));
     vi.stubGlobal("fetch", fetchMock);

--- a/src/__tests__/components/SettingsPanel.test.tsx
+++ b/src/__tests__/components/SettingsPanel.test.tsx
@@ -24,6 +24,11 @@ vi.mock("@/components/ServiceForm", () => ({
       <button onClick={() => onSave({ name: "NewSvc", url: "http://new.local" })}>
         StubSave
       </button>
+      {service && (
+        <button onClick={() => onSave({ ...service, name: "RenamedSvc" })}>
+          StubRename
+        </button>
+      )}
       <button onClick={onClose}>StubClose</button>
     </div>
   ),
@@ -475,6 +480,84 @@ describe("SettingsPanel - services tab", () => {
     );
   });
 
+  it("uses the server's refreshed credential reference after a service rename", async () => {
+    const oldReference = "widget-secret-ref.old-name";
+    const refreshedReference = "widget-secret-ref.renamed-service";
+    const initialConfig = makeConfig({
+      services: [
+        {
+          name: "Jellyfin",
+          url: "http://jellyfin.local",
+          widget: {
+            type: "tautulli-activity",
+            config: { api_key: oldReference },
+          },
+        },
+        { name: "Portainer", url: "http://portainer.local" },
+      ],
+    });
+    const refreshedConfig = makeConfig({
+      services: [
+        {
+          name: "RenamedSvc",
+          url: "http://jellyfin.local",
+          widget: {
+            type: "tautulli-activity",
+            config: { api_key: refreshedReference },
+          },
+        },
+        { name: "Portainer", url: "http://portainer.local" },
+      ],
+    });
+    let resolveRename!: (response: Response) => void;
+    const renameResponse = new Promise<Response>((resolve) => {
+      resolveRename = resolve;
+    });
+    const fetchMock = vi
+      .fn()
+      .mockReturnValueOnce(renameResponse)
+      .mockResolvedValueOnce(jsonResponse(refreshedConfig));
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<SettingsPanel config={initialConfig} />);
+    fireEvent.click(screen.getByRole("button", { name: "Services" }));
+    fireEvent.click(within(screen.getByText("Jellyfin").closest("tr")!).getByRole("button", { name: "Edit" }));
+
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "StubRename" }));
+    });
+
+    const renamedRow = screen.getByText("RenamedSvc").closest("tr")!;
+    expect(within(renamedRow).getByRole("button", { name: "Edit" })).toBeDisabled();
+    expect(within(renamedRow).getByRole("button", { name: "Delete" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "+ Add Service" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Groups" })).toBeDisabled();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveRename(jsonResponse(refreshedConfig));
+      await renameResponse;
+    });
+
+    const refreshedRow = screen.getByText("RenamedSvc").closest("tr")!;
+    const editButton = within(refreshedRow).getByRole("button", {
+      name: "Edit",
+    });
+    expect(editButton).toBeEnabled();
+    expect(screen.getByRole("button", { name: "Groups" })).toBeEnabled();
+    fireEvent.click(editButton);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "StubRename" }));
+    });
+
+    const secondPayload = JSON.parse(
+      (fetchMock.mock.calls[1][1] as RequestInit).body as string
+    );
+    expect(secondPayload.services[0].widget.config.api_key).toBe(
+      refreshedReference
+    );
+  });
+
   it("deletes a service from state and saves via PATCH", async () => {
     const fetchMock = vi.fn().mockResolvedValue(jsonResponse({}));
     vi.stubGlobal("fetch", fetchMock);
@@ -644,6 +727,36 @@ describe("SettingsPanel - groups tab", () => {
     const jelly = body.services.find((s: Service) => s.name === "Jellyfin");
     expect(jelly.group).toBe("Movies");
     expect(body.bookmarks[0].placement.group).toBe("Movies");
+  });
+
+  it("locks service writes while a group cascade is saving", async () => {
+    let resolveCascade!: (response: Response) => void;
+    const cascadeResponse = new Promise<Response>((resolve) => {
+      resolveCascade = resolve;
+    });
+    const fetchMock = vi.fn().mockReturnValueOnce(cascadeResponse);
+    vi.stubGlobal("fetch", fetchMock);
+    gotoGroups();
+
+    const input = screen.getByLabelText("Group name for Media");
+    fireEvent.change(input, { target: { value: "Movies" } });
+    fireEvent.blur(input);
+    act(() => {
+      fireEvent.click(screen.getByRole("button", { name: "Save" }));
+    });
+
+    const servicesTab = screen.getByRole("button", { name: "Services" });
+    expect(servicesTab).toBeDisabled();
+    fireEvent.click(servicesTab);
+    expect(screen.getByText("Groups", { selector: "h2" })).toBeInTheDocument();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveCascade(jsonResponse({}));
+      await cascadeResponse;
+    });
+
+    expect(servicesTab).toBeEnabled();
   });
 
   it("deleting a group clears members' group and bookmark placement references", async () => {

--- a/src/__tests__/config/revision.test.ts
+++ b/src/__tests__/config/revision.test.ts
@@ -1,7 +1,18 @@
-import { describe, it, expect } from "vitest";
+import { createHash, createHmac } from "node:crypto";
+import { describe, it, expect, vi } from "vitest";
 import { KokpitConfigSchema, type KokpitConfig } from "@/config/schema";
 import { configRevision } from "@/config/revision";
 import { canonicalJSONString } from "@/config/canonicalJson";
+
+const { serverSecret } = vi.hoisted(() => ({
+  serverSecret: {
+    bytes: new Uint8Array([0x00, 0xff, 0x10, 0x80, 0x41]),
+  },
+}));
+
+vi.mock("@/auth/serverSecret", () => ({
+  getServerSecret: () => serverSecret.bytes,
+}));
 
 function makeConfig(overrides: Record<string, unknown> = {}): KokpitConfig {
   return KokpitConfigSchema.parse({
@@ -32,12 +43,9 @@ describe("canonicalJSONString", () => {
 });
 
 describe("configRevision", () => {
-  it("is a stable 64-char hex sha256", () => {
+  it("is a stable 64-char hex HMAC for the same key and config", () => {
     const rev = configRevision(makeConfig());
     expect(rev).toMatch(/^[0-9a-f]{64}$/);
-  });
-
-  it("returns the same revision for equal configs", () => {
     expect(configRevision(makeConfig())).toBe(configRevision(makeConfig()));
   });
 
@@ -57,5 +65,92 @@ describe("configRevision", () => {
     const before = configRevision(makeConfig());
     const after = configRevision(makeConfig({ groups: [{ name: "Media" }] }));
     expect(after).not.toBe(before);
+  });
+
+  it("changes when only a saved widget secret changes", () => {
+    const before = configRevision(
+      makeConfig({
+        services: [
+          {
+            name: "Tautulli",
+            widget: {
+              type: "tautulli-activity",
+              config: { url: "http://tautulli.local", api_key: "pin-1" },
+            },
+          },
+        ],
+      })
+    );
+    const after = configRevision(
+      makeConfig({
+        services: [
+          {
+            name: "Tautulli",
+            widget: {
+              type: "tautulli-activity",
+              config: { url: "http://tautulli.local", api_key: "pin-2" },
+            },
+          },
+        ],
+      })
+    );
+
+    expect(after).not.toBe(before);
+  });
+
+  it("changes when the server secret changes", () => {
+    const config = makeConfig();
+    const before = configRevision(config);
+    serverSecret.bytes = new Uint8Array([0x00, 0xff, 0x10, 0x80, 0x42]);
+
+    expect(configRevision(config)).not.toBe(before);
+  });
+
+  it("is purpose-separated from an unkeyed config digest and preserves key bytes", () => {
+    const config = makeConfig({
+      services: [
+        {
+          name: "Tautulli",
+          widget: {
+            type: "tautulli-activity",
+            config: { url: "http://tautulli.local", api_key: "1" },
+          },
+        },
+      ],
+    });
+    const canonical = canonicalJSONString(config);
+    const unkeyed = createHash("sha256").update(canonical).digest("hex");
+    const purposeKey = createHmac("sha256", serverSecret.bytes)
+      .update("kokpit/config-revision/v1")
+      .digest();
+    const expected = createHmac("sha256", purposeKey)
+      .update(canonical)
+      .digest("hex");
+
+    expect(configRevision(config)).toBe(expected);
+    expect(configRevision(config)).not.toBe(unkeyed);
+  });
+
+  it("does not expose a low-entropy saved secret through an unkeyed hash oracle", () => {
+    const configForPin = (pin: string) =>
+      makeConfig({
+        services: [
+          {
+            name: "Tautulli",
+            widget: {
+              type: "tautulli-activity",
+              config: { url: "http://tautulli.local", api_key: pin },
+            },
+          },
+        ],
+      });
+    const observed = configRevision(configForPin("1"));
+    const candidateDigests = ["1", "2"].map((pin) =>
+      createHash("sha256")
+        .update(canonicalJSONString(configForPin(pin)))
+        .digest("hex")
+    );
+
+    expect(candidateDigests).not.toContain(observed);
   });
 });

--- a/src/__tests__/integrations/TautulliActivityWidget.test.tsx
+++ b/src/__tests__/integrations/TautulliActivityWidget.test.tsx
@@ -38,6 +38,9 @@ describe("TautulliActivityWidget", () => {
     expect(screen.getByText("Transcoding")).toBeInTheDocument();
     expect(screen.getByText("12.5 Mbps")).toBeInTheDocument();
     expect(screen.getByText("Bandwidth")).toBeInTheDocument();
+    expect(screen.getByText("Bandwidth").closest(
+      ".tautulli-activity-widget__stat"
+    )).toHaveClass("tautulli-activity-widget__stat--bandwidth");
   });
 
   it("formats bandwidth as Kbps, Mbps, and Gbps at decimal thresholds", () => {

--- a/src/__tests__/integrations/TautulliActivityWidget.test.tsx
+++ b/src/__tests__/integrations/TautulliActivityWidget.test.tsx
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+import { render, screen } from "@testing-library/react";
+import {
+  formatBandwidth,
+  TautulliActivityWidget,
+} from "@/integrations/tautulli/activityWidget";
+
+const noop = () => {};
+
+const SAMPLE_DATA = {
+  summary: {
+    streamCount: 2,
+    directPlayCount: 1,
+    directStreamCount: 0,
+    transcodeCount: 1,
+    totalBandwidthKbps: 12_500,
+  },
+  sessions: [{
+    username: "alice",
+    title: "The Expanse · S02E05",
+    progressPercent: 42.8,
+    state: "playing",
+    mediaType: "episode",
+    transcodeDecision: "transcode",
+  }],
+};
+
+describe("TautulliActivityWidget", () => {
+  it("renders the five summary values and labels", () => {
+    render(<TautulliActivityWidget data={SAMPLE_DATA} loading={false} error={null} refresh={noop} />);
+
+    expect(screen.getByText("2")).toBeInTheDocument();
+    expect(screen.getByText("Active")).toBeInTheDocument();
+    expect(screen.getAllByText("1", { selector: ".tautulli-activity-widget__value" })).toHaveLength(2);
+    expect(screen.getByText("Direct Play")).toBeInTheDocument();
+    expect(screen.getByText("0")).toBeInTheDocument();
+    expect(screen.getByText("Direct Stream")).toBeInTheDocument();
+    expect(screen.getByText("Transcoding")).toBeInTheDocument();
+    expect(screen.getByText("12.5 Mbps")).toBeInTheDocument();
+    expect(screen.getByText("Bandwidth")).toBeInTheDocument();
+  });
+
+  it("formats bandwidth as Kbps, Mbps, and Gbps at decimal thresholds", () => {
+    expect(formatBandwidth(999)).toBe("999 Kbps");
+    expect(formatBandwidth(1_000)).toBe("1.0 Mbps");
+    expect(formatBandwidth(1_000_000)).toBe("1.0 Gbps");
+  });
+
+  it("renders username, state, title, media type, and transcode mode", () => {
+    render(<TautulliActivityWidget data={SAMPLE_DATA} loading={false} error={null} refresh={noop} />);
+
+    expect(screen.getByText("alice")).toBeInTheDocument();
+    expect(screen.getByText("Playing")).toBeInTheDocument();
+    expect(screen.getByText("The Expanse · S02E05")).toBeInTheDocument();
+    expect(screen.getByText("Episode · Transcode")).toBeInTheDocument();
+  });
+
+  it("renders an accessible clamped progress bar and rounded percentage", () => {
+    render(<TautulliActivityWidget data={SAMPLE_DATA} loading={false} error={null} refresh={noop} />);
+
+    expect(screen.getByRole("progressbar", { name: /alice progress/i }))
+      .toHaveAttribute("aria-valuenow", "43");
+    expect(screen.getByText("43%")).toBeInTheDocument();
+  });
+
+  it("renders summary-only data without a session list", () => {
+    render(<TautulliActivityWidget data={{ summary: SAMPLE_DATA.summary }} loading={false} error={null} refresh={noop} />);
+
+    expect(screen.getByLabelText("Tautulli summary")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Active Tautulli sessions")).not.toBeInTheDocument();
+  });
+
+  it("renders sessions-only data without a summary row", () => {
+    render(<TautulliActivityWidget data={{ sessions: SAMPLE_DATA.sessions }} loading={false} error={null} refresh={noop} />);
+
+    expect(screen.queryByLabelText("Tautulli summary")).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Active Tautulli sessions")).toBeInTheDocument();
+  });
+
+  it('shows "No active streams" for an empty selected session list', () => {
+    render(<TautulliActivityWidget data={{ sessions: [] }} loading={false} error={null} refresh={noop} />);
+
+    expect(screen.getByText("No active streams")).toBeInTheDocument();
+  });
+
+  it("shows loading when data is null", () => {
+    render(<TautulliActivityWidget data={null} loading={true} error={null} refresh={noop} />);
+
+    expect(screen.getByText("Loading…")).toBeInTheDocument();
+  });
+
+  it("shows an initial error when data is null", () => {
+    render(<TautulliActivityWidget data={null} loading={false} error="Tautulli responded with 401" refresh={noop} />);
+
+    expect(screen.getByText("Tautulli responded with 401")).toBeInTheDocument();
+  });
+
+  it("keeps data visible with a stale error alert", () => {
+    render(<TautulliActivityWidget data={SAMPLE_DATA} loading={false} error="Refresh failed" refresh={noop} />);
+
+    expect(screen.getByText("12.5 Mbps")).toBeInTheDocument();
+    expect(screen.getByRole("alert")).toHaveTextContent("Refresh failed");
+  });
+
+  it("renders the empty CSS state when data, loading, and error are absent", () => {
+    const { container } = render(
+      <TautulliActivityWidget data={null} loading={false} error={null} refresh={noop} />
+    );
+
+    expect(container.querySelector(".tautulli-activity-widget--empty")).toBeInTheDocument();
+    expect(screen.queryByLabelText("Tautulli summary")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Active Tautulli sessions")).not.toBeInTheDocument();
+  });
+});

--- a/src/__tests__/integrations/tautulli.test.ts
+++ b/src/__tests__/integrations/tautulli.test.ts
@@ -281,8 +281,8 @@ describe("Tautulli activity widget registration", () => {
     expect(widget?.id).toBe("tautulli-activity");
     expect(widget?.name).toBe("Tautulli Activity");
     expect(widget?.refreshInterval).toBe(10_000);
-    expect(widget?.preferredSize).toBe("large");
-    expect(widget?.minSize).toBe("wide");
+    expect(widget?.preferredSize).toBe("tall");
+    expect(widget?.minSize).toBe("tall");
     expect(widget?.serviceEditorPreset).toEqual({
       defaultName: "Tautulli",
       defaultIconUrl:

--- a/src/__tests__/integrations/tautulli.test.ts
+++ b/src/__tests__/integrations/tautulli.test.ts
@@ -269,6 +269,35 @@ describe("fetchActivity", () => {
     expect(error.message).not.toContain("super-secret-key");
   });
 
+  it("preserves externally-triggered abort semantics when reading the response body", async () => {
+    const controller = new AbortController();
+    const leakedUrl =
+      "http://tautulli.local:8181/api/v2?apikey=super-secret-key&cmd=get_activity";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => {
+          controller.abort();
+          throw new Error(`body read aborted for ${leakedUrl}`);
+        },
+      })
+    );
+
+    const error = await fetchActivity(BASE_CONFIG, controller.signal).catch(
+      (reason: unknown) => reason
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    if (!(error instanceof Error)) throw error;
+    expect(error.name).toBe("AbortError");
+    expect(error.message).toBe("Tautulli request aborted");
+    expect(error.message).not.toContain(leakedUrl);
+    expect(error.message).not.toContain("apikey=");
+    expect(error.message).not.toContain("super-secret-key");
+  });
+
   it("rejects an error envelope without exposing upstream request details", async () => {
     const upstreamMessage = "Request failed at http://tautulli.local:8181/api/v2?apikey=super-secret-key&cmd=get_activity";
     vi.stubGlobal("fetch", mockFetch({

--- a/src/__tests__/integrations/tautulli.test.ts
+++ b/src/__tests__/integrations/tautulli.test.ts
@@ -5,6 +5,8 @@ import {
   TautulliConfigSchema,
 } from "@/integrations/tautulli/api";
 import type { TautulliConfig } from "@/integrations/tautulli/api";
+import "@/integrations";
+import { getWidget } from "@/widgets";
 
 const BASE_CONFIG: TautulliConfig = {
   url: "http://tautulli.local:8181",
@@ -251,5 +253,28 @@ describe("TautulliConfigSchema", () => {
 
   it("rejects unknown section names", () => {
     expect(() => TautulliConfigSchema.parse({ ...BASE_CONFIG, sections: ["users"] })).toThrow();
+  });
+});
+
+describe("Tautulli activity widget registration", () => {
+  it("registers the configurable activity widget", () => {
+    const widget = getWidget("tautulli-activity");
+
+    expect(widget).toBeDefined();
+    expect(widget?.id).toBe("tautulli-activity");
+    expect(widget?.name).toBe("Tautulli Activity");
+    expect(widget?.refreshInterval).toBe(10_000);
+    expect(widget?.preferredSize).toBe("large");
+    expect(widget?.minSize).toBe("wide");
+    expect(widget?.serviceEditorPreset).toEqual({
+      defaultName: "Tautulli",
+      defaultIconUrl:
+        "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@main/svg/tautulli.svg",
+    });
+    expect(widget?.configFields?.map((field) => field.key)).toEqual([
+      "url",
+      "api_key",
+      "sections",
+    ]);
   });
 });

--- a/src/__tests__/integrations/tautulli.test.ts
+++ b/src/__tests__/integrations/tautulli.test.ts
@@ -154,6 +154,21 @@ describe("fetchActivity", () => {
     ]);
   });
 
+  it("trims selected user and title values", async () => {
+    const response = makeActivityResponse();
+    response.response.data.sessions = [{
+      ...ACTIVITY_RESPONSE.response.data.sessions[0],
+      username: "  alice  ",
+      full_title: "  The Expanse  ",
+    }];
+    vi.stubGlobal("fetch", mockFetch(response));
+
+    expect((await fetchActivity(BASE_CONFIG)).sessions?.[0]).toMatchObject({
+      username: "alice",
+      title: "The Expanse",
+    });
+  });
+
   it("uses full_title, title, and a neutral fallback in that order", async () => {
     const response = makeActivityResponse();
     response.response.data.sessions = [

--- a/src/__tests__/integrations/tautulli.test.ts
+++ b/src/__tests__/integrations/tautulli.test.ts
@@ -168,6 +168,23 @@ describe("fetchActivity", () => {
     ]);
   });
 
+  it("uses unknown for missing session state, media type, and transcode decision", async () => {
+    const response = makeActivityResponse();
+    response.response.data.sessions = [{
+      ...ACTIVITY_RESPONSE.response.data.sessions[0],
+      state: " ",
+      media_type: null,
+      transcode_decision: undefined,
+    }];
+    vi.stubGlobal("fetch", mockFetch(response));
+
+    expect((await fetchActivity(BASE_CONFIG)).sessions?.[0]).toMatchObject({
+      state: "unknown",
+      mediaType: "unknown",
+      transcodeDecision: "unknown",
+    });
+  });
+
   it("clamps progress to zero through one hundred", async () => {
     const response = makeActivityResponse();
     response.response.data.sessions = [

--- a/src/__tests__/integrations/tautulli.test.ts
+++ b/src/__tests__/integrations/tautulli.test.ts
@@ -1,0 +1,245 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  fetchActivity,
+  TautulliConfigSchema,
+} from "@/integrations/tautulli/api";
+import type { TautulliConfig } from "@/integrations/tautulli/api";
+
+const BASE_CONFIG: TautulliConfig = {
+  url: "http://tautulli.local:8181",
+  api_key: "super-secret-key",
+  sections: ["summary", "sessions"],
+};
+
+const ACTIVITY_RESPONSE = {
+  response: {
+    result: "success",
+    message: null,
+    data: {
+      stream_count: "2",
+      stream_count_direct_play: 1,
+      stream_count_direct_stream: "0",
+      stream_count_transcode: 1,
+      total_bandwidth: "12500",
+      sessions: [
+        {
+          username: "alice",
+          user: "legacy-alice",
+          friendly_name: "Alice Friendly",
+          full_title: "The Expanse · S02E05",
+          title: "Home",
+          progress_percent: "42.8",
+          state: "playing",
+          media_type: "episode",
+          transcode_decision: "transcode",
+          email: "alice@example.test",
+          ip_address: "203.0.113.5",
+          machine_id: "private-machine",
+          file: "/media/private/file.mkv",
+          platform: "Private Device",
+          thumb: "/library/metadata/1/thumb/1",
+        },
+      ],
+    },
+  },
+};
+
+function mockFetch(body: unknown, ok = true, status = 200) {
+  return vi.fn().mockResolvedValue({ ok, status, json: async () => body });
+}
+
+type TestActivityResponse = {
+  response: { result: string; message: string | null; data: Record<string, unknown> };
+};
+
+function makeActivityResponse(): TestActivityResponse {
+  return structuredClone(ACTIVITY_RESPONSE);
+}
+
+describe("fetchActivity", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("maps the activity response to a privacy-minimized DTO", async () => {
+    vi.stubGlobal("fetch", mockFetch(ACTIVITY_RESPONSE));
+
+    const result = await fetchActivity(BASE_CONFIG);
+
+    expect(result).toEqual({
+      summary: {
+        streamCount: 2,
+        directPlayCount: 1,
+        directStreamCount: 0,
+        transcodeCount: 1,
+        totalBandwidthKbps: 12500,
+      },
+      sessions: [{
+        username: "alice",
+        title: "The Expanse · S02E05",
+        progressPercent: 42.8,
+        state: "playing",
+        mediaType: "episode",
+        transcodeDecision: "transcode",
+      }],
+    });
+    expect(JSON.stringify(result)).not.toMatch(
+      /alice@example|203\.0\.113\.5|private-machine|private\/file|Private Device|thumb/
+    );
+  });
+
+  it("preserves a reverse-proxy HTTP root and sends documented query auth", async () => {
+    const fetchMock = mockFetch(ACTIVITY_RESPONSE);
+    vi.stubGlobal("fetch", fetchMock);
+
+    await fetchActivity({ ...BASE_CONFIG, url: "http://tautulli.local/root/tautulli" });
+
+    const url = new URL(fetchMock.mock.calls[0][0]);
+    expect(url.pathname).toBe("/root/tautulli/api/v2");
+    expect(url.searchParams.get("cmd")).toBe("get_activity");
+    expect(url.searchParams.get("apikey")).toBe("super-secret-key");
+  });
+
+  it("forwards the AbortSignal", async () => {
+    const fetchMock = mockFetch(ACTIVITY_RESPONSE);
+    vi.stubGlobal("fetch", fetchMock);
+    const controller = new AbortController();
+
+    await fetchActivity(BASE_CONFIG, controller.signal);
+
+    expect(fetchMock).toHaveBeenCalledWith(expect.any(String), { signal: controller.signal });
+  });
+
+  it("returns only summary when sections is summary-only", async () => {
+    vi.stubGlobal("fetch", mockFetch(ACTIVITY_RESPONSE));
+
+    expect(await fetchActivity({ ...BASE_CONFIG, sections: ["summary"] })).toEqual({
+      summary: {
+        streamCount: 2,
+        directPlayCount: 1,
+        directStreamCount: 0,
+        transcodeCount: 1,
+        totalBandwidthKbps: 12500,
+      },
+    });
+  });
+
+  it("returns only sessions when sections is sessions-only", async () => {
+    vi.stubGlobal("fetch", mockFetch(ACTIVITY_RESPONSE));
+
+    expect(await fetchActivity({ ...BASE_CONFIG, sections: ["sessions"] })).toEqual({
+      sessions: [{
+        username: "alice", title: "The Expanse · S02E05", progressPercent: 42.8,
+        state: "playing", mediaType: "episode", transcodeDecision: "transcode",
+      }],
+    });
+  });
+
+  it("uses username, user, friendly_name, and neutral fallbacks in that order", async () => {
+    const response = makeActivityResponse();
+    response.response.data.sessions = [
+      { ...ACTIVITY_RESPONSE.response.data.sessions[0], username: "preferred" },
+      { ...ACTIVITY_RESPONSE.response.data.sessions[0], username: " ", user: "legacy" },
+      { ...ACTIVITY_RESPONSE.response.data.sessions[0], username: null, user: "", friendly_name: "friendly" },
+      { ...ACTIVITY_RESPONSE.response.data.sessions[0], username: null, user: null, friendly_name: " " },
+    ];
+    vi.stubGlobal("fetch", mockFetch(response));
+
+    expect((await fetchActivity(BASE_CONFIG)).sessions?.map(({ username }) => username)).toEqual([
+      "preferred", "legacy", "friendly", "Unknown user",
+    ]);
+  });
+
+  it("uses full_title, title, and a neutral fallback in that order", async () => {
+    const response = makeActivityResponse();
+    response.response.data.sessions = [
+      { ...ACTIVITY_RESPONSE.response.data.sessions[0], full_title: "preferred" },
+      { ...ACTIVITY_RESPONSE.response.data.sessions[0], full_title: " ", title: "title" },
+      { ...ACTIVITY_RESPONSE.response.data.sessions[0], full_title: null, title: " " },
+    ];
+    vi.stubGlobal("fetch", mockFetch(response));
+
+    expect((await fetchActivity(BASE_CONFIG)).sessions?.map(({ title }) => title)).toEqual([
+      "preferred", "title", "Unknown title",
+    ]);
+  });
+
+  it("clamps progress to zero through one hundred", async () => {
+    const response = makeActivityResponse();
+    response.response.data.sessions = [
+      { ...ACTIVITY_RESPONSE.response.data.sessions[0], progress_percent: "-1" },
+      { ...ACTIVITY_RESPONSE.response.data.sessions[0], progress_percent: 101 },
+    ];
+    vi.stubGlobal("fetch", mockFetch(response));
+
+    expect((await fetchActivity(BASE_CONFIG)).sessions?.map(({ progressPercent }) => progressPercent)).toEqual([0, 100]);
+  });
+
+  it("normalizes missing or non-array sessions to an empty list", async () => {
+    for (const sessions of [undefined, null, {}]) {
+      const response = makeActivityResponse();
+      if (sessions === undefined) delete response.response.data.sessions;
+      else response.response.data.sessions = sessions;
+      vi.stubGlobal("fetch", mockFetch(response));
+      expect((await fetchActivity(BASE_CONFIG)).sessions).toEqual([]);
+    }
+  });
+
+  it("normalizes absent or non-finite optional metrics to zero", async () => {
+    const response = makeActivityResponse();
+    delete response.response.data.stream_count;
+    response.response.data.stream_count_direct_play = "not-a-number";
+    response.response.data.stream_count_direct_stream = "Infinity";
+    response.response.data.stream_count_transcode = Number.NaN;
+    response.response.data.total_bandwidth = null;
+    vi.stubGlobal("fetch", mockFetch(response));
+
+    expect((await fetchActivity(BASE_CONFIG)).summary).toEqual({
+      streamCount: 0, directPlayCount: 0, directStreamCount: 0, transcodeCount: 0, totalBandwidthKbps: 0,
+    });
+  });
+
+  it("throws a status-only message for non-2xx responses", async () => {
+    vi.stubGlobal("fetch", mockFetch({ response: { message: "leak" } }, false, 401));
+
+    await expect(fetchActivity(BASE_CONFIG)).rejects.toThrow("Tautulli responded with 401");
+  });
+
+  it("rejects an error envelope and redacts the configured API key", async () => {
+    vi.stubGlobal("fetch", mockFetch({ response: { result: "error", message: "Bad super-secret-key\nrequest", data: null } }));
+
+    await expect(fetchActivity(BASE_CONFIG)).rejects.toThrow("Tautulli API error: Bad [redacted] request");
+  });
+
+  it("rejects invalid JSON with a Tautulli-specific message", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => { throw new SyntaxError("bad JSON"); },
+    }));
+
+    await expect(fetchActivity(BASE_CONFIG)).rejects.toThrow("Tautulli returned invalid JSON");
+  });
+
+  it("rejects a malformed success envelope", async () => {
+    vi.stubGlobal("fetch", mockFetch({ response: { result: "success", message: null } }));
+
+    await expect(fetchActivity(BASE_CONFIG)).rejects.toThrow("Tautulli returned an invalid activity response");
+  });
+});
+
+describe("TautulliConfigSchema", () => {
+  it("defaults omitted sections to summary and sessions", () => {
+    expect(TautulliConfigSchema.parse({ url: BASE_CONFIG.url, api_key: BASE_CONFIG.api_key }).sections).toEqual(["summary", "sessions"]);
+  });
+
+  it("rejects an empty sections array", () => {
+    expect(() => TautulliConfigSchema.parse({ ...BASE_CONFIG, sections: [] })).toThrow();
+  });
+
+  it("rejects unknown section names", () => {
+    expect(() => TautulliConfigSchema.parse({ ...BASE_CONFIG, sections: ["users"] })).toThrow();
+  });
+});

--- a/src/__tests__/integrations/tautulli.test.ts
+++ b/src/__tests__/integrations/tautulli.test.ts
@@ -269,6 +269,26 @@ describe("fetchActivity", () => {
     expect(error.message).not.toContain("super-secret-key");
   });
 
+  it("sanitizes a fetch rejection named AbortError without an aborted signal", async () => {
+    const rawMessage =
+      "aborted http://tautulli.local/api/v2?apikey=super-secret-key";
+    const abortError = new Error(rawMessage);
+    abortError.name = "AbortError";
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(abortError));
+
+    const error = await fetchActivity(BASE_CONFIG).catch(
+      (reason: unknown) => reason
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    if (!(error instanceof Error)) throw error;
+    expect(error).not.toBe(abortError);
+    expect(error.name).toBe("AbortError");
+    expect(error.message).toBe("Tautulli request aborted");
+    expect(error.message).not.toContain(rawMessage);
+    expect(error.message).not.toContain("super-secret-key");
+  });
+
   it("preserves externally-triggered abort semantics when reading the response body", async () => {
     const controller = new AbortController();
     const leakedUrl =
@@ -295,6 +315,35 @@ describe("fetchActivity", () => {
     expect(error.message).toBe("Tautulli request aborted");
     expect(error.message).not.toContain(leakedUrl);
     expect(error.message).not.toContain("apikey=");
+    expect(error.message).not.toContain("super-secret-key");
+  });
+
+  it("sanitizes a body-read rejection named AbortError without an aborted signal", async () => {
+    const rawMessage =
+      "body aborted http://tautulli.local/api/v2?apikey=super-secret-key";
+    const abortError = new Error(rawMessage);
+    abortError.name = "AbortError";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => {
+          throw abortError;
+        },
+      })
+    );
+
+    const error = await fetchActivity(BASE_CONFIG).catch(
+      (reason: unknown) => reason
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    if (!(error instanceof Error)) throw error;
+    expect(error).not.toBe(abortError);
+    expect(error.name).toBe("AbortError");
+    expect(error.message).toBe("Tautulli request aborted");
+    expect(error.message).not.toContain(rawMessage);
     expect(error.message).not.toContain("super-secret-key");
   });
 

--- a/src/__tests__/integrations/tautulli.test.ts
+++ b/src/__tests__/integrations/tautulli.test.ts
@@ -204,13 +204,23 @@ describe("fetchActivity", () => {
   it("throws a status-only message for non-2xx responses", async () => {
     vi.stubGlobal("fetch", mockFetch({ response: { message: "leak" } }, false, 401));
 
-    await expect(fetchActivity(BASE_CONFIG)).rejects.toThrow("Tautulli responded with 401");
+    await expect(fetchActivity(BASE_CONFIG)).rejects.toThrow(/^Tautulli responded with 401$/);
   });
 
-  it("rejects an error envelope and redacts the configured API key", async () => {
-    vi.stubGlobal("fetch", mockFetch({ response: { result: "error", message: "Bad super-secret-key\nrequest", data: null } }));
+  it("rejects an error envelope without exposing upstream request details", async () => {
+    const upstreamMessage = "Request failed at http://tautulli.local:8181/api/v2?apikey=super-secret-key&cmd=get_activity";
+    vi.stubGlobal("fetch", mockFetch({
+      response: { result: "error", message: upstreamMessage, data: null },
+    }));
 
-    await expect(fetchActivity(BASE_CONFIG)).rejects.toThrow("Tautulli API error: Bad [redacted] request");
+    const error = await fetchActivity(BASE_CONFIG).catch((reason: unknown) => reason);
+    expect(error).toBeInstanceOf(Error);
+    if (!(error instanceof Error)) throw error;
+    expect(error.message).toBe("Tautulli API request failed");
+    expect(error.message).not.toContain(upstreamMessage);
+    expect(error.message).not.toContain("http://tautulli.local:8181");
+    expect(error.message).not.toContain("apikey=");
+    expect(error.message).not.toContain("super-secret-key");
   });
 
   it("rejects invalid JSON with a Tautulli-specific message", async () => {

--- a/src/__tests__/integrations/tautulli.test.ts
+++ b/src/__tests__/integrations/tautulli.test.ts
@@ -226,6 +226,49 @@ describe("fetchActivity", () => {
     await expect(fetchActivity(BASE_CONFIG)).rejects.toThrow(/^Tautulli responded with 401$/);
   });
 
+  it("replaces a raw network rejection that contains the request URL and API key", async () => {
+    const leakedUrl =
+      "http://tautulli.local:8181/api/v2?apikey=super-secret-key&cmd=get_activity";
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error(`fetch failed for ${leakedUrl}`))
+    );
+
+    const error = await fetchActivity(BASE_CONFIG).catch(
+      (reason: unknown) => reason
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    if (!(error instanceof Error)) throw error;
+    expect(error.message).toBe("Tautulli network request failed");
+    expect(error.message).not.toContain(leakedUrl);
+    expect(error.message).not.toContain("apikey=");
+    expect(error.message).not.toContain("super-secret-key");
+  });
+
+  it("preserves externally-triggered abort semantics without leaking rejection details", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(
+        new Error(
+          "aborted http://tautulli.local/api/v2?apikey=super-secret-key"
+        )
+      )
+    );
+
+    const error = await fetchActivity(BASE_CONFIG, controller.signal).catch(
+      (reason: unknown) => reason
+    );
+
+    expect(error).toBeInstanceOf(Error);
+    if (!(error instanceof Error)) throw error;
+    expect(error.name).toBe("AbortError");
+    expect(error.message).toBe("Tautulli request aborted");
+    expect(error.message).not.toContain("super-secret-key");
+  });
+
   it("rejects an error envelope without exposing upstream request details", async () => {
     const upstreamMessage = "Request failed at http://tautulli.local:8181/api/v2?apikey=super-secret-key&cmd=get_activity";
     vi.stubGlobal("fetch", mockFetch({

--- a/src/__tests__/widgets/configSecrets.test.ts
+++ b/src/__tests__/widgets/configSecrets.test.ts
@@ -19,6 +19,7 @@ import {
   UNKNOWN_WIDGET_CONFIG_REFERENCE_KEY,
   WidgetSecretResolutionError,
 } from "@/widgets/configSecrets";
+import { WIDGET_SECRET_REFERENCE_PREFIX } from "@/widgets/secretReference";
 import {
   createWidgetConfigReference,
   createWidgetSecretReference,
@@ -34,6 +35,7 @@ const baseDefinition = {
   configFields: [
     { key: "url", label: "URL", type: "url" as const },
     { key: "token", label: "Token", type: "password" as const },
+    { key: "number", label: "Number", type: "number" as const },
   ],
 };
 
@@ -53,10 +55,10 @@ describe("widget credential scope registry invariant", () => {
           .sort((left, right) => left[0].localeCompare(right[0]))
       )
     ).toEqual({
-      "actualbudget-accounts": ["url"],
-      "actualbudget-categories": ["url"],
-      "actualbudget-schedules": ["url"],
-      "actualbudget-summary": ["url"],
+      "actualbudget-accounts": ["url", "budget_sync_id"],
+      "actualbudget-categories": ["url", "budget_sync_id"],
+      "actualbudget-schedules": ["url", "budget_sync_id"],
+      "actualbudget-summary": ["url", "budget_sync_id"],
       "immich-stats": ["url"],
       "netdata-cpu": ["url"],
       "netdata-disk-io": ["url"],
@@ -95,6 +97,7 @@ describe("widget credential scope registry invariant", () => {
     { id: "empty-scope", credentialScopeFields: [] },
     { id: "unknown-scope", credentialScopeFields: ["missing"] },
     { id: "secret-scope", credentialScopeFields: ["token"] },
+    { id: "number-scope", credentialScopeFields: ["number"] },
   ])("rejects invalid definition $id", (extra) => {
     expect(() =>
       registerWidget({
@@ -158,6 +161,22 @@ describe("credential scope normalization", () => {
         { url: "http://host:8080", username: "admin" },
         { url: "http://host:8080", username: "Admin" }
       )
+    ).toBe(false);
+  });
+
+  it("keeps Actual Budget credentials bound to the selected budget", () => {
+    const source = {
+      url: "http://actual.local:5006",
+      budget_sync_id: "budget-a",
+    };
+    expect(
+      normalizeCredentialScope("actualbudget-accounts", source)
+    ).toEqual(["http://actual.local:5006/", "budget-a"]);
+    expect(
+      widgetCredentialScopesMatch("actualbudget-accounts", source, {
+        ...source,
+        budget_sync_id: "budget-b",
+      })
     ).toBe(false);
   });
 });
@@ -239,6 +258,94 @@ describe("destination-bound secret resolution", () => {
       }
     }
   });
+
+  it("preserves literal credentials that use the old marker prefix", () => {
+    const literal = `${WIDGET_SECRET_REFERENCE_PREFIX}a-real-password`;
+    const config = {
+      ...savedServices[0],
+      widget: {
+        type: "tautulli-activity",
+        config: {
+          url: "http://tautulli.local:8181",
+          api_key: literal,
+        },
+      },
+    } satisfies Service;
+    const redacted = redactWidgetSecrets({
+      schema_version: 1,
+      auth: { enabled: false, session_ttl_hours: 24 },
+      appearance: { theme: "dark" },
+      layout: { columns: 4, row_height: 120 },
+      services: [config],
+    });
+
+    expect(redacted.services[0].widget?.config?.api_key).not.toBe(literal);
+    expect(
+      resolveWidgetConfigSecrets(
+        "tautulli-activity",
+        redacted.services[0].widget!.config,
+        [config]
+      )
+    ).toEqual(config.widget?.config);
+  });
+});
+
+describe("registered widget config redaction", () => {
+  function kokpitConfig(service: Service) {
+    return {
+      schema_version: 1 as const,
+      auth: { enabled: false, session_ttl_hours: 24 },
+      appearance: { theme: "dark" as const },
+      layout: { columns: 4, row_height: 120 },
+      services: [service],
+    };
+  }
+
+  it("keeps invalid stored configs opaque instead of making them look valid", () => {
+    const service = {
+      name: "Plex",
+      widget: {
+        type: "plex",
+        config: { url: "http://plex.local:32400", token: "" },
+      },
+    } satisfies Service;
+    const redacted = redactWidgetSecrets(kokpitConfig(service));
+    const browserConfig = redacted.services[0].widget!.config!;
+
+    expect(browserConfig).toEqual({
+      [UNKNOWN_WIDGET_CONFIG_REFERENCE_KEY]: expect.any(String),
+    });
+    expect(
+      resolveWidgetConfigSecrets("plex", browserConfig, [service])
+    ).toEqual(service.widget?.config);
+  });
+
+  it("keeps configs with unregistered fields opaque", () => {
+    const service = {
+      name: "Plex",
+      widget: {
+        type: "plex",
+        config: {
+          url: "http://plex.local:32400",
+          token: "saved-secret",
+          legacy_token: "must-not-reach-browser",
+        },
+      },
+    } satisfies Service;
+    const redacted = redactWidgetSecrets(kokpitConfig(service));
+    const browserConfig = redacted.services[0].widget!.config!;
+
+    expect(JSON.stringify(browserConfig)).not.toContain("saved-secret");
+    expect(JSON.stringify(browserConfig)).not.toContain(
+      "must-not-reach-browser"
+    );
+    expect(browserConfig).toEqual({
+      [UNKNOWN_WIDGET_CONFIG_REFERENCE_KEY]: expect.any(String),
+    });
+    expect(
+      resolveWidgetConfigSecrets("plex", browserConfig, [service])
+    ).toEqual(service.widget?.config);
+  });
 });
 
 describe("unregistered widget config redaction", () => {
@@ -292,13 +399,13 @@ describe("unregistered widget config redaction", () => {
     );
   });
 
-  it("rejects an opaque whole-config reference on a registered widget", () => {
+  it("rejects an opaque whole-config reference mixed with regular config", () => {
     expect(() =>
       resolveWidgetConfigSecrets(
         "tautulli-activity",
         {
           url: "http://tautulli.local:8181",
-          api_key: createWidgetConfigReference(
+          [UNKNOWN_WIDGET_CONFIG_REFERENCE_KEY]: createWidgetConfigReference(
             "Retired integration",
             "removed-widget"
           ),

--- a/src/__tests__/widgets/configSecrets.test.ts
+++ b/src/__tests__/widgets/configSecrets.test.ts
@@ -334,6 +334,92 @@ describe("registered widget config redaction", () => {
     );
   });
 
+  it("preserves schema-supported non-editor fields", () => {
+    const service = {
+      name: "Actual Budget",
+      widget: {
+        type: "actualbudget-accounts",
+        config: {
+          url: "http://actual.local:5006",
+          api_key: "actual-secret",
+          budget_sync_id: "budget-id",
+          timezone: "Europe/Warsaw",
+        },
+      },
+    } satisfies Service;
+    const redacted = redactWidgetSecrets(kokpitConfig(service));
+    const browserConfig = redacted.services[0].widget!.config!;
+
+    expect(browserConfig).toMatchObject({
+      url: "http://actual.local:5006",
+      budget_sync_id: "budget-id",
+      timezone: "Europe/Warsaw",
+    });
+    expect(JSON.stringify(browserConfig)).not.toContain("actual-secret");
+    expect(
+      resolveWidgetConfigSecrets(
+        "actualbudget-accounts",
+        browserConfig,
+        [service]
+      )
+    ).toEqual(service.widget?.config);
+  });
+
+  it("hides malformed declared values with the complete config", () => {
+    const service = {
+      name: "Plex",
+      widget: {
+        type: "plex",
+        config: {
+          url: { api_key: "nested-secret" },
+          token: "saved-secret",
+        },
+      },
+    } satisfies Service;
+    const redacted = redactWidgetSecrets(kokpitConfig(service));
+    const browserConfig = redacted.services[0].widget!.config!;
+
+    expect(JSON.stringify(browserConfig)).not.toContain("nested-secret");
+    expect(JSON.stringify(browserConfig)).not.toContain("saved-secret");
+    expect(browserConfig).toEqual({
+      [UNKNOWN_WIDGET_CONFIG_REFERENCE_KEY]: expect.any(String),
+    });
+  });
+
+  it("allows a verified opaque config to be replaced", () => {
+    const service = {
+      name: "Plex",
+      widget: {
+        type: "plex",
+        config: {
+          url: { api_key: "nested-secret" },
+          token: "saved-secret",
+        },
+      },
+    } satisfies Service;
+    const opaqueConfig = redactWidgetSecrets(kokpitConfig(service)).services[0]
+      .widget!.config!;
+    const replacement = {
+      ...opaqueConfig,
+      url: "http://plex.local:32400",
+      token: "replacement-token",
+    };
+    const resolved = resolveServiceWidgetSecrets(
+      [
+        {
+          ...service,
+          widget: { ...service.widget!, config: replacement },
+        },
+      ],
+      [service]
+    );
+
+    expect(resolved[0].widget?.config).toEqual({
+      url: "http://plex.local:32400",
+      token: "replacement-token",
+    });
+  });
+
   it("keeps configs with unregistered fields opaque", () => {
     const service = {
       name: "Plex",

--- a/src/__tests__/widgets/configSecrets.test.ts
+++ b/src/__tests__/widgets/configSecrets.test.ts
@@ -37,7 +37,39 @@ describe("widget credential scope registry invariant", () => {
       widget.configFields?.some((field) => field.type === "password")
     );
 
-    expect(credentialed).toHaveLength(22);
+    expect(
+      Object.fromEntries(
+        credentialed
+          .map(
+            (widget) =>
+              [widget.id, widget.credentialScopeFields] as const
+          )
+          .sort((left, right) => left[0].localeCompare(right[0]))
+      )
+    ).toEqual({
+      "immich-stats": ["url"],
+      "netdata-cpu": ["url"],
+      "netdata-disk-io": ["url"],
+      "netdata-disk-space": ["url"],
+      "netdata-load": ["url"],
+      "netdata-net": ["url"],
+      "netdata-ram": ["url"],
+      "netdata-sensor": ["url"],
+      plex: ["url"],
+      "prowlarr-stats": ["url"],
+      "qbittorrent-stats": ["url", "username"],
+      "qbittorrent-torrents": ["url", "username"],
+      "radarr-queue": ["url"],
+      "radarr-stats": ["url"],
+      sabnzbd: ["url"],
+      "seerr-requests": ["url"],
+      "seerr-stats": ["url"],
+      "sonarr-calendar": ["url"],
+      "sonarr-queue": ["url"],
+      "tautulli-activity": ["url"],
+      "tdarr-stats": ["url"],
+      "unraid-stats": ["url"],
+    });
     for (const widget of credentialed) {
       expect(widget.credentialScopeFields?.length).toBeGreaterThan(0);
       for (const key of widget.credentialScopeFields ?? []) {

--- a/src/__tests__/widgets/configSecrets.test.ts
+++ b/src/__tests__/widgets/configSecrets.test.ts
@@ -1,0 +1,200 @@
+// @vitest-environment node
+import React from "react";
+import { z } from "zod";
+import { describe, expect, it } from "vitest";
+import "@/integrations";
+import {
+  getAllWidgets,
+  registerWidget,
+  type WidgetDefinition,
+} from "@/widgets";
+import {
+  normalizeCredentialScope,
+  widgetCredentialScopesMatch,
+} from "@/widgets/credentialScope";
+import {
+  resolveWidgetConfigSecrets,
+  WidgetSecretResolutionError,
+} from "@/widgets/configSecrets";
+import { createWidgetSecretReference } from "@/widgets/secretReference.server";
+import type { Service } from "@/config/schema";
+
+const component = () => React.createElement("div");
+const baseDefinition = {
+  name: "Invalid test widget",
+  configSchema: z.record(z.string(), z.unknown()),
+  fetchData: async () => ({}),
+  component,
+  configFields: [
+    { key: "url", label: "URL", type: "url" as const },
+    { key: "token", label: "Token", type: "password" as const },
+  ],
+};
+
+describe("widget credential scope registry invariant", () => {
+  it("requires every password-bearing widget to declare valid non-secret scope", () => {
+    const credentialed = getAllWidgets().filter((widget) =>
+      widget.configFields?.some((field) => field.type === "password")
+    );
+
+    expect(credentialed).toHaveLength(22);
+    for (const widget of credentialed) {
+      expect(widget.credentialScopeFields?.length).toBeGreaterThan(0);
+      for (const key of widget.credentialScopeFields ?? []) {
+        expect(
+          widget.configFields?.find((field) => field.key === key)?.type
+        ).not.toBe("password");
+      }
+    }
+  });
+
+  it.each([
+    { id: "missing-scope" },
+    { id: "empty-scope", credentialScopeFields: [] },
+    { id: "unknown-scope", credentialScopeFields: ["missing"] },
+    { id: "secret-scope", credentialScopeFields: ["token"] },
+  ])("rejects invalid definition $id", (extra) => {
+    expect(() =>
+      registerWidget({
+        ...baseDefinition,
+        ...extra,
+      } as WidgetDefinition)
+    ).toThrow(/credential scope/i);
+  });
+});
+
+describe("credential scope normalization", () => {
+  it("canonicalizes equivalent HTTP URLs and drops fragments", () => {
+    expect(
+      normalizeCredentialScope("tautulli-activity", {
+        url: " HTTP://Example.COM:80/#ignored ",
+      })
+    ).toEqual(["http://example.com/"]);
+    expect(
+      widgetCredentialScopesMatch(
+        "tautulli-activity",
+        { url: "http://example.com" },
+        { url: "HTTP://EXAMPLE.COM:80/#fragment" }
+      )
+    ).toBe(true);
+  });
+
+  it.each([
+    ["host", "https://other/api?a=1"],
+    ["scheme", "http://host/api?a=1"],
+    ["port", "https://host:8443/api?a=1"],
+    ["path", "https://host/other?a=1"],
+    ["query", "https://host/api?a=2"],
+  ])("keeps URL %s destination-bound", (_part, destination) => {
+    expect(
+      widgetCredentialScopesMatch(
+        "tautulli-activity",
+        { url: "https://host/api?a=1" },
+        { url: destination }
+      )
+    ).toBe(false);
+  });
+
+  it("rejects non-http URLs", () => {
+    expect(
+      normalizeCredentialScope("tautulli-activity", {
+        url: "ftp://host/api",
+      })
+    ).toBeNull();
+  });
+
+  it("compares qBittorrent usernames exactly", () => {
+    expect(
+      normalizeCredentialScope("qbittorrent-stats", {
+        url: "http://host:8080",
+        username: " Admin ",
+      })
+    ).toEqual(["http://host:8080/", " Admin "]);
+    expect(
+      widgetCredentialScopesMatch(
+        "qbittorrent-stats",
+        { url: "http://host:8080", username: "admin" },
+        { url: "http://host:8080", username: "Admin" }
+      )
+    ).toBe(false);
+  });
+});
+
+describe("destination-bound secret resolution", () => {
+  const savedServices: Service[] = [
+    {
+      name: "Tautulli",
+      widget: {
+        type: "tautulli-activity",
+        config: {
+          url: "http://tautulli.local:8181",
+          api_key: "unit-saved-secret",
+        },
+      },
+    },
+  ];
+
+  it("rejects a copied reference at a different destination", () => {
+    const reference = createWidgetSecretReference(
+      "Tautulli",
+      "tautulli-activity",
+      "api_key"
+    );
+    expect(() =>
+      resolveWidgetConfigSecrets(
+        "tautulli-activity",
+        { url: "http://other.local:8181", api_key: reference },
+        savedServices
+      )
+    ).toThrowError(
+      expect.objectContaining({
+        code: "widget_secret_scope_changed",
+      }) as WidgetSecretResolutionError
+    );
+  });
+
+  it("rejects wrong source, field, and misplaced reserved references", () => {
+    const cases = [
+      {
+        url: "http://tautulli.local:8181",
+        api_key: createWidgetSecretReference(
+          "Missing",
+          "tautulli-activity",
+          "api_key"
+        ),
+      },
+      {
+        url: "http://tautulli.local:8181",
+        api_key: createWidgetSecretReference(
+          "Tautulli",
+          "tautulli-activity",
+          "other"
+        ),
+      },
+      {
+        url: createWidgetSecretReference(
+          "Tautulli",
+          "tautulli-activity",
+          "api_key"
+        ),
+        api_key: "replacement",
+      },
+    ];
+
+    for (const config of cases) {
+      try {
+        resolveWidgetConfigSecrets(
+          "tautulli-activity",
+          config,
+          savedServices
+        );
+        throw new Error("Expected secret resolution to fail");
+      } catch (error) {
+        expect(error).toBeInstanceOf(WidgetSecretResolutionError);
+        expect((error as WidgetSecretResolutionError).code).toBe(
+          "widget_secret_reference_invalid"
+        );
+      }
+    }
+  });
+});

--- a/src/__tests__/widgets/configSecrets.test.ts
+++ b/src/__tests__/widgets/configSecrets.test.ts
@@ -13,10 +13,16 @@ import {
   widgetCredentialScopesMatch,
 } from "@/widgets/credentialScope";
 import {
+  redactWidgetSecrets,
+  resolveServiceWidgetSecrets,
   resolveWidgetConfigSecrets,
+  UNKNOWN_WIDGET_CONFIG_REFERENCE_KEY,
   WidgetSecretResolutionError,
 } from "@/widgets/configSecrets";
-import { createWidgetSecretReference } from "@/widgets/secretReference.server";
+import {
+  createWidgetConfigReference,
+  createWidgetSecretReference,
+} from "@/widgets/secretReference.server";
 import type { Service } from "@/config/schema";
 
 const component = () => React.createElement("div");
@@ -228,5 +234,75 @@ describe("destination-bound secret resolution", () => {
         );
       }
     }
+  });
+});
+
+describe("unregistered widget config redaction", () => {
+  const config = {
+    schema_version: 1 as const,
+    auth: { enabled: false, session_ttl_hours: 24 },
+    appearance: { theme: "dark" as const },
+    layout: { columns: 4, row_height: 120 },
+    services: [
+      {
+        name: "Retired integration",
+        widget: {
+          type: "removed-widget",
+          config: {
+            endpoint: "https://retired.local",
+            api_key: "unknown-widget-secret",
+          },
+        },
+      },
+    ],
+  } satisfies import("@/config/schema").KokpitConfig;
+
+  it("hides the complete config and restores it from the signed placeholder", () => {
+    const redacted = redactWidgetSecrets(config);
+    const browserConfig = redacted.services[0].widget!.config!;
+
+    expect(JSON.stringify(redacted)).not.toContain("unknown-widget-secret");
+    expect(JSON.stringify(redacted)).not.toContain("retired.local");
+    expect(browserConfig).toEqual({
+      [UNKNOWN_WIDGET_CONFIG_REFERENCE_KEY]: expect.stringMatching(
+        /^__KOKPIT_WIDGET_CONFIG_REF__:/
+      ),
+    });
+
+    const restored = resolveServiceWidgetSecrets(
+      redacted.services,
+      config.services
+    );
+    expect(restored[0].widget?.config).toEqual(config.services[0].widget?.config);
+  });
+
+  it("rejects a malformed opaque config placeholder", () => {
+    expect(() =>
+      resolveWidgetConfigSecrets(
+        "removed-widget",
+        { [UNKNOWN_WIDGET_CONFIG_REFERENCE_KEY]: "not-a-reference" },
+        config.services
+      )
+    ).toThrowError(
+      expect.objectContaining({ code: "widget_secret_reference_invalid" })
+    );
+  });
+
+  it("rejects an opaque whole-config reference on a registered widget", () => {
+    expect(() =>
+      resolveWidgetConfigSecrets(
+        "tautulli-activity",
+        {
+          url: "http://tautulli.local:8181",
+          api_key: createWidgetConfigReference(
+            "Retired integration",
+            "removed-widget"
+          ),
+        },
+        config.services
+      )
+    ).toThrowError(
+      expect.objectContaining({ code: "widget_secret_reference_invalid" })
+    );
   });
 });

--- a/src/__tests__/widgets/configSecrets.test.ts
+++ b/src/__tests__/widgets/configSecrets.test.ts
@@ -301,7 +301,7 @@ describe("registered widget config redaction", () => {
     };
   }
 
-  it("keeps invalid stored configs opaque instead of making them look valid", () => {
+  it("preserves empty saved credentials so invalid configs stay editable", () => {
     const service = {
       name: "Plex",
       widget: {
@@ -312,12 +312,26 @@ describe("registered widget config redaction", () => {
     const redacted = redactWidgetSecrets(kokpitConfig(service));
     const browserConfig = redacted.services[0].widget!.config!;
 
-    expect(browserConfig).toEqual({
-      [UNKNOWN_WIDGET_CONFIG_REFERENCE_KEY]: expect.any(String),
-    });
+    expect(browserConfig).toEqual(service.widget?.config);
     expect(
       resolveWidgetConfigSecrets("plex", browserConfig, [service])
     ).toEqual(service.widget?.config);
+  });
+
+  it("preserves known fields when a required credential is missing", () => {
+    const service = {
+      name: "Sonarr",
+      widget: {
+        type: "sonarr-queue",
+        config: { url: "http://sonarr.local:8989" },
+      },
+    } satisfies Service;
+
+    const redacted = redactWidgetSecrets(kokpitConfig(service));
+
+    expect(redacted.services[0].widget?.config).toEqual(
+      service.widget?.config
+    );
   });
 
   it("keeps configs with unregistered fields opaque", () => {

--- a/src/__tests__/widgets/secretReference.test.ts
+++ b/src/__tests__/widgets/secretReference.test.ts
@@ -1,6 +1,10 @@
 // @vitest-environment node
 import { createHmac } from "node:crypto";
 import { beforeAll, describe, expect, it } from "vitest";
+import {
+  WIDGET_SECRET_REFERENCE_KEY,
+  WIDGET_SECRET_REFERENCE_PREFIX,
+} from "@/widgets/secretReference";
 
 beforeAll(() => {
   process.env.KOKPIT_SESSION_SECRET =
@@ -19,6 +23,10 @@ function signRawPayload(payload: unknown): string {
   return `__KOKPIT_WIDGET_SECRET_REF__:${encoded}.${mac}`;
 }
 
+function fieldReference(token: string) {
+  return { [WIDGET_SECRET_REFERENCE_KEY]: token };
+}
+
 describe("signed widget secret references", () => {
   it("round-trips an authenticated locator without secret material", async () => {
     const {
@@ -32,10 +40,11 @@ describe("signed widget secret references", () => {
       "api_key"
     );
 
-    expect(token).not.toContain("saved-super-secret");
-    expect(token).not.toContain("Tautulli");
-    expect(token).not.toContain("tautulli-activity");
-    expect(token).not.toContain("api_key");
+    const encodedToken = token[WIDGET_SECRET_REFERENCE_KEY];
+    expect(encodedToken).not.toContain("saved-super-secret");
+    expect(encodedToken).not.toContain("Tautulli");
+    expect(encodedToken).not.toContain("tautulli-activity");
+    expect(encodedToken).not.toContain("api_key");
     const reference = verifyWidgetSecretReference(token);
     expect(reference).toMatchObject({ v: 2, kind: "field" });
     expect(reference).not.toBeNull();
@@ -50,15 +59,12 @@ describe("signed widget secret references", () => {
   });
 
   it("uses a purpose-derived key rather than the raw JWT key", async () => {
-    const { WIDGET_SECRET_REFERENCE_PREFIX } = await import(
-      "@/widgets/secretReference"
-    );
     const { createWidgetSecretReference } = await import(
       "@/widgets/secretReference.server"
     );
     const token = createWidgetSecretReference("A", "plex", "token");
     const [payload, signature] = token
-      .slice(WIDGET_SECRET_REFERENCE_PREFIX.length)
+      [WIDGET_SECRET_REFERENCE_KEY].slice(WIDGET_SECRET_REFERENCE_PREFIX.length)
       .split(".");
     const rawKeySignature = createHmac(
       "sha256",
@@ -71,10 +77,10 @@ describe("signed widget secret references", () => {
   });
 
   it.each([
-    "",
-    "__KOKPIT_WIDGET_SECRET_REF__:",
-    "__KOKPIT_WIDGET_SECRET_REF__:not-a-token",
-    `__KOKPIT_WIDGET_SECRET_REF__:${"a".repeat(5000)}`,
+    fieldReference(""),
+    fieldReference("__KOKPIT_WIDGET_SECRET_REF__:"),
+    fieldReference("__KOKPIT_WIDGET_SECRET_REF__:not-a-token"),
+    fieldReference(`__KOKPIT_WIDGET_SECRET_REF__:${"a".repeat(5000)}`),
   ])("fails closed for malformed or oversized value %#", async (value) => {
     const { verifyWidgetSecretReference } = await import(
       "@/widgets/secretReference.server"
@@ -95,7 +101,7 @@ describe("signed widget secret references", () => {
       "api_key"
     );
 
-    expect(token.length).toBeLessThan(2_048);
+    expect(token[WIDGET_SECRET_REFERENCE_KEY].length).toBeLessThan(2_048);
     const reference = verifyWidgetSecretReference(token);
     expect(reference).not.toBeNull();
     expect(
@@ -109,13 +115,12 @@ describe("signed widget secret references", () => {
   });
 
   it("rejects payload and signature tampering", async () => {
-    const { WIDGET_SECRET_REFERENCE_PREFIX } = await import(
-      "@/widgets/secretReference"
-    );
     const { createWidgetSecretReference, verifyWidgetSecretReference } =
       await import("@/widgets/secretReference.server");
     const token = createWidgetSecretReference("A", "plex", "token");
-    const encoded = token.slice(WIDGET_SECRET_REFERENCE_PREFIX.length);
+    const encoded = token[WIDGET_SECRET_REFERENCE_KEY].slice(
+      WIDGET_SECRET_REFERENCE_PREFIX.length
+    );
     const [payload, signature] = encoded.split(".");
     const decoded = JSON.parse(
       Buffer.from(payload, "base64url").toString("utf8")
@@ -128,12 +133,16 @@ describe("signed widget secret references", () => {
 
     expect(
       verifyWidgetSecretReference(
-        `${WIDGET_SECRET_REFERENCE_PREFIX}${changedPayload}.${signature}`
+        fieldReference(
+          `${WIDGET_SECRET_REFERENCE_PREFIX}${changedPayload}.${signature}`
+        )
       )
     ).toBeNull();
     expect(
       verifyWidgetSecretReference(
-        `${WIDGET_SECRET_REFERENCE_PREFIX}${payload}.${changedSignature}`
+        fieldReference(
+          `${WIDGET_SECRET_REFERENCE_PREFIX}${payload}.${changedSignature}`
+        )
       )
     ).toBeNull();
   });
@@ -145,23 +154,23 @@ describe("signed widget secret references", () => {
 
     expect(
       verifyWidgetSecretReference(
-        signRawPayload({
+        fieldReference(signRawPayload({
           v: 2,
           serviceName: "A",
           widgetType: "plex",
           fieldKey: "token",
-        })
+        }))
       )
     ).toBeNull();
     expect(
       verifyWidgetSecretReference(
-        signRawPayload({
+        fieldReference(signRawPayload({
           v: 1,
           serviceName: "A",
           widgetType: "plex",
           fieldKey: "token",
           extra: true,
-        })
+        }))
       )
     ).toBeNull();
   });

--- a/src/__tests__/widgets/secretReference.test.ts
+++ b/src/__tests__/widgets/secretReference.test.ts
@@ -10,7 +10,7 @@ beforeAll(() => {
 function signRawPayload(payload: unknown): string {
   const rawKey = process.env.KOKPIT_SESSION_SECRET!;
   const purposeKey = createHmac("sha256", rawKey)
-    .update("kokpit/widget-secret-reference/v1")
+    .update("kokpit/widget-secret-reference/v2")
     .digest();
   const encoded = Buffer.from(JSON.stringify(payload)).toString("base64url");
   const mac = createHmac("sha256", purposeKey)
@@ -21,8 +21,11 @@ function signRawPayload(payload: unknown): string {
 
 describe("signed widget secret references", () => {
   it("round-trips an authenticated locator without secret material", async () => {
-    const { createWidgetSecretReference, verifyWidgetSecretReference } =
-      await import("@/widgets/secretReference.server");
+    const {
+      createWidgetSecretReference,
+      verifyWidgetSecretReference,
+      widgetSecretReferenceMatches,
+    } = await import("@/widgets/secretReference.server");
     const token = createWidgetSecretReference(
       "Tautulli",
       "tautulli-activity",
@@ -30,12 +33,20 @@ describe("signed widget secret references", () => {
     );
 
     expect(token).not.toContain("saved-super-secret");
-    expect(verifyWidgetSecretReference(token)).toEqual({
-      v: 1,
-      serviceName: "Tautulli",
-      widgetType: "tautulli-activity",
-      fieldKey: "api_key",
-    });
+    expect(token).not.toContain("Tautulli");
+    expect(token).not.toContain("tautulli-activity");
+    expect(token).not.toContain("api_key");
+    const reference = verifyWidgetSecretReference(token);
+    expect(reference).toMatchObject({ v: 2, kind: "field" });
+    expect(reference).not.toBeNull();
+    expect(
+      widgetSecretReferenceMatches(
+        reference!,
+        "Tautulli",
+        "tautulli-activity",
+        "api_key"
+      )
+    ).toBe(true);
   });
 
   it("uses a purpose-derived key rather than the raw JWT key", async () => {
@@ -69,6 +80,32 @@ describe("signed widget secret references", () => {
       "@/widgets/secretReference.server"
     );
     expect(verifyWidgetSecretReference(value)).toBeNull();
+  });
+
+  it("issues a verifiable fixed-size locator for an arbitrarily long service name", async () => {
+    const {
+      createWidgetSecretReference,
+      verifyWidgetSecretReference,
+      widgetSecretReferenceMatches,
+    } = await import("@/widgets/secretReference.server");
+    const serviceName = "T".repeat(10_000);
+    const token = createWidgetSecretReference(
+      serviceName,
+      "tautulli-activity",
+      "api_key"
+    );
+
+    expect(token.length).toBeLessThan(2_048);
+    const reference = verifyWidgetSecretReference(token);
+    expect(reference).not.toBeNull();
+    expect(
+      widgetSecretReferenceMatches(
+        reference!,
+        serviceName,
+        "tautulli-activity",
+        "api_key"
+      )
+    ).toBe(true);
   });
 
   it("rejects payload and signature tampering", async () => {

--- a/src/__tests__/widgets/secretReference.test.ts
+++ b/src/__tests__/widgets/secretReference.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment node
+import { createHmac } from "node:crypto";
+import { beforeAll, describe, expect, it } from "vitest";
+
+beforeAll(() => {
+  process.env.KOKPIT_SESSION_SECRET =
+    "reference-test-secret-32-chars-minimum";
+});
+
+function signRawPayload(payload: unknown): string {
+  const rawKey = process.env.KOKPIT_SESSION_SECRET!;
+  const purposeKey = createHmac("sha256", rawKey)
+    .update("kokpit/widget-secret-reference/v1")
+    .digest();
+  const encoded = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const mac = createHmac("sha256", purposeKey)
+    .update(encoded)
+    .digest("base64url");
+  return `__KOKPIT_WIDGET_SECRET_REF__:${encoded}.${mac}`;
+}
+
+describe("signed widget secret references", () => {
+  it("round-trips an authenticated locator without secret material", async () => {
+    const { createWidgetSecretReference, verifyWidgetSecretReference } =
+      await import("@/widgets/secretReference.server");
+    const token = createWidgetSecretReference(
+      "Tautulli",
+      "tautulli-activity",
+      "api_key"
+    );
+
+    expect(token).not.toContain("saved-super-secret");
+    expect(verifyWidgetSecretReference(token)).toEqual({
+      v: 1,
+      serviceName: "Tautulli",
+      widgetType: "tautulli-activity",
+      fieldKey: "api_key",
+    });
+  });
+
+  it("uses a purpose-derived key rather than the raw JWT key", async () => {
+    const { WIDGET_SECRET_REFERENCE_PREFIX } = await import(
+      "@/widgets/secretReference"
+    );
+    const { createWidgetSecretReference } = await import(
+      "@/widgets/secretReference.server"
+    );
+    const token = createWidgetSecretReference("A", "plex", "token");
+    const [payload, signature] = token
+      .slice(WIDGET_SECRET_REFERENCE_PREFIX.length)
+      .split(".");
+    const rawKeySignature = createHmac(
+      "sha256",
+      process.env.KOKPIT_SESSION_SECRET!
+    )
+      .update(payload)
+      .digest("base64url");
+
+    expect(signature).not.toBe(rawKeySignature);
+  });
+
+  it.each([
+    "",
+    "__KOKPIT_WIDGET_SECRET_REF__:",
+    "__KOKPIT_WIDGET_SECRET_REF__:not-a-token",
+    `__KOKPIT_WIDGET_SECRET_REF__:${"a".repeat(5000)}`,
+  ])("fails closed for malformed or oversized value %#", async (value) => {
+    const { verifyWidgetSecretReference } = await import(
+      "@/widgets/secretReference.server"
+    );
+    expect(verifyWidgetSecretReference(value)).toBeNull();
+  });
+
+  it("rejects payload and signature tampering", async () => {
+    const { WIDGET_SECRET_REFERENCE_PREFIX } = await import(
+      "@/widgets/secretReference"
+    );
+    const { createWidgetSecretReference, verifyWidgetSecretReference } =
+      await import("@/widgets/secretReference.server");
+    const token = createWidgetSecretReference("A", "plex", "token");
+    const encoded = token.slice(WIDGET_SECRET_REFERENCE_PREFIX.length);
+    const [payload, signature] = encoded.split(".");
+    const decoded = JSON.parse(
+      Buffer.from(payload, "base64url").toString("utf8")
+    );
+    const changedPayload = Buffer.from(
+      JSON.stringify({ ...decoded, serviceName: "B" })
+    ).toString("base64url");
+    const changedSignature =
+      signature.slice(0, -1) + (signature.endsWith("A") ? "B" : "A");
+
+    expect(
+      verifyWidgetSecretReference(
+        `${WIDGET_SECRET_REFERENCE_PREFIX}${changedPayload}.${signature}`
+      )
+    ).toBeNull();
+    expect(
+      verifyWidgetSecretReference(
+        `${WIDGET_SECRET_REFERENCE_PREFIX}${payload}.${changedSignature}`
+      )
+    ).toBeNull();
+  });
+
+  it("rejects signed payloads with wrong version or extra shape", async () => {
+    const { verifyWidgetSecretReference } = await import(
+      "@/widgets/secretReference.server"
+    );
+
+    expect(
+      verifyWidgetSecretReference(
+        signRawPayload({
+          v: 2,
+          serviceName: "A",
+          widgetType: "plex",
+          fieldKey: "token",
+        })
+      )
+    ).toBeNull();
+    expect(
+      verifyWidgetSecretReference(
+        signRawPayload({
+          v: 1,
+          serviceName: "A",
+          widgetType: "plex",
+          fieldKey: "token",
+          extra: true,
+        })
+      )
+    ).toBeNull();
+  });
+});

--- a/src/app/(protected)/settings/page.tsx
+++ b/src/app/(protected)/settings/page.tsx
@@ -1,10 +1,11 @@
 import { getConfig } from "@/config";
 import SettingsPanel from "@/components/SettingsPanel";
+import { redactWidgetSecrets } from "@/widgets/configSecrets";
 
 export const dynamic = 'force-dynamic';
 
 export default function SettingsPage() {
-  const config = getConfig();
+  const config = redactWidgetSecrets(getConfig());
 
   return (
     <div className="settings-page">

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -150,7 +150,10 @@ export async function PATCH(request: NextRequest) {
           { status: 400 }
         );
       }
-      throw error;
+      return NextResponse.json(
+        { error: "Failed to save settings" },
+        { status: 500 }
+      );
     }
   }
 

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -10,6 +10,11 @@ import {
 } from "@/config/schema";
 import { CONFIG_REVISION_HEADER, configRevision } from "@/config/revision";
 import { pruneOrphanedUploads } from "@/lib/uploadGc";
+import {
+  redactWidgetSecrets,
+  resolveServiceWidgetSecrets,
+  WidgetSecretResolutionError,
+} from "@/widgets/configSecrets";
 
 const PatchBodySchema = z.object({
   appearance: z
@@ -75,9 +80,9 @@ export async function GET() {
   }
 
   const config = getConfig();
-  // Body shape is unchanged (other consumers/e2e depend on it); the revision
-  // rides along as a response header for the edit-mode conflict check.
-  return NextResponse.json(config, {
+  // The revision is derived from the real config while the browser receives
+  // opaque references for registry-declared password fields.
+  return NextResponse.json(redactWidgetSecrets(config), {
     headers: { [CONFIG_REVISION_HEADER]: configRevision(config) },
   });
 }
@@ -132,16 +137,33 @@ export async function PATCH(request: NextRequest) {
     }
   }
 
+  if (result.data.services !== undefined) {
+    try {
+      updates.services = resolveServiceWidgetSecrets(
+        result.data.services,
+        getConfig().services
+      );
+    } catch (error) {
+      if (error instanceof WidgetSecretResolutionError) {
+        return NextResponse.json({ error: error.message }, { status: 400 });
+      }
+      throw error;
+    }
+  }
+
   try {
     writeConfig(updates as Parameters<typeof writeConfig>[0]);
     const updated = getConfig();
     // Best-effort GC of now-orphaned uploads against the FULL merged config.
     // Never throws, so it can't affect the 200 response below.
     await pruneOrphanedUploads(updated);
-    return NextResponse.json(updated, {
+    return NextResponse.json(redactWidgetSecrets(updated), {
       headers: { [CONFIG_REVISION_HEADER]: configRevision(updated) },
     });
-  } catch (error) {
-    return NextResponse.json({ error: String(error) }, { status: 500 });
+  } catch {
+    return NextResponse.json(
+      { error: "Failed to save settings" },
+      { status: 500 }
+    );
   }
 }

--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -145,7 +145,10 @@ export async function PATCH(request: NextRequest) {
       );
     } catch (error) {
       if (error instanceof WidgetSecretResolutionError) {
-        return NextResponse.json({ error: error.message }, { status: 400 });
+        return NextResponse.json(
+          { error: error.message, code: error.code },
+          { status: 400 }
+        );
       }
       throw error;
     }

--- a/src/app/api/widget/route.ts
+++ b/src/app/api/widget/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { isRequestAuthenticated } from "@/auth";
 import { getConfig } from "@/config";
 import { getWidget } from "@/widgets";
+import { publicWidgetFetchError } from "@/widgets/publicFetchError";
 import { fetchWithHardTimeout, WidgetFetchTimeoutError } from "@/lib/fetchTimeout";
 
 export async function GET(request: Request) {
@@ -61,7 +62,7 @@ export async function GET(request: Request) {
       return NextResponse.json({ ok: false, error: err.message }, { status: 504 });
     }
     return NextResponse.json(
-      { ok: false, error: err instanceof Error ? err.message : "Widget fetch failed" },
+      { ok: false, error: publicWidgetFetchError("load") },
       { status: 500 }
     );
   }

--- a/src/app/api/widget/test/route.ts
+++ b/src/app/api/widget/test/route.ts
@@ -8,6 +8,7 @@ import {
   resolveWidgetConfigSecrets,
   WidgetSecretResolutionError,
 } from "@/widgets/configSecrets";
+import { publicWidgetFetchError } from "@/widgets/publicFetchError";
 
 // Tests a widget connection with config straight from the (possibly unsaved)
 // service form. Unlike GET /api/widget, the config arrives in the body instead
@@ -80,7 +81,7 @@ export async function POST(request: Request) {
       return NextResponse.json({ ok: false, error: err.message }, { status: 504 });
     }
     return NextResponse.json(
-      { ok: false, error: err instanceof Error ? err.message : "Connection test failed" },
+      { ok: false, error: publicWidgetFetchError("connection-test") },
       { status: 500 }
     );
   }

--- a/src/app/api/widget/test/route.ts
+++ b/src/app/api/widget/test/route.ts
@@ -1,8 +1,13 @@
 import "@/integrations";
 import { NextResponse } from "next/server";
 import { isRequestAuthenticated } from "@/auth";
+import { getConfig } from "@/config";
 import { getWidget } from "@/widgets";
 import { fetchWithHardTimeout, WidgetFetchTimeoutError } from "@/lib/fetchTimeout";
+import {
+  resolveWidgetConfigSecrets,
+  WidgetSecretResolutionError,
+} from "@/widgets/configSecrets";
 
 // Tests a widget connection with config straight from the (possibly unsaved)
 // service form. Unlike GET /api/widget, the config arrives in the body instead
@@ -34,7 +39,24 @@ export async function POST(request: Request) {
     );
   }
 
-  const parsed = widget.configSchema.safeParse(config ?? {});
+  let resolvedConfig: unknown;
+  try {
+    resolvedConfig = resolveWidgetConfigSecrets(
+      type,
+      config ?? {},
+      getConfig().services
+    );
+  } catch (error) {
+    if (error instanceof WidgetSecretResolutionError) {
+      return NextResponse.json(
+        { ok: false, error: error.message },
+        { status: 400 }
+      );
+    }
+    throw error;
+  }
+
+  const parsed = widget.configSchema.safeParse(resolvedConfig);
   if (!parsed.success) {
     const messages = parsed.error.issues
       .map((issue) => `${issue.path.join(".")}: ${issue.message}`)

--- a/src/app/api/widget/test/route.ts
+++ b/src/app/api/widget/test/route.ts
@@ -54,7 +54,10 @@ export async function POST(request: Request) {
         { status: 400 }
       );
     }
-    throw error;
+    return NextResponse.json(
+      { ok: false, error: publicWidgetFetchError("connection-test") },
+      { status: 500 }
+    );
   }
 
   const parsed = widget.configSchema.safeParse(resolvedConfig);

--- a/src/app/api/widget/test/route.ts
+++ b/src/app/api/widget/test/route.ts
@@ -49,7 +49,7 @@ export async function POST(request: Request) {
   } catch (error) {
     if (error instanceof WidgetSecretResolutionError) {
       return NextResponse.json(
-        { ok: false, error: error.message },
+        { ok: false, error: error.message, code: error.code },
         { status: 400 }
       );
     }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3622,8 +3622,12 @@ button {
 .tautulli-activity-widget__summary {
   display: grid;
   flex-shrink: 0;
-  grid-template-columns: repeat(5, minmax(0, 1fr));
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 4px;
+}
+
+.tautulli-activity-widget__stat--bandwidth {
+  grid-column: 1 / -1;
 }
 
 .tautulli-activity-widget__sessions {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3607,8 +3607,9 @@ button {
 
 /* User-injected custom CSS from appearance.customCss in settings.yaml */
 /* This layer is loaded last and always wins without needing !important */
-@layer user-custom;
+@layer tautulli-widget, user-custom;
 
+@layer tautulli-widget {
 .tautulli-activity-widget {
   display: flex;
   flex: 1 1 0;
@@ -3725,7 +3726,7 @@ button {
 
 .tautulli-activity-widget__stale-error {
   flex-shrink: 0;
-  color: #f87171;
+  color: var(--color-error);
   font-size: 0.7rem;
   text-align: center;
 }
@@ -3742,5 +3743,6 @@ button {
 }
 
 .tautulli-activity-widget__hint--error {
-  color: #f87171;
+  color: var(--color-error);
+}
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -3608,3 +3608,139 @@ button {
 /* User-injected custom CSS from appearance.customCss in settings.yaml */
 /* This layer is loaded last and always wins without needing !important */
 @layer user-custom;
+
+.tautulli-activity-widget {
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.tautulli-activity-widget__summary {
+  display: grid;
+  flex-shrink: 0;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 4px;
+}
+
+.tautulli-activity-widget__sessions {
+  display: flex;
+  flex: 1 1 0;
+  flex-direction: column;
+  gap: 5px;
+  min-height: 0;
+  overflow-y: auto;
+}
+
+.tautulli-activity-widget__stat,
+.tautulli-activity-widget__session {
+  min-width: 0;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius);
+  background: var(--color-surface-2);
+}
+
+.tautulli-activity-widget__stat {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 5px 3px;
+}
+
+.tautulli-activity-widget__value {
+  max-width: 100%;
+  overflow: hidden;
+  color: var(--color-text);
+  font-size: 0.9rem;
+  font-weight: 700;
+  line-height: 1;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tautulli-activity-widget__label {
+  color: var(--color-text-muted);
+  font-size: 0.58rem;
+  font-weight: 500;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.tautulli-activity-widget__session {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 4px 8px;
+  padding: 6px;
+}
+
+.tautulli-activity-widget__session-heading,
+.tautulli-activity-widget__session-media {
+  display: flex;
+  grid-column: 1 / -1;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+  color: var(--color-text-muted);
+  font-size: 0.68rem;
+}
+
+.tautulli-activity-widget__username,
+.tautulli-activity-widget__title {
+  overflow: hidden;
+  color: var(--color-text);
+  font-weight: 600;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tautulli-activity-widget__progress {
+  height: 3px;
+  overflow: hidden;
+  border-radius: 999px;
+  background: var(--color-surface-2);
+}
+
+.tautulli-activity-widget__progress > span {
+  display: block;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--color-accent);
+}
+
+.tautulli-activity-widget__progress-label {
+  color: var(--color-text-muted);
+  font-size: 0.65rem;
+  line-height: 1;
+}
+
+.tautulli-activity-widget__no-sessions {
+  margin: auto;
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+}
+
+.tautulli-activity-widget__stale-error {
+  flex-shrink: 0;
+  color: #f87171;
+  font-size: 0.7rem;
+  text-align: center;
+}
+
+.tautulli-activity-widget--empty {
+  align-items: center;
+  justify-content: center;
+  min-height: 2rem;
+}
+
+.tautulli-activity-widget__hint {
+  color: var(--color-text-muted);
+  font-size: 0.8rem;
+}
+
+.tautulli-activity-widget__hint--error {
+  color: #f87171;
+}

--- a/src/auth/jwt.ts
+++ b/src/auth/jwt.ts
@@ -1,36 +1,5 @@
 import { SignJWT, jwtVerify } from "jose";
-import { randomBytes } from "crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { dirname, join } from "path";
-
-let cachedSecret: Uint8Array | null = null;
-
-function getSecret(): Uint8Array {
-  if (cachedSecret) return cachedSecret;
-
-  const envSecret = process.env.KOKPIT_SESSION_SECRET;
-  if (envSecret) {
-    cachedSecret = new TextEncoder().encode(envSecret);
-    return cachedSecret;
-  }
-
-  // No env var — auto-generate a secret and persist it next to the database so
-  // it survives container restarts via the /data volume mount.
-  const dbDir = dirname(process.env.KOKPIT_DB_PATH ?? "data/users.db");
-  const secretPath = join(dbDir, ".session_secret");
-
-  let secret: string;
-  if (existsSync(secretPath)) {
-    secret = readFileSync(secretPath, "utf-8").trim();
-  } else {
-    secret = randomBytes(32).toString("hex");
-    mkdirSync(dbDir, { recursive: true });
-    writeFileSync(secretPath, secret, { encoding: "utf-8", mode: 0o600 });
-  }
-
-  cachedSecret = new TextEncoder().encode(secret);
-  return cachedSecret;
-}
+import { getServerSecret } from "./serverSecret";
 
 export async function signJWT(
   userId: string,
@@ -41,14 +10,14 @@ export async function signJWT(
     .setProtectedHeader({ alg: "HS256" })
     .setExpirationTime(expiresAt)
     .setIssuedAt()
-    .sign(getSecret());
+    .sign(getServerSecret());
 }
 
 export async function verifyJWT(
   token: string
 ): Promise<{ userId: string } | null> {
   try {
-    const { payload } = await jwtVerify(token, getSecret());
+    const { payload } = await jwtVerify(token, getServerSecret());
     if (typeof payload.userId !== "string") return null;
     if (payload.type === "totp_challenge") return null;
     return { userId: payload.userId };
@@ -62,14 +31,14 @@ export async function signTotpChallenge(userId: string): Promise<string> {
     .setProtectedHeader({ alg: "HS256" })
     .setExpirationTime("5m")
     .setIssuedAt()
-    .sign(getSecret());
+    .sign(getServerSecret());
 }
 
 export async function verifyTotpChallenge(
   token: string
 ): Promise<{ userId: string } | null> {
   try {
-    const { payload } = await jwtVerify(token, getSecret());
+    const { payload } = await jwtVerify(token, getServerSecret());
     if (typeof payload.userId !== "string") return null;
     if (payload.type !== "totp_challenge") return null;
     return { userId: payload.userId };

--- a/src/auth/serverSecret.ts
+++ b/src/auth/serverSecret.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "crypto";
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
 import { dirname, join } from "path";
 
 let cachedSecret: Uint8Array | null = null;
@@ -13,7 +13,10 @@ export function getServerSecret(): Uint8Array {
   if (cachedSecret) return cachedSecret;
 
   const envSecret = process.env.KOKPIT_SESSION_SECRET;
-  if (envSecret) {
+  if (envSecret !== undefined) {
+    if (!envSecret.trim()) {
+      throw new Error("KOKPIT_SESSION_SECRET must not be empty");
+    }
     cachedSecret = new TextEncoder().encode(envSecret);
     return cachedSecret;
   }
@@ -22,12 +25,40 @@ export function getServerSecret(): Uint8Array {
   const secretPath = join(dbDir, ".session_secret");
 
   let secret: string;
-  if (existsSync(secretPath)) {
+  try {
     secret = readFileSync(secretPath, "utf-8").trim();
-  } else {
-    secret = randomBytes(32).toString("hex");
+  } catch (error) {
+    if (
+      typeof error !== "object" ||
+      error === null ||
+      !("code" in error) ||
+      error.code !== "ENOENT"
+    ) {
+      throw error;
+    }
     mkdirSync(dbDir, { recursive: true });
-    writeFileSync(secretPath, secret, { encoding: "utf-8", mode: 0o600 });
+    secret = randomBytes(32).toString("hex");
+    try {
+      writeFileSync(secretPath, secret, {
+        encoding: "utf-8",
+        mode: 0o600,
+        flag: "wx",
+      });
+    } catch (writeError) {
+      if (
+        typeof writeError !== "object" ||
+        writeError === null ||
+        !("code" in writeError) ||
+        writeError.code !== "EEXIST"
+      ) {
+        throw writeError;
+      }
+      secret = readFileSync(secretPath, "utf-8").trim();
+    }
+  }
+
+  if (!secret.trim()) {
+    throw new Error("Server session secret must not be empty");
   }
 
   cachedSecret = new TextEncoder().encode(secret);

--- a/src/auth/serverSecret.ts
+++ b/src/auth/serverSecret.ts
@@ -1,0 +1,35 @@
+import { randomBytes } from "crypto";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, join } from "path";
+
+let cachedSecret: Uint8Array | null = null;
+
+/**
+ * Returns the stable server secret shared by session signing and other
+ * purpose-separated server primitives. The persisted bytes intentionally
+ * retain the existing JWT behavior so already-issued sessions remain valid.
+ */
+export function getServerSecret(): Uint8Array {
+  if (cachedSecret) return cachedSecret;
+
+  const envSecret = process.env.KOKPIT_SESSION_SECRET;
+  if (envSecret) {
+    cachedSecret = new TextEncoder().encode(envSecret);
+    return cachedSecret;
+  }
+
+  const dbDir = dirname(process.env.KOKPIT_DB_PATH ?? "data/users.db");
+  const secretPath = join(dbDir, ".session_secret");
+
+  let secret: string;
+  if (existsSync(secretPath)) {
+    secret = readFileSync(secretPath, "utf-8").trim();
+  } else {
+    secret = randomBytes(32).toString("hex");
+    mkdirSync(dbDir, { recursive: true });
+    writeFileSync(secretPath, secret, { encoding: "utf-8", mode: 0o600 });
+  }
+
+  cachedSecret = new TextEncoder().encode(secret);
+  return cachedSecret;
+}

--- a/src/components/ServiceForm.tsx
+++ b/src/components/ServiceForm.tsx
@@ -353,6 +353,16 @@ function WidgetConfigFields({
                 savedSecret ? "Saved — enter a new value to replace" : field.placeholder
               }
             />
+            {savedSecret && !field.required && (
+              <button
+                type="button"
+                className="settings-btn settings-btn--danger"
+                onClick={() => onChange(field.key, undefined)}
+                aria-label={`Clear saved ${field.label}`}
+              >
+                Clear saved credential
+              </button>
+            )}
             {needsReplacement && (
               <p className="settings-form-hint settings-form-hint--error">
                 This credential is saved for a different connection. Re-enter the credential to continue.

--- a/src/components/ServiceForm.tsx
+++ b/src/components/ServiceForm.tsx
@@ -16,6 +16,7 @@ import {
   getWidgetsWithServiceEditorPreset,
 } from "@/widgets";
 import type { WidgetConfigField } from "@/widgets";
+import { widgetCredentialScopesMatch } from "@/widgets/credentialScope";
 import { isWidgetSecretReference } from "@/widgets/secretReference";
 import { SIZE_ORDER, sizeLabel } from "./settingsSizeOptions";
 
@@ -282,10 +283,12 @@ function WidgetConfigFields({
   fields,
   config,
   onChange,
+  savedCredentialsStale,
 }: {
   fields: WidgetConfigField[];
   config: Record<string, unknown>;
   onChange: (key: string, value: unknown) => void;
+  savedCredentialsStale: boolean;
 }) {
   return (
     <>
@@ -293,6 +296,7 @@ function WidgetConfigFields({
         const value = config[field.key] ?? field.defaultValue;
         const savedSecret =
           field.type === "password" && isWidgetSecretReference(value);
+        const needsReplacement = savedSecret && savedCredentialsStale;
 
         if (field.type === "multiselect" && field.options) {
           const selected = Array.isArray(value) ? (value as string[]) : [];
@@ -326,11 +330,14 @@ function WidgetConfigFields({
 
         return (
           <div key={field.key} className="settings-form-row">
-            <label htmlFor={`sf-widget-${field.key}`}>{field.label}{field.required && " *"}</label>
+            <label htmlFor={`sf-widget-${field.key}`}>
+              {field.label}{(field.required || needsReplacement) && " *"}
+            </label>
             <input
               id={`sf-widget-${field.key}`}
               type={field.type === "password" ? "password" : field.type === "number" ? "number" : "text"}
               className="settings-input"
+              required={needsReplacement}
               value={
                 savedSecret
                   ? ""
@@ -346,6 +353,11 @@ function WidgetConfigFields({
                 savedSecret ? "Saved — enter a new value to replace" : field.placeholder
               }
             />
+            {needsReplacement && (
+              <p className="settings-form-hint settings-form-hint--error">
+                This credential is saved for a different connection. Re-enter the credential to continue.
+              </p>
+            )}
             {field.description && (
               <p className="settings-form-hint">{field.description}</p>
             )}
@@ -428,15 +440,39 @@ export default function ServiceForm({
 
   const activeWidgetType =
     tileType !== "" ? tileType : orphanWidget?.type ?? null;
-  const activeCleanedConfig = cleanWidgetConfig(
+  const activeRawConfig =
     tileType !== ""
       ? widgetConfig
-      : ((orphanWidget?.config as Record<string, unknown>) ?? {})
+      : ((orphanWidget?.config as Record<string, unknown>) ?? {});
+  const activeCleanedConfig = cleanWidgetConfig(
+    activeRawConfig
   );
+  const originalWidgetConfig =
+    service?.widget?.type === activeWidgetType
+      ? ((service.widget.config as Record<string, unknown>) ?? {})
+      : null;
+  const retainedSavedSecret = selectedWidgetDef?.configFields?.some(
+    (field) =>
+      field.type === "password" &&
+      isWidgetSecretReference(activeRawConfig[field.key])
+  ) ?? false;
+  // Signed references are intentionally opaque to the browser. The only
+  // client-side decision is whether their original and current destinations
+  // normalize to the same registry-declared credential scope.
+  const savedCredentialsStale =
+    retainedSavedSecret &&
+    (!activeWidgetType ||
+      !originalWidgetConfig ||
+      !widgetCredentialScopesMatch(
+        activeWidgetType,
+        originalWidgetConfig,
+        activeCleanedConfig
+      ));
   // Mirrors the dashboard's rule: the widget renders only when its config
   // passes the schema. Unknown types can't be validated client-side.
   const widgetConfigValid = selectedWidgetDef
-    ? selectedWidgetDef.configSchema.safeParse(activeCleanedConfig).success
+    ? selectedWidgetDef.configSchema.safeParse(activeCleanedConfig).success &&
+      !savedCredentialsStale
     : null;
 
   function handleWidgetConfigChange(key: string, value: unknown) {
@@ -483,7 +519,7 @@ export default function ServiceForm({
   }
 
   async function handleTestConnection() {
-    if (!activeWidgetType) return;
+    if (!activeWidgetType || savedCredentialsStale) return;
     setTestStatus({ state: "testing" });
     try {
       const res = await fetch("/api/widget/test", {
@@ -637,6 +673,8 @@ export default function ServiceForm({
       return;
     }
     setNameError(null);
+
+    if (savedCredentialsStale) return;
 
     let widget: ServiceWidget | undefined;
     if (tileType !== "") {
@@ -951,6 +989,7 @@ export default function ServiceForm({
                 <WidgetConfigFields
                   fields={selectedWidgetDef.configFields}
                   config={tileType !== "" ? widgetConfig : orphanConfig}
+                  savedCredentialsStale={savedCredentialsStale}
                   onChange={
                     tileType !== ""
                       ? handleWidgetConfigChange

--- a/src/components/ServiceForm.tsx
+++ b/src/components/ServiceForm.tsx
@@ -289,7 +289,7 @@ function WidgetConfigFields({
   return (
     <>
       {fields.map((field) => {
-        const value = config[field.key];
+        const value = config[field.key] ?? field.defaultValue;
 
         if (field.type === "multiselect" && field.options) {
           const selected = Array.isArray(value) ? (value as string[]) : [];
@@ -306,6 +306,7 @@ function WidgetConfigFields({
                         const next = e.target.checked
                           ? [...selected, opt.value]
                           : selected.filter((v) => v !== opt.value);
+                        if (field.required && next.length === 0) return;
                         onChange(field.key, next);
                       }}
                     />

--- a/src/components/ServiceForm.tsx
+++ b/src/components/ServiceForm.tsx
@@ -16,6 +16,7 @@ import {
   getWidgetsWithServiceEditorPreset,
 } from "@/widgets";
 import type { WidgetConfigField } from "@/widgets";
+import { isWidgetSecretReference } from "@/widgets/secretReference";
 import { SIZE_ORDER, sizeLabel } from "./settingsSizeOptions";
 
 interface ServiceFormProps {
@@ -290,6 +291,8 @@ function WidgetConfigFields({
     <>
       {fields.map((field) => {
         const value = config[field.key] ?? field.defaultValue;
+        const savedSecret =
+          field.type === "password" && isWidgetSecretReference(value);
 
         if (field.type === "multiselect" && field.options) {
           const selected = Array.isArray(value) ? (value as string[]) : [];
@@ -328,12 +331,20 @@ function WidgetConfigFields({
               id={`sf-widget-${field.key}`}
               type={field.type === "password" ? "password" : field.type === "number" ? "number" : "text"}
               className="settings-input"
-              value={typeof value === "string" || typeof value === "number" ? String(value) : ""}
+              value={
+                savedSecret
+                  ? ""
+                  : typeof value === "string" || typeof value === "number"
+                    ? String(value)
+                    : ""
+              }
               onChange={(e) => {
                 const raw = e.target.value;
                 onChange(field.key, field.type === "number" ? (raw === "" ? undefined : Number(raw)) : raw);
               }}
-              placeholder={field.placeholder}
+              placeholder={
+                savedSecret ? "Saved — enter a new value to replace" : field.placeholder
+              }
             />
             {field.description && (
               <p className="settings-form-hint">{field.description}</p>

--- a/src/components/ServiceForm.tsx
+++ b/src/components/ServiceForm.tsx
@@ -112,6 +112,23 @@ function cleanWidgetConfig(
   return cleaned;
 }
 
+function widgetConfigForValidation(
+  fields: WidgetConfigField[] | undefined,
+  config: Record<string, unknown>
+): Record<string, unknown> {
+  if (!fields) return config;
+  const validationConfig = { ...config };
+  for (const field of fields) {
+    if (
+      field.type === "password" &&
+      isWidgetSecretReference(validationConfig[field.key])
+    ) {
+      validationConfig[field.key] = "saved-credential";
+    }
+  }
+  return validationConfig;
+}
+
 type TestStatus =
   | { state: "idle" }
   | { state: "testing" }
@@ -307,6 +324,7 @@ function widgetIssueElementId(
 function WidgetConfigFields({
   fields,
   config,
+  initialConfig,
   onChange,
   savedCredentialsStale,
   issues,
@@ -314,12 +332,16 @@ function WidgetConfigFields({
 }: {
   fields: WidgetConfigField[];
   config: Record<string, unknown>;
+  initialConfig: Record<string, unknown>;
   onChange: (key: string, value: unknown) => void;
   savedCredentialsStale: boolean;
   /** Whichever issue list is currently displayed on screen (saved or live), or empty when neither is shown. */
   issues: WidgetConfigIssue[];
   issueKind: "saved" | "live";
 }) {
+  const [clearedSavedCredentialKeys, setClearedSavedCredentialKeys] = useState<
+    Set<string>
+  >(() => new Set());
   // Same "does this issue belong to this field" rule as the focusWidget mount
   // effect below: exact path match, or a nested path under `field.key.`.
   function issueIdsFor(key: string): string[] {
@@ -338,11 +360,19 @@ function WidgetConfigFields({
         const value = config[field.key] ?? field.defaultValue;
         const savedSecret =
           field.type === "password" && isWidgetSecretReference(value);
+        const initialSavedSecret =
+          field.type === "password" &&
+          isWidgetSecretReference(initialConfig[field.key]);
         const needsReplacement = savedSecret && savedCredentialsStale;
         const fieldIssueIds = issueIdsFor(field.key);
         const hintId = field.description ? `sf-widget-${field.key}-hint` : undefined;
+        const staleCredentialId = needsReplacement
+          ? `sf-widget-${field.key}-stale-credential`
+          : undefined;
         const describedBy =
-          [...fieldIssueIds, hintId].filter(Boolean).join(" ") || undefined;
+          [...fieldIssueIds, staleCredentialId, hintId]
+            .filter(Boolean)
+            .join(" ") || undefined;
 
         if (field.type === "multiselect" && field.options) {
           const selected = Array.isArray(value) ? (value as string[]) : [];
@@ -434,26 +464,53 @@ function WidgetConfigFields({
               }
               onChange={(e) => {
                 const raw = e.target.value;
-                onChange(field.key, field.type === "number" ? (raw === "" ? undefined : Number(raw)) : raw);
+                const restoreSavedCredential =
+                  field.type === "password" &&
+                  raw === "" &&
+                  initialSavedSecret &&
+                  !clearedSavedCredentialKeys.has(field.key);
+                onChange(
+                  field.key,
+                  restoreSavedCredential
+                    ? initialConfig[field.key]
+                    : field.type === "number"
+                      ? raw === ""
+                        ? undefined
+                        : Number(raw)
+                      : raw
+                );
               }}
               placeholder={
                 savedSecret ? "Saved — enter a new value to replace" : field.placeholder
               }
-              aria-invalid={fieldIssueIds.length > 0 ? true : undefined}
+              aria-invalid={
+                fieldIssueIds.length > 0 || needsReplacement ? true : undefined
+              }
               aria-describedby={describedBy}
             />
             {savedSecret && !field.required && (
               <button
                 type="button"
                 className="settings-btn settings-btn--danger"
-                onClick={() => onChange(field.key, undefined)}
+                onClick={() => {
+                  setClearedSavedCredentialKeys((keys) => {
+                    const next = new Set(keys);
+                    next.add(field.key);
+                    return next;
+                  });
+                  onChange(field.key, undefined);
+                }}
                 aria-label={`Clear saved ${field.label}`}
               >
                 Clear saved credential
               </button>
             )}
             {needsReplacement && (
-              <p className="settings-form-hint settings-form-hint--error">
+              <p
+                id={staleCredentialId}
+                className="settings-form-hint settings-form-hint--error"
+                role="alert"
+              >
                 This credential is saved for a different connection. Re-enter the credential to continue.
               </p>
             )}
@@ -530,7 +587,13 @@ export default function ServiceForm({
     if (!w) return [];
     const def = getWidget(w.type);
     if (!def) return [];
-    return widgetConfigIssues(def, w.config);
+    return widgetConfigIssues(
+      def,
+      widgetConfigForValidation(
+        def.configFields,
+        (w.config as Record<string, unknown>) ?? {}
+      )
+    );
   });
   const [testStatus, setTestStatus] = useState<TestStatus>({ state: "idle" });
   const [iconDetectStatus, setIconDetectStatus] = useState<IconDetectStatus>({ state: "idle" });
@@ -592,7 +655,13 @@ export default function ServiceForm({
   // same shared mapper as the tile badge (src/widgets/tileWidget.ts) so the
   // dialog's error list always matches what the badge's tooltip says.
   const configIssues: WidgetConfigIssue[] = selectedWidgetDef
-    ? widgetConfigIssues(selectedWidgetDef, activeCleanedConfig)
+    ? widgetConfigIssues(
+        selectedWidgetDef,
+        widgetConfigForValidation(
+          selectedWidgetDef.configFields,
+          activeCleanedConfig
+        )
+      )
     : [];
   const widgetConfigValid = selectedWidgetDef
     ? configIssues.length === 0 && !savedCredentialsStale
@@ -1178,8 +1247,10 @@ export default function ServiceForm({
             {selectedWidgetDef?.configFields &&
               selectedWidgetDef.configFields.length > 0 && (
                 <WidgetConfigFields
+                  key={activeWidgetType}
                   fields={selectedWidgetDef.configFields}
                   config={tileType !== "" ? widgetConfig : orphanConfig}
+                  initialConfig={originalWidgetConfig ?? {}}
                   savedCredentialsStale={savedCredentialsStale}
                   onChange={
                     tileType !== ""

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -566,7 +566,13 @@ export default function SettingsPanel({ config }: { config: KokpitConfig }) {
       const result = await saveRaw("groups", payload);
       if (result.ok) {
         // Now — and only now — reflect the cascade in shared state and clear ops.
-        if (cascade.servicesChanged) setServices(cascade.services);
+        if (cascade.servicesChanged) {
+          setServices(
+            Array.isArray(result.config?.services)
+              ? result.config.services
+              : cascade.services
+          );
+        }
         if (cascade.bookmarksChanged) setBookmarks(cascade.bookmarks);
         setPendingGroupOps([]);
       }

--- a/src/components/SettingsPanel.tsx
+++ b/src/components/SettingsPanel.tsx
@@ -35,6 +35,10 @@ type TotpState =
   | { status: "setup"; secret: string; qrCode: string }
   | { status: "error" };
 type SaveStatus = "idle" | "saving" | "saved" | "error";
+type SaveResult = {
+  ok: boolean;
+  config?: Partial<KokpitConfig>;
+};
 
 const THEMES = ["dark", "light", "oled", "high-contrast"] as const;
 
@@ -122,6 +126,7 @@ export default function SettingsPanel({ config }: { config: KokpitConfig }) {
   const [services, setServices] = useState<Service[]>(config.services);
   const [showServiceForm, setShowServiceForm] = useState(false);
   const [editingIndex, setEditingIndex] = useState<number | null>(null);
+  const [servicesWritePending, setServicesWritePending] = useState(false);
 
   // Groups
   const [groups, setGroups] = useState<Group[]>(config.groups ?? []);
@@ -155,6 +160,7 @@ export default function SettingsPanel({ config }: { config: KokpitConfig }) {
   });
 
   const saveTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const servicesSavePendingRef = useRef(false);
   useEffect(() => () => { if (saveTimerRef.current) clearTimeout(saveTimerRef.current); }, []);
 
   async function fetchTotpStatus() {
@@ -252,7 +258,10 @@ export default function SettingsPanel({ config }: { config: KokpitConfig }) {
     }
   }
 
-  async function saveRaw(section: Tab, payload: Record<string, unknown>) {
+  async function saveRaw(
+    section: Tab,
+    payload: Record<string, unknown>
+  ): Promise<SaveResult> {
     setSaveStatus((s) => ({ ...s, [section]: "saving" }));
     try {
       const res = await fetch("/api/settings", {
@@ -261,14 +270,28 @@ export default function SettingsPanel({ config }: { config: KokpitConfig }) {
         body: JSON.stringify(payload),
       });
       if (!res.ok) throw new Error("Save failed");
+      // A services response contains freshly redacted credential references.
+      // Those references identify the service by name, so a rename must replace
+      // the optimistic client state with this authoritative response before the
+      // next services edit is submitted.
+      let updatedConfig: Partial<KokpitConfig> | undefined;
+      try {
+        const json: unknown = await res.json();
+        if (json !== null && typeof json === "object") {
+          updatedConfig = json as Partial<KokpitConfig>;
+        }
+      } catch {
+        // The API returns JSON, but a malformed success response must not turn
+        // an already-persisted settings change into a client-side save failure.
+      }
       setSaveStatus((s) => ({ ...s, [section]: "saved" }));
       startTransition(() => router.refresh());
       if (saveTimerRef.current) clearTimeout(saveTimerRef.current);
       saveTimerRef.current = setTimeout(() => setSaveStatus((s) => ({ ...s, [section]: "idle" })), 2000);
-      return true;
+      return { ok: true, config: updatedConfig };
     } catch {
       setSaveStatus((s) => ({ ...s, [section]: "error" }));
-      return false;
+      return { ok: false };
     }
   }
 
@@ -360,32 +383,48 @@ export default function SettingsPanel({ config }: { config: KokpitConfig }) {
     save("auth", { enabled: config.auth.enabled, session_ttl_hours: sessionTtl });
   }
 
+  async function saveServices(next: Service[]) {
+    if (servicesSavePendingRef.current) return;
+    servicesSavePendingRef.current = true;
+    setServicesWritePending(true);
+    setServices(next);
+    try {
+      const result = await save("services", next);
+      if (Array.isArray(result.config?.services)) {
+        setServices(result.config.services);
+      }
+    } finally {
+      servicesSavePendingRef.current = false;
+      setServicesWritePending(false);
+    }
+  }
+
   function handleServiceSave(service: Service) {
+    if (servicesSavePendingRef.current) return;
     const next = [...services];
     if (editingIndex !== null) {
       next[editingIndex] = service;
     } else {
       next.push(service);
     }
-    setServices(next);
     setShowServiceForm(false);
     setEditingIndex(null);
-    save("services", next);
+    void saveServices(next);
   }
 
   function handleServiceDelete(index: number) {
+    if (servicesSavePendingRef.current) return;
     const next = services.filter((_, i) => i !== index);
-    setServices(next);
-    save("services", next);
+    void saveServices(next);
   }
 
   function handleServiceReorder(from: number, to: number) {
+    if (servicesSavePendingRef.current) return;
     if (to < 0 || to >= services.length) return;
     const next = [...services];
     const [moved] = next.splice(from, 1);
     next.splice(to, 0, moved);
-    setServices(next);
-    save("services", next);
+    void saveServices(next);
   }
 
   function effectiveSize(svc: Service) {
@@ -500,6 +539,10 @@ export default function SettingsPanel({ config }: { config: KokpitConfig }) {
   }
 
   async function handleSaveGroups() {
+    // Group renames/deletes may cascade into the complete services array.
+    // Never let that full-list write race a service save carrying older
+    // credential references.
+    if (servicesSavePendingRef.current) return;
     // Strip default values so omitted keys stay omitted in the YAML round-trip.
     const cleanGroups = groups.map((g) => ({
       name: g.name,
@@ -515,12 +558,23 @@ export default function SettingsPanel({ config }: { config: KokpitConfig }) {
     };
     if (cascade.servicesChanged) payload.services = cascade.services;
     if (cascade.bookmarksChanged) payload.bookmarks = cascade.bookmarks;
-    const ok = await saveRaw("groups", payload);
-    if (ok) {
-      // Now — and only now — reflect the cascade in shared state and clear ops.
-      if (cascade.servicesChanged) setServices(cascade.services);
-      if (cascade.bookmarksChanged) setBookmarks(cascade.bookmarks);
-      setPendingGroupOps([]);
+    if (cascade.servicesChanged) {
+      servicesSavePendingRef.current = true;
+      setServicesWritePending(true);
+    }
+    try {
+      const result = await saveRaw("groups", payload);
+      if (result.ok) {
+        // Now — and only now — reflect the cascade in shared state and clear ops.
+        if (cascade.servicesChanged) setServices(cascade.services);
+        if (cascade.bookmarksChanged) setBookmarks(cascade.bookmarks);
+        setPendingGroupOps([]);
+      }
+    } finally {
+      if (cascade.servicesChanged) {
+        servicesSavePendingRef.current = false;
+        setServicesWritePending(false);
+      }
     }
   }
 
@@ -570,11 +624,13 @@ export default function SettingsPanel({ config }: { config: KokpitConfig }) {
   }
 
   function openAddForm() {
+    if (servicesSavePendingRef.current) return;
     setEditingIndex(null);
     setShowServiceForm(true);
   }
 
   function openEditForm(index: number) {
+    if (servicesSavePendingRef.current) return;
     setEditingIndex(index);
     setShowServiceForm(true);
   }
@@ -592,6 +648,7 @@ export default function SettingsPanel({ config }: { config: KokpitConfig }) {
             key={tab}
             className={`settings-tab${activeTab === tab ? " settings-tab--active" : ""}`}
             onClick={() => setActiveTab(tab)}
+            disabled={servicesWritePending}
           >
             {tab.charAt(0).toUpperCase() + tab.slice(1)}
           </button>
@@ -1127,7 +1184,7 @@ export default function SettingsPanel({ config }: { config: KokpitConfig }) {
                         <button
                           className="settings-icon-btn"
                           aria-label={`Move ${svc.name} up`}
-                          disabled={i === 0}
+                          disabled={servicesWritePending || i === 0}
                           onClick={() => handleServiceReorder(i, i - 1)}
                         >
                           ▲
@@ -1135,7 +1192,10 @@ export default function SettingsPanel({ config }: { config: KokpitConfig }) {
                         <button
                           className="settings-icon-btn"
                           aria-label={`Move ${svc.name} down`}
-                          disabled={i === services.length - 1}
+                          disabled={
+                            servicesWritePending ||
+                            i === services.length - 1
+                          }
                           onClick={() => handleServiceReorder(i, i + 1)}
                         >
                           ▼
@@ -1149,12 +1209,14 @@ export default function SettingsPanel({ config }: { config: KokpitConfig }) {
                         <button
                           className="settings-btn"
                           onClick={() => openEditForm(i)}
+                          disabled={servicesWritePending}
                         >
                           Edit
                         </button>
                         <button
                           className="settings-btn settings-btn--danger"
                           onClick={() => handleServiceDelete(i)}
+                          disabled={servicesWritePending}
                         >
                           Delete
                         </button>
@@ -1166,7 +1228,11 @@ export default function SettingsPanel({ config }: { config: KokpitConfig }) {
             )}
 
             <div className="settings-actions settings-actions--spaced">
-              <button className="settings-save-btn" onClick={openAddForm}>
+              <button
+                className="settings-save-btn"
+                onClick={openAddForm}
+                disabled={servicesWritePending}
+              >
                 + Add Service
               </button>
               {saveStatus.services === "saved" && (

--- a/src/config/revision.ts
+++ b/src/config/revision.ts
@@ -1,16 +1,24 @@
-// Content revision of a config: a sha256 over its canonical JSON serialization.
-// Two structurally-equal configs hash identically; any change to services,
-// groups, bookmarks, appearance, layout, etc. changes the hash.
+// Content revision of a config: a purpose-separated HMAC over its canonical
+// JSON serialization. Two structurally-equal configs hash identically; any
+// change to services, groups, bookmarks, appearance, layout, etc. changes the
+// hash without exposing an offline oracle for low-entropy saved credentials.
 //
 // Server-only (`node:crypto`). The client never computes a revision — it reads
 // the value from the `X-Config-Revision` response header of GET /api/settings.
-import { createHash } from "node:crypto";
+import { createHmac } from "node:crypto";
+import { getServerSecret } from "@/auth/serverSecret";
 import type { KokpitConfig } from "./schema";
 import { canonicalJSONString } from "./canonicalJson";
 
-/** Stable sha256 (hex) revision of a config's canonical serialization. */
+const PURPOSE = "kokpit/config-revision/v1";
+
+function revisionKey(): Buffer {
+  return createHmac("sha256", getServerSecret()).update(PURPOSE).digest();
+}
+
+/** Stable purpose-separated HMAC-SHA256 revision of canonical config JSON. */
 export function configRevision(config: KokpitConfig): string {
-  return createHash("sha256")
+  return createHmac("sha256", revisionKey())
     .update(canonicalJSONString(config))
     .digest("hex");
 }

--- a/src/integrations/actualbudget/accountsWidget.tsx
+++ b/src/integrations/actualbudget/accountsWidget.tsx
@@ -119,7 +119,7 @@ registerWidget<ActualAccountsConfig, ActualAccountsData>({
   refreshInterval: 300_000,
   fetchTimeoutMs: 15_000,
   component: ActualBudgetAccountsWidget,
-  credentialScopeFields: ["url"],
+  credentialScopeFields: ["url", "budget_sync_id"],
   configFields: [
     ...BASE_CONFIG_FIELDS,
     {

--- a/src/integrations/actualbudget/accountsWidget.tsx
+++ b/src/integrations/actualbudget/accountsWidget.tsx
@@ -120,6 +120,7 @@ registerWidget<ActualAccountsConfig, ActualAccountsData>({
   fetchTimeoutMs: 15_000,
   component: ActualBudgetAccountsWidget,
   credentialScopeFields: ["url", "budget_sync_id"],
+  preservedConfigFields: [{ key: "timezone", type: "text" }],
   configFields: [
     ...BASE_CONFIG_FIELDS,
     {

--- a/src/integrations/actualbudget/categoriesWidget.tsx
+++ b/src/integrations/actualbudget/categoriesWidget.tsx
@@ -203,7 +203,7 @@ registerWidget<ActualCategoriesConfig, ActualCategoriesData>({
   refreshInterval: 300_000,
   fetchTimeoutMs: 15_000,
   component: ActualBudgetCategoriesWidget,
-  credentialScopeFields: ["url"],
+  credentialScopeFields: ["url", "budget_sync_id"],
   configFields: [
     ...BASE_CONFIG_FIELDS,
     TIMEZONE_CONFIG_FIELD,

--- a/src/integrations/actualbudget/schedulesWidget.tsx
+++ b/src/integrations/actualbudget/schedulesWidget.tsx
@@ -190,7 +190,7 @@ registerWidget<ActualSchedulesConfig, ActualSchedulesData>({
   refreshInterval: 300_000,
   fetchTimeoutMs: 15_000,
   component: ActualBudgetSchedulesWidget,
-  credentialScopeFields: ["url"],
+  credentialScopeFields: ["url", "budget_sync_id"],
   configFields: [
     ...BASE_CONFIG_FIELDS,
     TIMEZONE_CONFIG_FIELD,

--- a/src/integrations/actualbudget/summaryWidget.tsx
+++ b/src/integrations/actualbudget/summaryWidget.tsx
@@ -138,5 +138,5 @@ registerWidget<ActualSummaryConfig, ActualSummaryData>({
   fetchTimeoutMs: 15_000,
   component: ActualBudgetSummaryWidget,
   configFields: [...BASE_CONFIG_FIELDS, TIMEZONE_CONFIG_FIELD],
-  credentialScopeFields: ["url"],
+  credentialScopeFields: ["url", "budget_sync_id"],
 });

--- a/src/integrations/immich/statsWidget.tsx
+++ b/src/integrations/immich/statsWidget.tsx
@@ -80,6 +80,7 @@ registerWidget<ImmichConfig, ImmichStats>({
   fetchData: fetchStats,
   refreshInterval: 60_000,
   component: ImmichStatsWidget,
+  credentialScopeFields: ["url"],
   configFields: [
     {
       key: "url",

--- a/src/integrations/index.ts
+++ b/src/integrations/index.ts
@@ -22,5 +22,6 @@ import "./netdata/diskSpaceWidget";
 import "./netdata/loadWidget";
 import "./netdata/sensorWidget";
 import "./docker/widget";
+import "./tautulli/activityWidget";
 
 export type IntegrationStatus = "ok" | "error" | "unknown";

--- a/src/integrations/netdata/cpuWidget.tsx
+++ b/src/integrations/netdata/cpuWidget.tsx
@@ -72,6 +72,7 @@ registerWidget<NetdataBaseConfig, CpuData>({
   fetchData: fetchCpuData,
   refreshInterval: 10_000,
   component: NetdataCpuWidget,
+  credentialScopeFields: ["url"],
   configFields: [
     {
       key: "url",

--- a/src/integrations/netdata/diskIoWidget.tsx
+++ b/src/integrations/netdata/diskIoWidget.tsx
@@ -91,6 +91,7 @@ registerWidget<NetdataBaseConfig, DiskIoData>({
   fetchData: fetchDiskIoData,
   refreshInterval: 10_000,
   component: NetdataDiskIoWidget,
+  credentialScopeFields: ["url"],
   configFields: [
     {
       key: "url",

--- a/src/integrations/netdata/diskSpaceWidget.tsx
+++ b/src/integrations/netdata/diskSpaceWidget.tsx
@@ -79,6 +79,7 @@ registerWidget<DiskSpaceConfig, DiskSpaceData>({
   fetchData: fetchDiskSpaceData,
   refreshInterval: 60_000,
   component: NetdataDiskSpaceWidget,
+  credentialScopeFields: ["url"],
   configFields: [
     {
       key: "url",

--- a/src/integrations/netdata/loadWidget.tsx
+++ b/src/integrations/netdata/loadWidget.tsx
@@ -71,6 +71,7 @@ registerWidget<NetdataBaseConfig, LoadData>({
   fetchData: fetchLoadData,
   refreshInterval: 10_000,
   component: NetdataLoadWidget,
+  credentialScopeFields: ["url"],
   configFields: [
     {
       key: "url",

--- a/src/integrations/netdata/netWidget.tsx
+++ b/src/integrations/netdata/netWidget.tsx
@@ -91,6 +91,7 @@ registerWidget<NetdataBaseConfig, NetData>({
   fetchData: fetchNetData,
   refreshInterval: 10_000,
   component: NetdataNetWidget,
+  credentialScopeFields: ["url"],
   configFields: [
     {
       key: "url",

--- a/src/integrations/netdata/ramWidget.tsx
+++ b/src/integrations/netdata/ramWidget.tsx
@@ -88,6 +88,7 @@ registerWidget<NetdataBaseConfig, RamData>({
   fetchData: fetchRamData,
   refreshInterval: 10_000,
   component: NetdataRamWidget,
+  credentialScopeFields: ["url"],
   configFields: [
     {
       key: "url",

--- a/src/integrations/netdata/sensorWidget.tsx
+++ b/src/integrations/netdata/sensorWidget.tsx
@@ -101,6 +101,7 @@ registerWidget<SensorConfig, SensorData>({
   fetchData: fetchSensorData,
   refreshInterval: 10_000,
   component: NetdataSensorWidget,
+  credentialScopeFields: ["url"],
   configFields: [
     {
       key: "url",

--- a/src/integrations/plex/widget.tsx
+++ b/src/integrations/plex/widget.tsx
@@ -109,6 +109,7 @@ registerWidget<PlexConfig, PlexData>({
   },
   refreshInterval: 10_000,
   component: PlexWidget,
+  credentialScopeFields: ["url"],
   configFields: [
     {
       key: "url",

--- a/src/integrations/prowlarr/statsWidget.tsx
+++ b/src/integrations/prowlarr/statsWidget.tsx
@@ -69,6 +69,7 @@ registerWidget<ProwlarrConfig, ProwlarrStats>({
   fetchData: fetchStats,
   refreshInterval: 60_000,
   component: ProwlarrStatsWidget,
+  credentialScopeFields: ["url"],
   configFields: [
     {
       key: "url",

--- a/src/integrations/qbittorrent/statsWidget.tsx
+++ b/src/integrations/qbittorrent/statsWidget.tsx
@@ -67,6 +67,7 @@ registerWidget<QbittorrentConfig, TransferInfo>({
   fetchData: fetchTransferInfo,
   refreshInterval: 10_000,
   component: QbittorrentStatsWidget,
+  credentialScopeFields: ["url", "username"],
   configFields: [
     {
       key: "url",

--- a/src/integrations/qbittorrent/torrentsWidget.tsx
+++ b/src/integrations/qbittorrent/torrentsWidget.tsx
@@ -102,6 +102,7 @@ registerWidget<QbittorrentConfig, Torrent[]>({
   fetchData: fetchTorrents,
   refreshInterval: 15_000,
   component: QbittorrentTorrentsWidget,
+  credentialScopeFields: ["url", "username"],
   configFields: [
     {
       key: "url",

--- a/src/integrations/radarr/queueWidget.tsx
+++ b/src/integrations/radarr/queueWidget.tsx
@@ -102,6 +102,7 @@ registerWidget<RadarrConfig, RadarrQueueItem[]>({
   fetchData: fetchQueue,
   refreshInterval: 15_000,
   component: RadarrQueueWidget,
+  credentialScopeFields: ["url"],
   configFields: [
     {
       key: "url",

--- a/src/integrations/radarr/statsWidget.tsx
+++ b/src/integrations/radarr/statsWidget.tsx
@@ -73,6 +73,7 @@ registerWidget<RadarrConfig, RadarrStats>({
   fetchData: fetchStats,
   refreshInterval: 60_000,
   component: RadarrStatsWidget,
+  credentialScopeFields: ["url"],
   configFields: [
     {
       key: "url",

--- a/src/integrations/sabnzbd/widget.tsx
+++ b/src/integrations/sabnzbd/widget.tsx
@@ -73,6 +73,7 @@ registerWidget<SabnzbdConfig, SabnzbdQueueData>({
   fetchData: fetchQueueData,
   refreshInterval: 10_000,
   component: SabnzbdWidget,
+  credentialScopeFields: ["url"],
   configFields: [
     {
       key: "url",

--- a/src/integrations/seerr/requestsWidget.tsx
+++ b/src/integrations/seerr/requestsWidget.tsx
@@ -148,6 +148,7 @@ registerWidget<SeerrConfig, SeerrRequest[]>({
   fetchData: fetchRequests,
   refreshInterval: 60_000,
   component: SeerrRequestsWidget,
+  credentialScopeFields: ["url"],
   configFields: [
     {
       key: "url",

--- a/src/integrations/seerr/statsWidget.tsx
+++ b/src/integrations/seerr/statsWidget.tsx
@@ -60,6 +60,7 @@ registerWidget<SeerrConfig, SeerrStats>({
   fetchData: fetchStats,
   refreshInterval: 60_000,
   component: SeerrStatsWidget,
+  credentialScopeFields: ["url"],
   configFields: [
     {
       key: "url",

--- a/src/integrations/sonarr/calendarWidget.tsx
+++ b/src/integrations/sonarr/calendarWidget.tsx
@@ -113,6 +113,7 @@ registerWidget<SonarrConfig, SonarrEpisode[]>({
   fetchData: fetchCalendar,
   refreshInterval: 60_000,
   component: SonarrCalendarWidget,
+  credentialScopeFields: ["url"],
   configFields: [
     {
       key: "url",

--- a/src/integrations/sonarr/queueWidget.tsx
+++ b/src/integrations/sonarr/queueWidget.tsx
@@ -102,6 +102,7 @@ registerWidget<SonarrConfig, SonarrQueueItem[]>({
   fetchData: fetchQueue,
   refreshInterval: 15_000,
   component: SonarrQueueWidget,
+  credentialScopeFields: ["url"],
   configFields: [
     {
       key: "url",

--- a/src/integrations/tautulli/activityWidget.tsx
+++ b/src/integrations/tautulli/activityWidget.tsx
@@ -1,0 +1,129 @@
+import { registerWidget } from "@/widgets";
+import type { WidgetProps } from "@/widgets";
+import {
+  fetchActivity,
+  TautulliConfigSchema,
+} from "./api";
+import type { TautulliActivityData, TautulliConfig } from "./api";
+
+function formatLabel(value: string): string {
+  return value
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (character) => character.toUpperCase());
+}
+
+export function formatBandwidth(kbps: number): string {
+  if (kbps >= 1_000_000) return `${(kbps / 1_000_000).toFixed(1)} Gbps`;
+  if (kbps >= 1_000) return `${(kbps / 1_000).toFixed(1)} Mbps`;
+  return `${kbps.toFixed(0)} Kbps`;
+}
+
+export function TautulliActivityWidget({
+  data,
+  loading,
+  error,
+}: WidgetProps<TautulliActivityData>): React.ReactElement {
+  if (!data) {
+    return (
+      <div className="tautulli-activity-widget tautulli-activity-widget--empty">
+        {loading && <span className="tautulli-activity-widget__hint">Loading&hellip;</span>}
+        {error && (
+          <span className="tautulli-activity-widget__hint tautulli-activity-widget__hint--error">
+            {error}
+          </span>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="tautulli-activity-widget" aria-label="Tautulli activity">
+      {data.summary && (
+        <div className="tautulli-activity-widget__summary" aria-label="Tautulli summary">
+          {[
+            ["Active", String(data.summary.streamCount)],
+            ["Direct Play", String(data.summary.directPlayCount)],
+            ["Direct Stream", String(data.summary.directStreamCount)],
+            ["Transcoding", String(data.summary.transcodeCount)],
+            ["Bandwidth", formatBandwidth(data.summary.totalBandwidthKbps)],
+          ].map(([label, value]) => (
+            <div className="tautulli-activity-widget__stat" key={label}>
+              <span className="tautulli-activity-widget__value">{value}</span>
+              <span className="tautulli-activity-widget__label">{label}</span>
+            </div>
+          ))}
+        </div>
+      )}
+      {data.sessions && (
+        <div className="tautulli-activity-widget__sessions" aria-label="Active Tautulli sessions">
+          {data.sessions.length === 0
+            ? <span className="tautulli-activity-widget__no-sessions">No active streams</span>
+            : data.sessions.map((session, index) => {
+                const progress = Math.round(
+                  Math.min(100, Math.max(0, session.progressPercent))
+                );
+                return (
+                  <div
+                    className="tautulli-activity-widget__session"
+                    key={`${session.username}:${session.title}:${index}`}
+                  >
+                    <div className="tautulli-activity-widget__session-heading">
+                      <span className="tautulli-activity-widget__username">{session.username}</span>
+                      <span>{formatLabel(session.state)}</span>
+                    </div>
+                    <div className="tautulli-activity-widget__session-media">
+                      <span className="tautulli-activity-widget__title">{session.title}</span>
+                      <span>{formatLabel(session.mediaType)} · {formatLabel(session.transcodeDecision)}</span>
+                    </div>
+                    <div
+                      className="tautulli-activity-widget__progress"
+                      role="progressbar"
+                      aria-label={`${session.username} progress`}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                      aria-valuenow={progress}
+                    >
+                      <span style={{ width: `${progress}%` }} />
+                    </div>
+                    <span className="tautulli-activity-widget__progress-label">{progress}%</span>
+                  </div>
+                );
+              })}
+        </div>
+      )}
+      {error && <span className="tautulli-activity-widget__stale-error" role="alert">{error}</span>}
+    </div>
+  );
+}
+
+registerWidget<TautulliConfig, TautulliActivityData>({
+  id: "tautulli-activity",
+  name: "Tautulli Activity",
+  configSchema: TautulliConfigSchema,
+  fetchData: fetchActivity,
+  refreshInterval: 10_000,
+  preferredSize: "large",
+  minSize: "wide",
+  component: TautulliActivityWidget,
+  serviceEditorPreset: {
+    defaultName: "Tautulli",
+    defaultIconUrl:
+      "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@main/svg/tautulli.svg",
+  },
+  configFields: [
+    { key: "url", label: "URL", type: "url", required: true, placeholder: "http://192.168.1.x:8181" },
+    { key: "api_key", label: "API Key", type: "password", required: true },
+    {
+      key: "sections",
+      label: "Display sections",
+      type: "multiselect",
+      required: true,
+      defaultValue: ["summary", "sessions"],
+      options: [
+        { value: "summary", label: "Summary" },
+        { value: "sessions", label: "Active sessions" },
+      ],
+      description: "Select at least one section.",
+    },
+  ],
+});

--- a/src/integrations/tautulli/activityWidget.tsx
+++ b/src/integrations/tautulli/activityWidget.tsx
@@ -41,13 +41,20 @@ export function TautulliActivityWidget({
       {data.summary && (
         <div className="tautulli-activity-widget__summary" aria-label="Tautulli summary">
           {[
-            ["Active", String(data.summary.streamCount)],
-            ["Direct Play", String(data.summary.directPlayCount)],
-            ["Direct Stream", String(data.summary.directStreamCount)],
-            ["Transcoding", String(data.summary.transcodeCount)],
-            ["Bandwidth", formatBandwidth(data.summary.totalBandwidthKbps)],
-          ].map(([label, value]) => (
-            <div className="tautulli-activity-widget__stat" key={label}>
+            { label: "Active", value: String(data.summary.streamCount) },
+            { label: "Direct Play", value: String(data.summary.directPlayCount) },
+            { label: "Direct Stream", value: String(data.summary.directStreamCount) },
+            { label: "Transcoding", value: String(data.summary.transcodeCount) },
+            {
+              label: "Bandwidth",
+              value: formatBandwidth(data.summary.totalBandwidthKbps),
+              modifier: "tautulli-activity-widget__stat--bandwidth",
+            },
+          ].map(({ label, value, modifier }) => (
+            <div
+              className={`tautulli-activity-widget__stat${modifier ? ` ${modifier}` : ""}`}
+              key={label}
+            >
               <span className="tautulli-activity-widget__value">{value}</span>
               <span className="tautulli-activity-widget__label">{label}</span>
             </div>
@@ -102,8 +109,8 @@ registerWidget<TautulliConfig, TautulliActivityData>({
   configSchema: TautulliConfigSchema,
   fetchData: fetchActivity,
   refreshInterval: 10_000,
-  preferredSize: "large",
-  minSize: "wide",
+  preferredSize: "tall",
+  minSize: "tall",
   component: TautulliActivityWidget,
   serviceEditorPreset: {
     defaultName: "Tautulli",

--- a/src/integrations/tautulli/activityWidget.tsx
+++ b/src/integrations/tautulli/activityWidget.tsx
@@ -117,6 +117,7 @@ registerWidget<TautulliConfig, TautulliActivityData>({
     defaultIconUrl:
       "https://cdn.jsdelivr.net/gh/homarr-labs/dashboard-icons@main/svg/tautulli.svg",
   },
+  credentialScopeFields: ["url"],
   configFields: [
     { key: "url", label: "URL", type: "url", required: true, placeholder: "http://192.168.1.x:8181" },
     { key: "api_key", label: "API Key", type: "password", required: true },

--- a/src/integrations/tautulli/api.ts
+++ b/src/integrations/tautulli/api.ts
@@ -82,6 +82,12 @@ function nonBlank(value: string | null | undefined, fallback: string): string {
   return value?.trim() ? value : fallback;
 }
 
+function abortedRequestError(): Error {
+  const error = new Error("Tautulli request aborted");
+  error.name = "AbortError";
+  return error;
+}
+
 export async function fetchActivity(
   config: TautulliConfig,
   signal?: AbortSignal
@@ -95,9 +101,7 @@ export async function fetchActivity(
     response = await fetch(url.toString(), { signal });
   } catch {
     if (signal?.aborted) {
-      const abortError = new Error("Tautulli request aborted");
-      abortError.name = "AbortError";
-      throw abortError;
+      throw abortedRequestError();
     }
     throw new Error("Tautulli network request failed");
   }
@@ -109,6 +113,9 @@ export async function fetchActivity(
   try {
     json = await response.json();
   } catch {
+    if (signal?.aborted) {
+      throw abortedRequestError();
+    }
     throw new Error("Tautulli returned invalid JSON");
   }
 

--- a/src/integrations/tautulli/api.ts
+++ b/src/integrations/tautulli/api.ts
@@ -79,7 +79,8 @@ function withTrailingSlash(url: string): string {
 }
 
 function nonBlank(value: string | null | undefined, fallback: string): string {
-  return value?.trim() ? value : fallback;
+  const trimmed = value?.trim();
+  return trimmed || fallback;
 }
 
 function abortedRequestError(): Error {

--- a/src/integrations/tautulli/api.ts
+++ b/src/integrations/tautulli/api.ts
@@ -130,9 +130,9 @@ export async function fetchActivity(
     ),
     title: nonBlank(session.full_title, nonBlank(session.title, "Unknown title")),
     progressPercent: Math.min(100, Math.max(0, session.progress_percent)),
-    state: nonBlank(session.state, "Unknown state"),
-    mediaType: nonBlank(session.media_type, "Unknown media"),
-    transcodeDecision: nonBlank(session.transcode_decision, "Unknown decision"),
+    state: nonBlank(session.state, "unknown"),
+    mediaType: nonBlank(session.media_type, "unknown"),
+    transcodeDecision: nonBlank(session.transcode_decision, "unknown"),
   }));
 
   const selected = new Set(config.sections);

--- a/src/integrations/tautulli/api.ts
+++ b/src/integrations/tautulli/api.ts
@@ -90,7 +90,17 @@ export async function fetchActivity(
   url.searchParams.set("apikey", config.api_key);
   url.searchParams.set("cmd", "get_activity");
 
-  const response = await fetch(url.toString(), { signal });
+  let response: Response;
+  try {
+    response = await fetch(url.toString(), { signal });
+  } catch {
+    if (signal?.aborted) {
+      const abortError = new Error("Tautulli request aborted");
+      abortError.name = "AbortError";
+      throw abortError;
+    }
+    throw new Error("Tautulli network request failed");
+  }
   if (!response.ok) {
     throw new Error(`Tautulli responded with ${response.status}`);
   }

--- a/src/integrations/tautulli/api.ts
+++ b/src/integrations/tautulli/api.ts
@@ -82,20 +82,6 @@ function nonBlank(value: string | null | undefined, fallback: string): string {
   return value?.trim() ? value : fallback;
 }
 
-function sanitizeApiMessage(
-  message: string | null | undefined,
-  apiKey: string
-): string {
-  const cleaned = (message ?? "")
-    .replaceAll(apiKey, "[redacted]")
-    .replace(/[\r\n]+/g, " ")
-    .trim()
-    .slice(0, 200);
-  return cleaned
-    ? `Tautulli API error: ${cleaned}`
-    : "Tautulli API request failed";
-}
-
 export async function fetchActivity(
   config: TautulliConfig,
   signal?: AbortSignal
@@ -121,9 +107,7 @@ export async function fetchActivity(
     throw new Error("Tautulli returned an invalid activity response");
   }
   if (envelope.data.response.result !== "success") {
-    throw new Error(
-      sanitizeApiMessage(envelope.data.response.message, config.api_key)
-    );
+    throw new Error("Tautulli API request failed");
   }
 
   const parsedData = ActivityDataSchema.safeParse(envelope.data.response.data);

--- a/src/integrations/tautulli/api.ts
+++ b/src/integrations/tautulli/api.ts
@@ -1,0 +1,159 @@
+import { z } from "zod";
+
+export const TAUTULLI_SECTIONS = ["summary", "sessions"] as const;
+export type TautulliSection = (typeof TAUTULLI_SECTIONS)[number];
+
+export const TautulliConfigSchema = z.object({
+  url: z.string().url(),
+  api_key: z.string().min(1),
+  sections: z
+    .array(z.enum(TAUTULLI_SECTIONS))
+    .min(1)
+    .default(["summary", "sessions"]),
+});
+export type TautulliConfig = z.infer<typeof TautulliConfigSchema>;
+
+export interface TautulliSummary {
+  streamCount: number;
+  directPlayCount: number;
+  directStreamCount: number;
+  transcodeCount: number;
+  totalBandwidthKbps: number;
+}
+
+export interface TautulliSession {
+  username: string;
+  title: string;
+  progressPercent: number;
+  state: string;
+  mediaType: string;
+  transcodeDecision: string;
+}
+
+export interface TautulliActivityData {
+  summary?: TautulliSummary;
+  sessions?: TautulliSession[];
+}
+
+const NumericValueSchema = z
+  .union([z.number(), z.string()])
+  .transform((value) => {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  })
+  .catch(0);
+
+const NullableTextSchema = z.string().nullish();
+
+const RawSessionSchema = z.object({
+  username: NullableTextSchema,
+  user: NullableTextSchema,
+  friendly_name: NullableTextSchema,
+  full_title: NullableTextSchema,
+  title: NullableTextSchema,
+  progress_percent: NumericValueSchema.optional().default(0),
+  state: NullableTextSchema,
+  media_type: NullableTextSchema,
+  transcode_decision: NullableTextSchema,
+});
+
+const ActivityDataSchema = z.object({
+  stream_count: NumericValueSchema.optional().default(0),
+  stream_count_direct_play: NumericValueSchema.optional().default(0),
+  stream_count_direct_stream: NumericValueSchema.optional().default(0),
+  stream_count_transcode: NumericValueSchema.optional().default(0),
+  total_bandwidth: NumericValueSchema.optional().default(0),
+  sessions: z.array(RawSessionSchema).catch([]).optional().default([]),
+});
+
+const EnvelopeSchema = z.object({
+  response: z.object({
+    result: z.string(),
+    message: z.string().nullish(),
+    data: z.unknown(),
+  }),
+});
+
+function withTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url : `${url}/`;
+}
+
+function nonBlank(value: string | null | undefined, fallback: string): string {
+  return value?.trim() ? value : fallback;
+}
+
+function sanitizeApiMessage(
+  message: string | null | undefined,
+  apiKey: string
+): string {
+  const cleaned = (message ?? "")
+    .replaceAll(apiKey, "[redacted]")
+    .replace(/[\r\n]+/g, " ")
+    .trim()
+    .slice(0, 200);
+  return cleaned
+    ? `Tautulli API error: ${cleaned}`
+    : "Tautulli API request failed";
+}
+
+export async function fetchActivity(
+  config: TautulliConfig,
+  signal?: AbortSignal
+): Promise<TautulliActivityData> {
+  const url = new URL("api/v2", withTrailingSlash(config.url));
+  url.searchParams.set("apikey", config.api_key);
+  url.searchParams.set("cmd", "get_activity");
+
+  const response = await fetch(url.toString(), { signal });
+  if (!response.ok) {
+    throw new Error(`Tautulli responded with ${response.status}`);
+  }
+
+  let json: unknown;
+  try {
+    json = await response.json();
+  } catch {
+    throw new Error("Tautulli returned invalid JSON");
+  }
+
+  const envelope = EnvelopeSchema.safeParse(json);
+  if (!envelope.success) {
+    throw new Error("Tautulli returned an invalid activity response");
+  }
+  if (envelope.data.response.result !== "success") {
+    throw new Error(
+      sanitizeApiMessage(envelope.data.response.message, config.api_key)
+    );
+  }
+
+  const parsedData = ActivityDataSchema.safeParse(envelope.data.response.data);
+  if (!parsedData.success) {
+    throw new Error("Tautulli returned an invalid activity response");
+  }
+
+  const raw = parsedData.data;
+  const summary: TautulliSummary = {
+    streamCount: raw.stream_count,
+    directPlayCount: raw.stream_count_direct_play,
+    directStreamCount: raw.stream_count_direct_stream,
+    transcodeCount: raw.stream_count_transcode,
+    totalBandwidthKbps: raw.total_bandwidth,
+  };
+  const sessions = raw.sessions.map((session) => ({
+    username: nonBlank(
+      session.username,
+      nonBlank(session.user, nonBlank(session.friendly_name, "Unknown user"))
+    ),
+    title: nonBlank(session.full_title, nonBlank(session.title, "Unknown title")),
+    progressPercent: Math.min(100, Math.max(0, session.progress_percent)),
+    state: nonBlank(session.state, "Unknown state"),
+    mediaType: nonBlank(session.media_type, "Unknown media"),
+    transcodeDecision: nonBlank(session.transcode_decision, "Unknown decision"),
+  }));
+
+  const selected = new Set(config.sections);
+  return {
+    ...(selected.has("summary") ? { summary } : {}),
+    ...(selected.has("sessions") ? { sessions } : {}),
+  };
+}

--- a/src/integrations/tautulli/api.ts
+++ b/src/integrations/tautulli/api.ts
@@ -88,6 +88,15 @@ function abortedRequestError(): Error {
   return error;
 }
 
+function isAbortError(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    (error as { name?: unknown }).name === "AbortError"
+  );
+}
+
 export async function fetchActivity(
   config: TautulliConfig,
   signal?: AbortSignal
@@ -99,8 +108,8 @@ export async function fetchActivity(
   let response: Response;
   try {
     response = await fetch(url.toString(), { signal });
-  } catch {
-    if (signal?.aborted) {
+  } catch (error) {
+    if (signal?.aborted || isAbortError(error)) {
       throw abortedRequestError();
     }
     throw new Error("Tautulli network request failed");
@@ -112,8 +121,8 @@ export async function fetchActivity(
   let json: unknown;
   try {
     json = await response.json();
-  } catch {
-    if (signal?.aborted) {
+  } catch (error) {
+    if (signal?.aborted || isAbortError(error)) {
       throw abortedRequestError();
     }
     throw new Error("Tautulli returned invalid JSON");

--- a/src/integrations/tdarr/statsWidget.tsx
+++ b/src/integrations/tdarr/statsWidget.tsx
@@ -92,6 +92,7 @@ registerWidget<TdarrConfig, TdarrStats>({
   fetchData: fetchTdarrStats,
   refreshInterval: 10_000,
   component: TdarrStatsWidget,
+  credentialScopeFields: ["url"],
   configFields: [
     {
       key: "url",

--- a/src/integrations/unraid/statsWidget.tsx
+++ b/src/integrations/unraid/statsWidget.tsx
@@ -126,6 +126,7 @@ registerWidget<UnraidConfig, UnraidStats>({
   fetchData: fetchStats,
   refreshInterval: 30_000,
   component: UnraidStatsWidget,
+  credentialScopeFields: ["url"],
   configFields: [
     {
       key: "url",

--- a/src/widgets/configSecrets.ts
+++ b/src/widgets/configSecrets.ts
@@ -43,7 +43,7 @@ export class WidgetSecretResolutionError extends Error {
   }
 }
 
-function passwordFieldKeys(widgetType: string): string[] {
+function credentialFieldKeys(widgetType: string): string[] {
   return (
     getWidget(widgetType)
       ?.configFields?.filter((field) => field.type === "password")
@@ -89,12 +89,12 @@ export function redactWidgetSecrets(config: KokpitConfig): KokpitConfig {
         };
       }
 
-      const passwordKeys = passwordFieldKeys(widget.type);
-      if (passwordKeys.length === 0) return service;
+      const credentialKeys = credentialFieldKeys(widget.type);
+      if (credentialKeys.length === 0) return service;
 
       let changed = false;
       const redactedConfig = { ...rawConfig };
-      for (const key of passwordKeys) {
+      for (const key of credentialKeys) {
         if (
           !Object.prototype.hasOwnProperty.call(rawConfig, key) ||
           rawConfig[key] === undefined
@@ -226,7 +226,7 @@ export function resolveWidgetConfigSecrets(
     return resolveUnknownWidgetConfig(widgetType, rawConfig, savedServices);
   }
   let resolvedConfig: Record<string, unknown> | null = null;
-  const passwordKeys = passwordFieldKeys(widgetType);
+  const credentialKeys = credentialFieldKeys(widgetType);
   for (const [key, value] of Object.entries(rawConfig)) {
     if (isWidgetConfigReference(value)) {
       throw new WidgetSecretResolutionError(
@@ -235,14 +235,14 @@ export function resolveWidgetConfigSecrets(
     }
     if (
       isWidgetSecretReference(value) &&
-      !passwordKeys.includes(key)
+      !credentialKeys.includes(key)
     ) {
       throw new WidgetSecretResolutionError(
         "widget_secret_reference_invalid"
       );
     }
   }
-  for (const key of passwordKeys) {
+  for (const key of credentialKeys) {
     const value = rawConfig[key];
     if (!isWidgetSecretReference(value)) continue;
     resolvedConfig ??= { ...rawConfig };

--- a/src/widgets/configSecrets.ts
+++ b/src/widgets/configSecrets.ts
@@ -6,7 +6,6 @@ import {
 import { getWidget } from "@/widgets";
 import { widgetCredentialScopesMatch } from "./credentialScope";
 import {
-  isWidgetConfigReference,
   isWidgetSecretReference,
 } from "./secretReference";
 import {
@@ -51,6 +50,25 @@ function credentialFieldKeys(widgetType: string): string[] {
   );
 }
 
+function configFieldKeys(widgetType: string): string[] {
+  return getWidget(widgetType)?.configFields?.map((field) => field.key) ?? [];
+}
+
+function shouldHideWholeConfig(
+  widgetType: string,
+  config: Record<string, unknown>
+): boolean {
+  const widget = getWidget(widgetType);
+  if (!widget) return Object.keys(config).length > 0;
+
+  const knownKeys = new Set(configFieldKeys(widgetType));
+  if (Object.keys(config).some((key) => !knownKeys.has(key))) {
+    return true;
+  }
+
+  return !widget.configSchema.safeParse(config).success;
+}
+
 function getOpaqueConfigReference(
   config: Record<string, unknown>
 ): unknown | null {
@@ -73,10 +91,9 @@ export function redactWidgetSecrets(config: KokpitConfig): KokpitConfig {
       const rawConfig = widget?.config;
       if (!widget || !rawConfig) return service;
 
-      // An unregistered widget has no trustworthy field metadata. Treat the
-      // entire non-empty config as secret and retain it only on the server.
-      if (!getWidget(widget.type)) {
-        if (Object.keys(rawConfig).length === 0) return service;
+      // A config outside the editor's exact field contract cannot safely be
+      // classified in the browser. Keep it on the server as one opaque value.
+      if (shouldHideWholeConfig(widget.type, rawConfig)) {
         return {
           ...service,
           widget: {
@@ -222,17 +239,21 @@ export function resolveWidgetConfigSecrets(
   }
 
   const rawConfig = config as Record<string, unknown>;
+  const opaqueReference = getOpaqueConfigReference(rawConfig);
+  if (opaqueReference !== null) {
+    return resolveUnknownWidgetConfig(widgetType, rawConfig, savedServices);
+  }
+  if (Object.prototype.hasOwnProperty.call(rawConfig, UNKNOWN_WIDGET_CONFIG_REFERENCE_KEY)) {
+    throw new WidgetSecretResolutionError(
+      "widget_secret_reference_invalid"
+    );
+  }
   if (!getWidget(widgetType)) {
     return resolveUnknownWidgetConfig(widgetType, rawConfig, savedServices);
   }
   let resolvedConfig: Record<string, unknown> | null = null;
   const credentialKeys = credentialFieldKeys(widgetType);
   for (const [key, value] of Object.entries(rawConfig)) {
-    if (isWidgetConfigReference(value)) {
-      throw new WidgetSecretResolutionError(
-        "widget_secret_reference_invalid"
-      );
-    }
     if (
       isWidgetSecretReference(value) &&
       !credentialKeys.includes(key)

--- a/src/widgets/configSecrets.ts
+++ b/src/widgets/configSecrets.ts
@@ -1,18 +1,26 @@
 import "@/integrations";
 import {
-  serviceNameUniquenessKey,
   type KokpitConfig,
   type Service,
 } from "@/config/schema";
 import { getWidget } from "@/widgets";
 import { widgetCredentialScopesMatch } from "./credentialScope";
 import {
+  isWidgetConfigReference,
   isWidgetSecretReference,
 } from "./secretReference";
 import {
+  createWidgetConfigReference,
   createWidgetSecretReference,
+  verifyWidgetConfigReference,
   verifyWidgetSecretReference,
+  widgetConfigReferenceMatches,
+  widgetSecretReferenceMatches,
 } from "./secretReference.server";
+
+/** The sole browser-visible key for an opaque unknown-widget config. */
+export const UNKNOWN_WIDGET_CONFIG_REFERENCE_KEY =
+  "__kokpit_widget_config_reference__";
 
 export type WidgetSecretResolutionErrorCode =
   | "widget_secret_reference_invalid"
@@ -43,6 +51,16 @@ function passwordFieldKeys(widgetType: string): string[] {
   );
 }
 
+function getOpaqueConfigReference(
+  config: Record<string, unknown>
+): unknown | null {
+  const keys = Object.keys(config);
+  if (keys.length !== 1 || keys[0] !== UNKNOWN_WIDGET_CONFIG_REFERENCE_KEY) {
+    return null;
+  }
+  return config[UNKNOWN_WIDGET_CONFIG_REFERENCE_KEY];
+}
+
 /**
  * Returns a browser-safe config copy. Password fields are identified only by
  * registry metadata, so integrations do not need key-name redaction lists.
@@ -54,6 +72,22 @@ export function redactWidgetSecrets(config: KokpitConfig): KokpitConfig {
       const widget = service.widget;
       const rawConfig = widget?.config;
       if (!widget || !rawConfig) return service;
+
+      // An unregistered widget has no trustworthy field metadata. Treat the
+      // entire non-empty config as secret and retain it only on the server.
+      if (!getWidget(widget.type)) {
+        if (Object.keys(rawConfig).length === 0) return service;
+        return {
+          ...service,
+          widget: {
+            ...widget,
+            config: {
+              [UNKNOWN_WIDGET_CONFIG_REFERENCE_KEY]:
+                createWidgetConfigReference(service.name, widget.type),
+            },
+          },
+        };
+      }
 
       const passwordKeys = passwordFieldKeys(widget.type);
       if (passwordKeys.length === 0) return service;
@@ -92,22 +126,22 @@ function resolveReference(
   savedServices: Service[]
 ): unknown {
   const reference = verifyWidgetSecretReference(referenceValue);
-  if (
-    !reference ||
-    reference.widgetType !== expectedWidgetType ||
-    reference.fieldKey !== expectedFieldKey
-  ) {
+  if (!reference) {
     throw new WidgetSecretResolutionError(
       "widget_secret_reference_invalid"
     );
   }
 
-  const source = savedServices.find(
-    (service) =>
-      serviceNameUniquenessKey(service.name) ===
-      serviceNameUniquenessKey(reference.serviceName)
+  const source = savedServices.find((service) =>
+    service.widget?.type === expectedWidgetType &&
+    widgetSecretReferenceMatches(
+      reference,
+      service.name,
+      expectedWidgetType,
+      expectedFieldKey
+    )
   );
-  if (source?.widget?.type !== expectedWidgetType) {
+  if (!source?.widget) {
     throw new WidgetSecretResolutionError(
       "widget_secret_reference_invalid"
     );
@@ -143,6 +177,37 @@ function resolveReference(
   return savedValue;
 }
 
+function resolveUnknownWidgetConfig(
+  widgetType: string,
+  config: Record<string, unknown>,
+  savedServices: Service[]
+): Record<string, unknown> {
+  const opaqueReference = getOpaqueConfigReference(config);
+  if (opaqueReference === null) {
+    if (Object.prototype.hasOwnProperty.call(config, UNKNOWN_WIDGET_CONFIG_REFERENCE_KEY)) {
+      throw new WidgetSecretResolutionError(
+        "widget_secret_reference_invalid"
+      );
+    }
+    return config;
+  }
+
+  const reference = verifyWidgetConfigReference(opaqueReference);
+  if (!reference) {
+    throw new WidgetSecretResolutionError("widget_secret_reference_invalid");
+  }
+  const source = savedServices.find(
+    (service) =>
+      service.widget?.config !== undefined &&
+      service.widget.type === widgetType &&
+      widgetConfigReferenceMatches(reference, service.name, widgetType)
+  );
+  if (!source?.widget?.config) {
+    throw new WidgetSecretResolutionError("widget_secret_reference_invalid");
+  }
+  return source.widget.config;
+}
+
 /**
  * Resolves placeholders in one submitted widget config against the live
  * server-side config. Used by connection testing before schema validation.
@@ -157,9 +222,17 @@ export function resolveWidgetConfigSecrets(
   }
 
   const rawConfig = config as Record<string, unknown>;
+  if (!getWidget(widgetType)) {
+    return resolveUnknownWidgetConfig(widgetType, rawConfig, savedServices);
+  }
   let resolvedConfig: Record<string, unknown> | null = null;
   const passwordKeys = passwordFieldKeys(widgetType);
   for (const [key, value] of Object.entries(rawConfig)) {
+    if (isWidgetConfigReference(value)) {
+      throw new WidgetSecretResolutionError(
+        "widget_secret_reference_invalid"
+      );
+    }
     if (
       isWidgetSecretReference(value) &&
       !passwordKeys.includes(key)

--- a/src/widgets/configSecrets.ts
+++ b/src/widgets/configSecrets.ts
@@ -50,8 +50,19 @@ function credentialFieldKeys(widgetType: string): string[] {
   );
 }
 
-function configFieldKeys(widgetType: string): string[] {
-  return getWidget(widgetType)?.configFields?.map((field) => field.key) ?? [];
+function isSafeConfigValue(
+  type: "text" | "url" | "password" | "number" | "multiselect" | "boolean",
+  value: unknown
+): boolean {
+  if (value === undefined) return true;
+  if (type === "text" || type === "url" || type === "password") {
+    return typeof value === "string";
+  }
+  if (type === "number") {
+    return typeof value === "number" && Number.isFinite(value);
+  }
+  if (type === "boolean") return typeof value === "boolean";
+  return Array.isArray(value) && value.every((item) => typeof item === "string");
 }
 
 function shouldHideWholeConfig(
@@ -61,14 +72,14 @@ function shouldHideWholeConfig(
   const widget = getWidget(widgetType);
   if (!widget) return Object.keys(config).length > 0;
 
-  const knownKeys = new Set(configFieldKeys(widgetType));
-  if (Object.keys(config).some((key) => !knownKeys.has(key))) {
-    return true;
-  }
-
-  return credentialFieldKeys(widgetType).some((key) => {
-    const value = config[key];
-    return value !== undefined && value !== "" && typeof value !== "string";
+  const fields = new Map(
+    [...(widget.configFields ?? []), ...(widget.preservedConfigFields ?? [])].map(
+      (field) => [field.key, field] as const
+    )
+  );
+  return Object.entries(config).some(([key, value]) => {
+    const field = fields.get(key);
+    return !field || !isSafeConfigValue(field.type, value);
   });
 }
 
@@ -94,8 +105,8 @@ export function redactWidgetSecrets(config: KokpitConfig): KokpitConfig {
       const rawConfig = widget?.config;
       if (!widget || !rawConfig) return service;
 
-      // Unknown fields and non-string credentials cannot safely be classified
-      // in the browser. Keep the complete config on the server in those cases.
+      // Unknown keys and malformed declared values could contain secrets.
+      // Keep the complete config on the server in those cases.
       if (shouldHideWholeConfig(widget.type, rawConfig)) {
         return {
           ...service,
@@ -210,6 +221,18 @@ function resolveUnknownWidgetConfig(
     return config;
   }
 
+  return resolveOpaqueWidgetConfigReference(
+    widgetType,
+    opaqueReference,
+    savedServices
+  );
+}
+
+function resolveOpaqueWidgetConfigReference(
+  widgetType: string,
+  opaqueReference: unknown,
+  savedServices: Service[]
+): Record<string, unknown> {
   const reference = verifyWidgetConfigReference(opaqueReference);
   if (!reference) {
     throw new WidgetSecretResolutionError("widget_secret_reference_invalid");
@@ -245,8 +268,20 @@ export function resolveWidgetConfigSecrets(
     return resolveUnknownWidgetConfig(widgetType, rawConfig, savedServices);
   }
   if (Object.prototype.hasOwnProperty.call(rawConfig, UNKNOWN_WIDGET_CONFIG_REFERENCE_KEY)) {
-    throw new WidgetSecretResolutionError(
-      "widget_secret_reference_invalid"
+    const replacementConfig = { ...rawConfig };
+    const replacementReference = replacementConfig[
+      UNKNOWN_WIDGET_CONFIG_REFERENCE_KEY
+    ];
+    delete replacementConfig[UNKNOWN_WIDGET_CONFIG_REFERENCE_KEY];
+    resolveOpaqueWidgetConfigReference(
+      widgetType,
+      replacementReference,
+      savedServices
+    );
+    return resolveWidgetConfigSecrets(
+      widgetType,
+      replacementConfig,
+      savedServices
     );
   }
   if (!getWidget(widgetType)) {

--- a/src/widgets/configSecrets.ts
+++ b/src/widgets/configSecrets.ts
@@ -66,7 +66,10 @@ function shouldHideWholeConfig(
     return true;
   }
 
-  return !widget.configSchema.safeParse(config).success;
+  return credentialFieldKeys(widgetType).some((key) => {
+    const value = config[key];
+    return value !== undefined && value !== "" && typeof value !== "string";
+  });
 }
 
 function getOpaqueConfigReference(
@@ -91,8 +94,8 @@ export function redactWidgetSecrets(config: KokpitConfig): KokpitConfig {
       const rawConfig = widget?.config;
       if (!widget || !rawConfig) return service;
 
-      // A config outside the editor's exact field contract cannot safely be
-      // classified in the browser. Keep it on the server as one opaque value.
+      // Unknown fields and non-string credentials cannot safely be classified
+      // in the browser. Keep the complete config on the server in those cases.
       if (shouldHideWholeConfig(widget.type, rawConfig)) {
         return {
           ...service,
@@ -112,10 +115,8 @@ export function redactWidgetSecrets(config: KokpitConfig): KokpitConfig {
       let changed = false;
       const redactedConfig = { ...rawConfig };
       for (const key of credentialKeys) {
-        if (
-          !Object.prototype.hasOwnProperty.call(rawConfig, key) ||
-          rawConfig[key] === undefined
-        ) {
+        const value = rawConfig[key];
+        if (value === undefined || value === "") {
           continue;
         }
         redactedConfig[key] = createWidgetSecretReference(

--- a/src/widgets/configSecrets.ts
+++ b/src/widgets/configSecrets.ts
@@ -1,0 +1,163 @@
+import "@/integrations";
+import {
+  serviceNameUniquenessKey,
+  type KokpitConfig,
+  type Service,
+} from "@/config/schema";
+import { getWidget } from "@/widgets";
+import {
+  createWidgetSecretReference,
+  isWidgetSecretReference,
+  parseWidgetSecretReference,
+} from "./secretReference";
+
+export class WidgetSecretResolutionError extends Error {
+  constructor() {
+    super("Saved widget secret could not be resolved");
+    this.name = "WidgetSecretResolutionError";
+  }
+}
+
+function passwordFieldKeys(widgetType: string): string[] {
+  return (
+    getWidget(widgetType)
+      ?.configFields?.filter((field) => field.type === "password")
+      .map((field) => field.key) ?? []
+  );
+}
+
+/**
+ * Returns a browser-safe config copy. Password fields are identified only by
+ * registry metadata, so integrations do not need key-name redaction lists.
+ */
+export function redactWidgetSecrets(config: KokpitConfig): KokpitConfig {
+  return {
+    ...config,
+    services: config.services.map((service) => {
+      const widget = service.widget;
+      const rawConfig = widget?.config;
+      if (!widget || !rawConfig) return service;
+
+      const passwordKeys = passwordFieldKeys(widget.type);
+      if (passwordKeys.length === 0) return service;
+
+      let changed = false;
+      const redactedConfig = { ...rawConfig };
+      for (const key of passwordKeys) {
+        if (
+          !Object.prototype.hasOwnProperty.call(rawConfig, key) ||
+          rawConfig[key] === undefined
+        ) {
+          continue;
+        }
+        redactedConfig[key] = createWidgetSecretReference(
+          service.name,
+          widget.type,
+          key
+        );
+        changed = true;
+      }
+      if (!changed) return service;
+
+      return {
+        ...service,
+        widget: { ...widget, config: redactedConfig },
+      };
+    }),
+  };
+}
+
+function resolveReference(
+  referenceValue: unknown,
+  expectedWidgetType: string,
+  expectedFieldKey: string,
+  savedServices: Service[]
+): unknown {
+  const reference = parseWidgetSecretReference(referenceValue);
+  if (
+    !reference ||
+    reference.widgetType !== expectedWidgetType ||
+    reference.fieldKey !== expectedFieldKey
+  ) {
+    throw new WidgetSecretResolutionError();
+  }
+
+  const source = savedServices.find(
+    (service) =>
+      serviceNameUniquenessKey(service.name) ===
+      serviceNameUniquenessKey(reference.serviceName)
+  );
+  if (source?.widget?.type !== expectedWidgetType) {
+    throw new WidgetSecretResolutionError();
+  }
+
+  const sourceConfig = source.widget.config;
+  if (
+    !sourceConfig ||
+    !Object.prototype.hasOwnProperty.call(sourceConfig, expectedFieldKey)
+  ) {
+    throw new WidgetSecretResolutionError();
+  }
+  const savedValue = sourceConfig[expectedFieldKey];
+  if (isWidgetSecretReference(savedValue)) {
+    throw new WidgetSecretResolutionError();
+  }
+  return savedValue;
+}
+
+/**
+ * Resolves placeholders in one submitted widget config against the live
+ * server-side config. Used by connection testing before schema validation.
+ */
+export function resolveWidgetConfigSecrets(
+  widgetType: string,
+  config: unknown,
+  savedServices: Service[]
+): unknown {
+  if (typeof config !== "object" || config === null || Array.isArray(config)) {
+    return config;
+  }
+
+  const rawConfig = config as Record<string, unknown>;
+  let resolvedConfig: Record<string, unknown> | null = null;
+  for (const key of passwordFieldKeys(widgetType)) {
+    const value = rawConfig[key];
+    if (!isWidgetSecretReference(value)) continue;
+    resolvedConfig ??= { ...rawConfig };
+    resolvedConfig[key] = resolveReference(
+      value,
+      widgetType,
+      key,
+      savedServices
+    );
+  }
+  return resolvedConfig ?? config;
+}
+
+/**
+ * Resolves all submitted service placeholders before YAML persistence. Each
+ * token points to its original service name, so rename and reorder operations
+ * can happen together without relying on array position.
+ */
+export function resolveServiceWidgetSecrets(
+  submittedServices: Service[],
+  savedServices: Service[]
+): Service[] {
+  return submittedServices.map((service) => {
+    const widget = service.widget;
+    if (!widget?.config) return service;
+    const resolved = resolveWidgetConfigSecrets(
+      widget.type,
+      widget.config,
+      savedServices
+    );
+    if (resolved === widget.config) return service;
+    return {
+      ...service,
+      widget: {
+        ...widget,
+        config: resolved as Record<string, unknown>,
+      },
+    };
+  });
+}

--- a/src/widgets/configSecrets.ts
+++ b/src/widgets/configSecrets.ts
@@ -5,16 +5,33 @@ import {
   type Service,
 } from "@/config/schema";
 import { getWidget } from "@/widgets";
+import { widgetCredentialScopesMatch } from "./credentialScope";
+import {
+  isWidgetSecretReference,
+} from "./secretReference";
 import {
   createWidgetSecretReference,
-  isWidgetSecretReference,
-  parseWidgetSecretReference,
-} from "./secretReference";
+  verifyWidgetSecretReference,
+} from "./secretReference.server";
+
+export type WidgetSecretResolutionErrorCode =
+  | "widget_secret_reference_invalid"
+  | "widget_secret_scope_changed";
+
+const ERROR_MESSAGES: Record<WidgetSecretResolutionErrorCode, string> = {
+  widget_secret_reference_invalid:
+    "Saved widget credential is no longer available. Re-enter the credential.",
+  widget_secret_scope_changed:
+    "Widget credential scope changed. Re-enter the credential.",
+};
 
 export class WidgetSecretResolutionError extends Error {
-  constructor() {
-    super("Saved widget secret could not be resolved");
+  readonly code: WidgetSecretResolutionErrorCode;
+
+  constructor(code: WidgetSecretResolutionErrorCode) {
+    super(ERROR_MESSAGES[code]);
     this.name = "WidgetSecretResolutionError";
+    this.code = code;
   }
 }
 
@@ -71,15 +88,18 @@ function resolveReference(
   referenceValue: unknown,
   expectedWidgetType: string,
   expectedFieldKey: string,
+  destinationConfig: Record<string, unknown>,
   savedServices: Service[]
 ): unknown {
-  const reference = parseWidgetSecretReference(referenceValue);
+  const reference = verifyWidgetSecretReference(referenceValue);
   if (
     !reference ||
     reference.widgetType !== expectedWidgetType ||
     reference.fieldKey !== expectedFieldKey
   ) {
-    throw new WidgetSecretResolutionError();
+    throw new WidgetSecretResolutionError(
+      "widget_secret_reference_invalid"
+    );
   }
 
   const source = savedServices.find(
@@ -88,7 +108,9 @@ function resolveReference(
       serviceNameUniquenessKey(reference.serviceName)
   );
   if (source?.widget?.type !== expectedWidgetType) {
-    throw new WidgetSecretResolutionError();
+    throw new WidgetSecretResolutionError(
+      "widget_secret_reference_invalid"
+    );
   }
 
   const sourceConfig = source.widget.config;
@@ -96,11 +118,27 @@ function resolveReference(
     !sourceConfig ||
     !Object.prototype.hasOwnProperty.call(sourceConfig, expectedFieldKey)
   ) {
-    throw new WidgetSecretResolutionError();
+    throw new WidgetSecretResolutionError(
+      "widget_secret_reference_invalid"
+    );
   }
   const savedValue = sourceConfig[expectedFieldKey];
-  if (isWidgetSecretReference(savedValue)) {
-    throw new WidgetSecretResolutionError();
+  if (
+    typeof savedValue !== "string" ||
+    isWidgetSecretReference(savedValue)
+  ) {
+    throw new WidgetSecretResolutionError(
+      "widget_secret_reference_invalid"
+    );
+  }
+  if (
+    !widgetCredentialScopesMatch(
+      expectedWidgetType,
+      sourceConfig,
+      destinationConfig
+    )
+  ) {
+    throw new WidgetSecretResolutionError("widget_secret_scope_changed");
   }
   return savedValue;
 }
@@ -120,7 +158,18 @@ export function resolveWidgetConfigSecrets(
 
   const rawConfig = config as Record<string, unknown>;
   let resolvedConfig: Record<string, unknown> | null = null;
-  for (const key of passwordFieldKeys(widgetType)) {
+  const passwordKeys = passwordFieldKeys(widgetType);
+  for (const [key, value] of Object.entries(rawConfig)) {
+    if (
+      isWidgetSecretReference(value) &&
+      !passwordKeys.includes(key)
+    ) {
+      throw new WidgetSecretResolutionError(
+        "widget_secret_reference_invalid"
+      );
+    }
+  }
+  for (const key of passwordKeys) {
     const value = rawConfig[key];
     if (!isWidgetSecretReference(value)) continue;
     resolvedConfig ??= { ...rawConfig };
@@ -128,6 +177,7 @@ export function resolveWidgetConfigSecrets(
       value,
       widgetType,
       key,
+      rawConfig,
       savedServices
     );
   }

--- a/src/widgets/credentialScope.ts
+++ b/src/widgets/credentialScope.ts
@@ -1,0 +1,60 @@
+import { getWidget, type WidgetConfigField } from "./index";
+
+function normalizeScopeValue(
+  field: WidgetConfigField,
+  value: unknown
+): string | null {
+  if (typeof value !== "string") return null;
+  if (field.type !== "url") return field.type === "text" ? value : null;
+
+  try {
+    const url = new URL(value.trim());
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Calculates a browser-safe credential destination scope from registry
+ * metadata. Missing or invalid values fail closed.
+ */
+export function normalizeCredentialScope(
+  widgetType: string,
+  config: unknown
+): string[] | null {
+  if (typeof config !== "object" || config === null || Array.isArray(config)) {
+    return null;
+  }
+  const widget = getWidget(widgetType);
+  const scopeFields = widget?.credentialScopeFields;
+  if (!widget || !scopeFields || scopeFields.length === 0) return null;
+
+  const rawConfig = config as Record<string, unknown>;
+  const normalized: string[] = [];
+  for (const key of scopeFields) {
+    const field = widget.configFields?.find((candidate) => candidate.key === key);
+    if (!field) return null;
+    const value = normalizeScopeValue(field, rawConfig[key]);
+    if (value === null) return null;
+    normalized.push(value);
+  }
+  return normalized;
+}
+
+export function widgetCredentialScopesMatch(
+  widgetType: string,
+  sourceConfig: unknown,
+  destinationConfig: unknown
+): boolean {
+  const source = normalizeCredentialScope(widgetType, sourceConfig);
+  const destination = normalizeCredentialScope(widgetType, destinationConfig);
+  return (
+    source !== null &&
+    destination !== null &&
+    source.length === destination.length &&
+    source.every((value, index) => value === destination[index])
+  );
+}

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -100,7 +100,7 @@ export function registerWidget<TConfig = Record<string, unknown>, TData = unknow
     }
     for (const key of scope) {
       const field = fields.find((candidate) => candidate.key === key);
-      if (!field || field.type === "password") {
+      if (!field || (field.type !== "url" && field.type !== "text")) {
         throw new Error(
           `Widget "${def.id}" has an invalid credential scope field "${key}"`
         );

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -41,6 +41,12 @@ export interface WidgetDefinition<TConfig = Record<string, unknown>, TData = unk
   component: React.ComponentType<WidgetProps<TData>>;
   /** Describes the config fields for in-app UI rendering. */
   configFields?: WidgetConfigField[];
+  /**
+   * Non-secret config fields that bind any password credential to its
+   * destination. Required and validated at registration when password fields
+   * exist.
+   */
+  credentialScopeFields?: string[];
   /** When set, this widget appears as a tile type in the service editor. */
   serviceEditorPreset?: ServiceEditorPreset;
   /**
@@ -60,6 +66,24 @@ const widgetRegistry = new Map<string, AnyWidgetDefinition>();
 export function registerWidget<TConfig = Record<string, unknown>, TData = unknown>(
   def: WidgetDefinition<TConfig, TData>
 ): void {
+  const fields = def.configFields ?? [];
+  const hasPassword = fields.some((field) => field.type === "password");
+  if (hasPassword) {
+    const scope = def.credentialScopeFields;
+    if (!scope || scope.length === 0) {
+      throw new Error(
+        `Widget "${def.id}" must declare a nonempty credential scope`
+      );
+    }
+    for (const key of scope) {
+      const field = fields.find((candidate) => candidate.key === key);
+      if (!field || field.type === "password") {
+        throw new Error(
+          `Widget "${def.id}" has an invalid credential scope field "${key}"`
+        );
+      }
+    }
+  }
   if (widgetRegistry.has(def.id)) {
     throw new Error(`Widget "${def.id}" is already registered`);
   }

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -18,6 +18,8 @@ export interface WidgetConfigField {
   placeholder?: string;
   description?: string;
   required?: boolean;
+  /** Initial editor value when the saved widget config omits this key. */
+  defaultValue?: string | number | string[];
   /** Options for multiselect fields. */
   options?: Array<{ value: string; label: string }>;
 }

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -41,6 +41,12 @@ export type WidgetConfigField =
       defaultValue?: string | number | string[];
     });
 
+/** A schema-supported non-secret field kept in config but omitted from the editor. */
+export interface WidgetPreservedConfigField {
+  key: string;
+  type: Exclude<WidgetConfigFieldType, "password">;
+}
+
 /** Default tile label and icon when picking this widget in the service editor. */
 export interface ServiceEditorPreset {
   defaultName: string;
@@ -58,6 +64,8 @@ export interface WidgetDefinition<TConfig = Record<string, unknown>, TData = unk
   component: React.ComponentType<WidgetProps<TData>>;
   /** Describes the config fields for in-app UI rendering. */
   configFields?: WidgetConfigField[];
+  /** Schema-supported non-secret fields kept on save but not shown in the editor. */
+  preservedConfigFields?: WidgetPreservedConfigField[];
   /**
    * Non-secret config fields that bind any password credential to its
    * destination. Required and validated at registration when password fields

--- a/src/widgets/publicFetchError.ts
+++ b/src/widgets/publicFetchError.ts
@@ -1,0 +1,13 @@
+export type WidgetFetchOperation = "load" | "connection-test";
+
+/**
+ * Returns only bounded application-owned text. Integration errors may contain
+ * upstream response bodies, request URLs, headers, or saved credentials.
+ */
+export function publicWidgetFetchError(
+  operation: WidgetFetchOperation
+): string {
+  return operation === "load"
+    ? "Widget fetch failed"
+    : "Connection test failed";
+}

--- a/src/widgets/secretReference.server.ts
+++ b/src/widgets/secretReference.server.ts
@@ -3,8 +3,10 @@ import { getServerSecret } from "@/auth/serverSecret";
 import {
   isWidgetConfigReference,
   isWidgetSecretReference,
+  WIDGET_SECRET_REFERENCE_KEY,
   WIDGET_CONFIG_REFERENCE_PREFIX,
   WIDGET_SECRET_REFERENCE_PREFIX,
+  type WidgetSecretReferencePlaceholder,
 } from "./secretReference";
 
 const PURPOSE = "kokpit/widget-secret-reference/v2";
@@ -66,14 +68,19 @@ export function createWidgetSecretReference(
   serviceName: string,
   widgetType: string,
   fieldKey: string
-): string {
-  return encodePayload(WIDGET_SECRET_REFERENCE_PREFIX, {
-    v: 2,
-    kind: "field",
-    serviceLocator: locator("service", serviceName),
-    widgetLocator: locator("widget", widgetType),
-    fieldLocator: locator("field", fieldKey),
-  });
+): WidgetSecretReferencePlaceholder {
+  return {
+    [WIDGET_SECRET_REFERENCE_KEY]: encodePayload(
+      WIDGET_SECRET_REFERENCE_PREFIX,
+      {
+        v: 2,
+        kind: "field",
+        serviceLocator: locator("service", serviceName),
+        widgetLocator: locator("widget", widgetType),
+        fieldLocator: locator("field", fieldKey),
+      }
+    ),
+  };
 }
 
 export function createWidgetConfigReference(
@@ -208,7 +215,11 @@ export function verifyWidgetSecretReference(
   value: unknown
 ): WidgetSecretReference | null {
   if (!isWidgetSecretReference(value)) return null;
-  return verifyReference(value, WIDGET_SECRET_REFERENCE_PREFIX, isExactFieldPayload);
+  return verifyReference(
+    value[WIDGET_SECRET_REFERENCE_KEY],
+    WIDGET_SECRET_REFERENCE_PREFIX,
+    isExactFieldPayload
+  );
 }
 
 export function verifyWidgetConfigReference(

--- a/src/widgets/secretReference.server.ts
+++ b/src/widgets/secretReference.server.ts
@@ -1,19 +1,29 @@
 import { createHmac, timingSafeEqual } from "node:crypto";
 import { getServerSecret } from "@/auth/serverSecret";
 import {
+  isWidgetConfigReference,
   isWidgetSecretReference,
+  WIDGET_CONFIG_REFERENCE_PREFIX,
   WIDGET_SECRET_REFERENCE_PREFIX,
 } from "./secretReference";
 
-const PURPOSE = "kokpit/widget-secret-reference/v1";
+const PURPOSE = "kokpit/widget-secret-reference/v2";
 const MAX_REFERENCE_LENGTH = 2_048;
 const BASE64URL = /^[A-Za-z0-9_-]+$/;
 
 export interface WidgetSecretReference {
-  v: 1;
-  serviceName: string;
-  widgetType: string;
-  fieldKey: string;
+  v: 2;
+  kind: "field";
+  serviceLocator: string;
+  widgetLocator: string;
+  fieldLocator: string;
+}
+
+export interface WidgetConfigReference {
+  v: 2;
+  kind: "config";
+  serviceLocator: string;
+  widgetLocator: string;
 }
 
 function signingKey(): Buffer {
@@ -24,11 +34,32 @@ function signature(payload: string): Buffer {
   return createHmac("sha256", signingKey()).update(payload).digest();
 }
 
-function encodePayload(payload: unknown): string {
+function encodePayload(prefix: string, payload: unknown): string {
   const encoded = Buffer.from(JSON.stringify(payload), "utf8").toString(
     "base64url"
   );
-  return `${WIDGET_SECRET_REFERENCE_PREFIX}${encoded}.${signature(encoded).toString("base64url")}`;
+  return `${prefix}${encoded}.${signature(encoded).toString("base64url")}`;
+}
+
+/**
+ * Fixed-length, server-keyed identifier for a locator component. The only
+ * variable-length strings that used to be embedded in references were service
+ * names, widget ids, and field names; hashing all three makes every issued
+ * token safely smaller than the verifier's input limit.
+ */
+function locator(kind: string, value: string): string {
+  const canonicalValue = kind === "service" ? value.trim().toLowerCase() : value;
+  return createHmac("sha256", signingKey())
+    .update(`${kind}\u0000${canonicalValue}`)
+    .digest("base64url");
+}
+
+function locatorMatches(locatorValue: string, kind: string, value: string): boolean {
+  const expected = Buffer.from(locator(kind, value), "utf8");
+  const received = Buffer.from(locatorValue, "utf8");
+  return (
+    received.length === expected.length && timingSafeEqual(received, expected)
+  );
 }
 
 export function createWidgetSecretReference(
@@ -36,15 +67,76 @@ export function createWidgetSecretReference(
   widgetType: string,
   fieldKey: string
 ): string {
-  return encodePayload({
-    v: 1,
-    serviceName,
-    widgetType,
-    fieldKey,
+  return encodePayload(WIDGET_SECRET_REFERENCE_PREFIX, {
+    v: 2,
+    kind: "field",
+    serviceLocator: locator("service", serviceName),
+    widgetLocator: locator("widget", widgetType),
+    fieldLocator: locator("field", fieldKey),
   });
 }
 
-function isExactPayload(value: unknown): value is WidgetSecretReference {
+export function createWidgetConfigReference(
+  serviceName: string,
+  widgetType: string
+): string {
+  return encodePayload(WIDGET_CONFIG_REFERENCE_PREFIX, {
+    v: 2,
+    kind: "config",
+    serviceLocator: locator("service", serviceName),
+    widgetLocator: locator("widget", widgetType),
+  });
+}
+
+export function widgetSecretReferenceMatches(
+  reference: WidgetSecretReference,
+  serviceName: string,
+  widgetType: string,
+  fieldKey: string
+): boolean {
+  return (
+    locatorMatches(reference.serviceLocator, "service", serviceName) &&
+    locatorMatches(reference.widgetLocator, "widget", widgetType) &&
+    locatorMatches(reference.fieldLocator, "field", fieldKey)
+  );
+}
+
+export function widgetConfigReferenceMatches(
+  reference: WidgetConfigReference,
+  serviceName: string,
+  widgetType: string
+): boolean {
+  return (
+    locatorMatches(reference.serviceLocator, "service", serviceName) &&
+    locatorMatches(reference.widgetLocator, "widget", widgetType)
+  );
+}
+
+function isExactFieldPayload(value: unknown): value is WidgetSecretReference {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const payload = value as Record<string, unknown>;
+  const keys = Object.keys(payload).sort();
+  return (
+    keys.length === 5 &&
+    keys[0] === "fieldLocator" &&
+    keys[1] === "kind" &&
+    keys[2] === "serviceLocator" &&
+    keys[3] === "v" &&
+    keys[4] === "widgetLocator" &&
+    payload.v === 2 &&
+    payload.kind === "field" &&
+    typeof payload.serviceLocator === "string" &&
+    typeof payload.widgetLocator === "string" &&
+    typeof payload.fieldLocator === "string" &&
+    BASE64URL.test(payload.serviceLocator) &&
+    BASE64URL.test(payload.widgetLocator) &&
+    BASE64URL.test(payload.fieldLocator)
+  );
+}
+
+function isExactConfigPayload(value: unknown): value is WidgetConfigReference {
   if (typeof value !== "object" || value === null || Array.isArray(value)) {
     return false;
   }
@@ -52,31 +144,33 @@ function isExactPayload(value: unknown): value is WidgetSecretReference {
   const keys = Object.keys(payload).sort();
   return (
     keys.length === 4 &&
-    keys[0] === "fieldKey" &&
-    keys[1] === "serviceName" &&
+    keys[0] === "kind" &&
+    keys[1] === "serviceLocator" &&
     keys[2] === "v" &&
-    keys[3] === "widgetType" &&
-    payload.v === 1 &&
-    typeof payload.serviceName === "string" &&
-    payload.serviceName.length > 0 &&
-    typeof payload.widgetType === "string" &&
-    payload.widgetType.length > 0 &&
-    typeof payload.fieldKey === "string" &&
-    payload.fieldKey.length > 0
+    keys[3] === "widgetLocator" &&
+    payload.v === 2 &&
+    payload.kind === "config" &&
+    typeof payload.serviceLocator === "string" &&
+    typeof payload.widgetLocator === "string" &&
+    BASE64URL.test(payload.serviceLocator) &&
+    BASE64URL.test(payload.widgetLocator)
   );
 }
 
-export function verifyWidgetSecretReference(
-  value: unknown
-): WidgetSecretReference | null {
+function verifyReference<T>(
+  value: unknown,
+  prefix: string,
+  isExactPayload: (payload: unknown) => payload is T
+): T | null {
   if (
-    !isWidgetSecretReference(value) ||
+    typeof value !== "string" ||
+    !value.startsWith(prefix) ||
     value.length > MAX_REFERENCE_LENGTH
   ) {
     return null;
   }
 
-  const token = value.slice(WIDGET_SECRET_REFERENCE_PREFIX.length);
+  const token = value.slice(prefix.length);
   const parts = token.split(".");
   if (
     parts.length !== 2 ||
@@ -108,4 +202,18 @@ export function verifyWidgetSecretReference(
   } catch {
     return null;
   }
+}
+
+export function verifyWidgetSecretReference(
+  value: unknown
+): WidgetSecretReference | null {
+  if (!isWidgetSecretReference(value)) return null;
+  return verifyReference(value, WIDGET_SECRET_REFERENCE_PREFIX, isExactFieldPayload);
+}
+
+export function verifyWidgetConfigReference(
+  value: unknown
+): WidgetConfigReference | null {
+  if (!isWidgetConfigReference(value)) return null;
+  return verifyReference(value, WIDGET_CONFIG_REFERENCE_PREFIX, isExactConfigPayload);
 }

--- a/src/widgets/secretReference.server.ts
+++ b/src/widgets/secretReference.server.ts
@@ -1,0 +1,111 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import { getServerSecret } from "@/auth/serverSecret";
+import {
+  isWidgetSecretReference,
+  WIDGET_SECRET_REFERENCE_PREFIX,
+} from "./secretReference";
+
+const PURPOSE = "kokpit/widget-secret-reference/v1";
+const MAX_REFERENCE_LENGTH = 2_048;
+const BASE64URL = /^[A-Za-z0-9_-]+$/;
+
+export interface WidgetSecretReference {
+  v: 1;
+  serviceName: string;
+  widgetType: string;
+  fieldKey: string;
+}
+
+function signingKey(): Buffer {
+  return createHmac("sha256", getServerSecret()).update(PURPOSE).digest();
+}
+
+function signature(payload: string): Buffer {
+  return createHmac("sha256", signingKey()).update(payload).digest();
+}
+
+function encodePayload(payload: unknown): string {
+  const encoded = Buffer.from(JSON.stringify(payload), "utf8").toString(
+    "base64url"
+  );
+  return `${WIDGET_SECRET_REFERENCE_PREFIX}${encoded}.${signature(encoded).toString("base64url")}`;
+}
+
+export function createWidgetSecretReference(
+  serviceName: string,
+  widgetType: string,
+  fieldKey: string
+): string {
+  return encodePayload({
+    v: 1,
+    serviceName,
+    widgetType,
+    fieldKey,
+  });
+}
+
+function isExactPayload(value: unknown): value is WidgetSecretReference {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const payload = value as Record<string, unknown>;
+  const keys = Object.keys(payload).sort();
+  return (
+    keys.length === 4 &&
+    keys[0] === "fieldKey" &&
+    keys[1] === "serviceName" &&
+    keys[2] === "v" &&
+    keys[3] === "widgetType" &&
+    payload.v === 1 &&
+    typeof payload.serviceName === "string" &&
+    payload.serviceName.length > 0 &&
+    typeof payload.widgetType === "string" &&
+    payload.widgetType.length > 0 &&
+    typeof payload.fieldKey === "string" &&
+    payload.fieldKey.length > 0
+  );
+}
+
+export function verifyWidgetSecretReference(
+  value: unknown
+): WidgetSecretReference | null {
+  if (
+    !isWidgetSecretReference(value) ||
+    value.length > MAX_REFERENCE_LENGTH
+  ) {
+    return null;
+  }
+
+  const token = value.slice(WIDGET_SECRET_REFERENCE_PREFIX.length);
+  const parts = token.split(".");
+  if (
+    parts.length !== 2 ||
+    !BASE64URL.test(parts[0]) ||
+    !BASE64URL.test(parts[1])
+  ) {
+    return null;
+  }
+
+  let receivedSignature: Buffer;
+  try {
+    receivedSignature = Buffer.from(parts[1], "base64url");
+  } catch {
+    return null;
+  }
+  const expectedSignature = signature(parts[0]);
+  if (
+    receivedSignature.length !== expectedSignature.length ||
+    !timingSafeEqual(receivedSignature, expectedSignature)
+  ) {
+    return null;
+  }
+
+  try {
+    const payload: unknown = JSON.parse(
+      Buffer.from(parts[0], "base64url").toString("utf8")
+    );
+    return isExactPayload(payload) ? payload : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/widgets/secretReference.ts
+++ b/src/widgets/secretReference.ts
@@ -2,6 +2,18 @@ export const WIDGET_SECRET_REFERENCE_PREFIX =
   "__KOKPIT_WIDGET_SECRET_REF__:";
 
 /**
+ * Browser-visible wrapper for a signed field reference. Keeping the signed
+ * token inside an object means a user-provided password can never be mistaken
+ * for a placeholder merely because it starts with a reserved string prefix.
+ */
+export const WIDGET_SECRET_REFERENCE_KEY =
+  "__kokpit_widget_secret_reference__";
+
+export type WidgetSecretReferencePlaceholder = {
+  [WIDGET_SECRET_REFERENCE_KEY]: string;
+};
+
+/**
  * Whole-config placeholder used when a widget type is no longer registered.
  * Its contents are intentionally opaque to the browser: without registry
  * metadata there is no safe way to decide which individual keys are secrets.
@@ -9,11 +21,20 @@ export const WIDGET_SECRET_REFERENCE_PREFIX =
 export const WIDGET_CONFIG_REFERENCE_PREFIX =
   "__KOKPIT_WIDGET_CONFIG_REF__:";
 
-/** True for the reserved placeholder namespace, including malformed tokens. */
-export function isWidgetSecretReference(value: unknown): value is string {
+/** True for an exact field-reference envelope, including malformed tokens. */
+export function isWidgetSecretReference(
+  value: unknown
+): value is WidgetSecretReferencePlaceholder {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const record = value as Record<string, unknown>;
   return (
-    typeof value === "string" &&
-    value.startsWith(WIDGET_SECRET_REFERENCE_PREFIX)
+    Object.keys(record).length === 1 &&
+    typeof record[WIDGET_SECRET_REFERENCE_KEY] === "string" &&
+    record[WIDGET_SECRET_REFERENCE_KEY].startsWith(
+      WIDGET_SECRET_REFERENCE_PREFIX
+    )
   );
 }
 

--- a/src/widgets/secretReference.ts
+++ b/src/widgets/secretReference.ts
@@ -1,0 +1,59 @@
+export const WIDGET_SECRET_REFERENCE_PREFIX =
+  "__KOKPIT_WIDGET_SECRET_REF__:";
+
+export interface WidgetSecretReference {
+  serviceName: string;
+  widgetType: string;
+  fieldKey: string;
+}
+
+/**
+ * Opaque browser-safe marker for a secret that remains in settings.yaml.
+ * The marker contains only the non-secret location needed to find the value
+ * again server-side; it never contains or derives from the secret itself.
+ */
+export function createWidgetSecretReference(
+  serviceName: string,
+  widgetType: string,
+  fieldKey: string
+): string {
+  return `${WIDGET_SECRET_REFERENCE_PREFIX}${JSON.stringify([
+    serviceName,
+    widgetType,
+    fieldKey,
+  ])}`;
+}
+
+/** True for the reserved placeholder namespace, including malformed tokens. */
+export function isWidgetSecretReference(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.startsWith(WIDGET_SECRET_REFERENCE_PREFIX)
+  );
+}
+
+export function parseWidgetSecretReference(
+  value: unknown
+): WidgetSecretReference | null {
+  if (!isWidgetSecretReference(value)) return null;
+
+  try {
+    const parsed: unknown = JSON.parse(
+      value.slice(WIDGET_SECRET_REFERENCE_PREFIX.length)
+    );
+    if (
+      !Array.isArray(parsed) ||
+      parsed.length !== 3 ||
+      !parsed.every((part) => typeof part === "string" && part.length > 0)
+    ) {
+      return null;
+    }
+    return {
+      serviceName: parsed[0],
+      widgetType: parsed[1],
+      fieldKey: parsed[2],
+    };
+  } catch {
+    return null;
+  }
+}

--- a/src/widgets/secretReference.ts
+++ b/src/widgets/secretReference.ts
@@ -1,59 +1,10 @@
 export const WIDGET_SECRET_REFERENCE_PREFIX =
   "__KOKPIT_WIDGET_SECRET_REF__:";
 
-export interface WidgetSecretReference {
-  serviceName: string;
-  widgetType: string;
-  fieldKey: string;
-}
-
-/**
- * Opaque browser-safe marker for a secret that remains in settings.yaml.
- * The marker contains only the non-secret location needed to find the value
- * again server-side; it never contains or derives from the secret itself.
- */
-export function createWidgetSecretReference(
-  serviceName: string,
-  widgetType: string,
-  fieldKey: string
-): string {
-  return `${WIDGET_SECRET_REFERENCE_PREFIX}${JSON.stringify([
-    serviceName,
-    widgetType,
-    fieldKey,
-  ])}`;
-}
-
 /** True for the reserved placeholder namespace, including malformed tokens. */
 export function isWidgetSecretReference(value: unknown): value is string {
   return (
     typeof value === "string" &&
     value.startsWith(WIDGET_SECRET_REFERENCE_PREFIX)
   );
-}
-
-export function parseWidgetSecretReference(
-  value: unknown
-): WidgetSecretReference | null {
-  if (!isWidgetSecretReference(value)) return null;
-
-  try {
-    const parsed: unknown = JSON.parse(
-      value.slice(WIDGET_SECRET_REFERENCE_PREFIX.length)
-    );
-    if (
-      !Array.isArray(parsed) ||
-      parsed.length !== 3 ||
-      !parsed.every((part) => typeof part === "string" && part.length > 0)
-    ) {
-      return null;
-    }
-    return {
-      serviceName: parsed[0],
-      widgetType: parsed[1],
-      fieldKey: parsed[2],
-    };
-  } catch {
-    return null;
-  }
 }

--- a/src/widgets/secretReference.ts
+++ b/src/widgets/secretReference.ts
@@ -1,10 +1,26 @@
 export const WIDGET_SECRET_REFERENCE_PREFIX =
   "__KOKPIT_WIDGET_SECRET_REF__:";
 
+/**
+ * Whole-config placeholder used when a widget type is no longer registered.
+ * Its contents are intentionally opaque to the browser: without registry
+ * metadata there is no safe way to decide which individual keys are secrets.
+ */
+export const WIDGET_CONFIG_REFERENCE_PREFIX =
+  "__KOKPIT_WIDGET_CONFIG_REF__:";
+
 /** True for the reserved placeholder namespace, including malformed tokens. */
 export function isWidgetSecretReference(value: unknown): value is string {
   return (
     typeof value === "string" &&
     value.startsWith(WIDGET_SECRET_REFERENCE_PREFIX)
+  );
+}
+
+/** True for the reserved opaque-config namespace, including malformed tokens. */
+export function isWidgetConfigReference(value: unknown): value is string {
+  return (
+    typeof value === "string" &&
+    value.startsWith(WIDGET_CONFIG_REFERENCE_PREFIX)
   );
 }


### PR DESCRIPTION
## Summary

- add a `tautulli-activity` widget backed by Tautulli API v2 `get_activity`
- support summary metrics, active sessions with usernames, or both through the YAML and visual editor
- use a tall one-column-by-two-row default layout with a wrapped summary and scrollable session list
- minimize browser-facing session data and redact upstream/network failures
- document the integration, example configuration, and roadmap status

## Credential security

This PR also closes the shared settings-boundary issue uncovered while adding Tautulli:

- saved widget credentials never return to settings responses or password inputs
- purpose-separated HMAC references preserve credentials server-side
- references are bound to registry-declared credential scope; URL changes require re-entry, and qBittorrent also binds username
- configuration revisions use a keyed HMAC instead of an offline-guessable digest
- widget routes return bounded application-owned errors rather than arbitrary upstream text
- Tautulli preserves sanitized `AbortError` semantics during both request and body-read cancellation

The shared protection covers all 22 current password-bearing widget definitions and remains effective when application authentication is disabled.

## User impact

Users can choose Summary, Active sessions, or both from one Tautulli widget. Renaming, reordering, resizing, and display-only edits preserve saved credentials. Changing a credential's destination prompts for the credential again before saving or connection testing.

## Validation

- `npm test` — 101 files, 1,403 tests passed
- `npm run lint` — 0 errors; 2 pre-existing warnings
- `npm run type-check`
- `npm run build`
- `git diff --check`
- independent adversarial security review and scoped re-review approved
- desktop tall-layout screenshot and mobile full-width behavior verified with mock Tautulli data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a Tautulli activity widget with summary statistics, active sessions, playback progress and bandwidth.
  - Added configurable sections, refresh behaviour and responsive layouts.
- **Security**
  - Protected widget credentials from browser exposure and validated them against their configured destination.
  - Sanitised connection and loading errors to prevent sensitive information leakage.
- **Bug Fixes**
  - Improved settings saves, credential replacement, cancellation handling and concurrent service updates.
- **Documentation**
  - Added Tautulli configuration guidance, examples and roadmap updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->