### PR TITLE
Align service tile icons and titles

### DIFF
--- a/src/__tests__/components/ServiceTile.test.tsx
+++ b/src/__tests__/components/ServiceTile.test.tsx
@@ -60,6 +60,56 @@ describe("ServiceTile", () => {
     expect(header?.children[1]).toHaveClass("service-tile__name");
   });
 
+  // The header row sits under the absolutely-positioned top-right corner
+  // controls, so it has to declare which one is there for globals.css to
+  // reserve the matching inset (--tile-corner-reach). jsdom applies no
+  // stylesheet, so the flag itself is what's assertable here.
+  describe("header corner-control clearance", () => {
+    const cornerSlot = (container: HTMLElement) =>
+      container
+        .querySelector(".service-tile__header")
+        ?.getAttribute("data-corner-slot");
+
+    it("flags the status dot's slot on a tile with a URL", async () => {
+      let container!: HTMLElement;
+      await act(async () => {
+        ({ container } = render(
+          <ServiceTile name="Jellyfin" url="http://192.168.1.10:8096" />
+        ));
+      });
+      expect(container.querySelector(".status-dot")).not.toBeNull();
+      expect(cornerSlot(container)).toBe("dot");
+    });
+
+    it("flags the wider badge slot when the widget config is invalid", async () => {
+      const issues: WidgetConfigIssue[] = [
+        { path: "api_key", message: "Required" },
+      ];
+      let container!: HTMLElement;
+      await act(async () => {
+        ({ container } = render(
+          <ServiceTile
+            name="Sonarr"
+            url="http://sonarr.local"
+            widget={{ type: "sonarr-queue", invalid: issues }}
+          />
+        ));
+      });
+      expect(container.querySelector(".tile-widget-badge")).not.toBeNull();
+      expect(cornerSlot(container)).toBe("badge");
+    });
+
+    it("omits the flag when neither corner control renders", async () => {
+      let container!: HTMLElement;
+      await act(async () => {
+        ({ container } = render(<ServiceTile name="System Stats" />));
+      });
+      expect(container.querySelector(".status-dot")).toBeNull();
+      expect(container.querySelector(".tile-widget-badge")).toBeNull();
+      expect(cornerSlot(container)).toBeNull();
+    });
+  });
+
   it("links to the correct URL in a new tab", async () => {
     await act(async () => {
       render(<ServiceTile name="Jellyfin" url="http://192.168.1.10:8096" />);

--- a/src/__tests__/components/ServiceTile.test.tsx
+++ b/src/__tests__/components/ServiceTile.test.tsx
@@ -41,6 +41,25 @@ describe("ServiceTile", () => {
     expect(screen.getByText("Jellyfin")).toBeInTheDocument();
   });
 
+  it("groups the service icon and name in the same header row", async () => {
+    let container!: HTMLElement;
+    await act(async () => {
+      ({ container } = render(
+        <ServiceTile
+          name="Jellyfin"
+          url="http://192.168.1.10:8096"
+          icon="/icons/jellyfin.png"
+        />
+      ));
+    });
+
+    const header = container.querySelector(".service-tile__header");
+    expect(header).not.toBeNull();
+    expect(header?.children).toHaveLength(2);
+    expect(header?.children[0]).toHaveClass("service-tile__icon");
+    expect(header?.children[1]).toHaveClass("service-tile__name");
+  });
+
   it("links to the correct URL in a new tab", async () => {
     await act(async () => {
       render(<ServiceTile name="Jellyfin" url="http://192.168.1.10:8096" />);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -436,6 +436,42 @@ button {
   align-items: center;
   gap: 10px;
   min-width: 0;
+  /* The corner controls (.status-dot / .tile-widget-badge and the edit-mode
+     .tile-kebab) are absolutely positioned over the tile's top-right corner —
+     which is this row. Without a reserved inset a long name runs underneath
+     them, most visibly on a 1x1 tile where the header owns the full content
+     width. --tile-corner-reach is how far the right-most control extends in
+     from the tile's BORDER edge; the header lives inside the tile's padding,
+     so that padding comes back off, plus 6px of breathing room. Clamped at 0
+     so a larger --gap simply means no inset rather than negative padding. */
+  padding-right: max(0px, calc(var(--tile-corner-reach, 0px) + 6px - var(--gap)));
+}
+
+/* View mode: the shared slot holds either the dot (right: 10px + 8px wide) or
+   the badge (right: 6px + 20px wide). Keep these in sync with .status-dot and
+   .tile-widget-badge below. */
+.service-tile__header[data-corner-slot="dot"] {
+  --tile-corner-reach: 18px;
+}
+
+.service-tile__header[data-corner-slot="badge"] {
+  --tile-corner-reach: 26px;
+}
+
+/* Edit mode: .tile-kebab takes the corner (right: 6px + 20px wide) and pushes
+   the dot/badge out to right: 30px — see the `.service-tile--editable
+   .status-dot` shift in the B3 section. Ordered after the view-mode rules so
+   the kebab-only case wins on equal specificity. */
+.service-tile--editable .service-tile__header {
+  --tile-corner-reach: 26px;
+}
+
+.service-tile--editable .service-tile__header[data-corner-slot="dot"] {
+  --tile-corner-reach: 38px;
+}
+
+.service-tile--editable .service-tile__header[data-corner-slot="badge"] {
+  --tile-corner-reach: 50px;
 }
 
 .service-tile__letter-fallback {
@@ -3573,7 +3609,9 @@ button {
 
 /* Keep the edit-mode status dot clear of the kebab in the same corner. The
    badge shares the dot's slot (they're mutually exclusive), so it needs the
-   identical shift for the same reason. */
+   identical shift for the same reason. Changing this offset also changes how
+   much clearance the header row needs — update the --tile-corner-reach values
+   on .service-tile__header to match. */
 .service-tile--editable .status-dot,
 .service-tile--editable .tile-widget-badge {
   right: 30px;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -428,6 +428,14 @@ button {
   height: 32px;
   object-fit: contain;
   border-radius: 4px;
+  flex-shrink: 0;
+}
+
+.service-tile__header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  min-width: 0;
 }
 
 .service-tile__letter-fallback {

--- a/src/components/ServiceTile.tsx
+++ b/src/components/ServiceTile.tsx
@@ -297,8 +297,10 @@ export default function ServiceTile({ name, url, icon, description, widget, size
       ) : (
         url && <StatusDot url={url} preview={preview} />
       )}
-      <ServiceIcon icon={icon} url={url} name={name} />
-      <span className="service-tile__name">{name}</span>
+      <div className="service-tile__header">
+        <ServiceIcon icon={icon} url={url} name={name} />
+        <span className="service-tile__name">{name}</span>
+      </div>
       {description && (
         <span className="service-tile__description">{description}</span>
       )}

--- a/src/components/ServiceTile.tsx
+++ b/src/components/ServiceTile.tsx
@@ -297,7 +297,20 @@ export default function ServiceTile({ name, url, icon, description, widget, size
       ) : (
         url && <StatusDot url={url} preview={preview} />
       )}
-      <div className="service-tile__header">
+      {/*
+       * The name shares the header row with the icon, and that row runs the
+       * full content width straight under the absolutely-positioned corner
+       * controls — so on a 1x1 tile a long name is overlaid by them. Which
+       * control occupies the shared slot decides how much clearance the row
+       * needs (the badge is 20px wide, the dot 8px), so report it to the
+       * stylesheet and let `.service-tile__header[data-corner-slot]` reserve
+       * the matching inset. The edit-mode kebab needs no flag: it is always
+       * present when `drag` is, which `.service-tile--editable` already says.
+       */}
+      <div
+        className="service-tile__header"
+        data-corner-slot={invalidIssues ? "badge" : url ? "dot" : undefined}
+      >
         <ServiceIcon icon={icon} url={url} name={name} />
         <span className="service-tile__name">{name}</span>
       </div>


### PR DESCRIPTION
### Motivation
- The service tile layout should show the service icon and its title on the same line to match the intended compact header design.
- Prevent icons from shrinking or wrapping awkwardly when service names are long and improve visual consistency across tiles.

### Description
- Wrap the icon and title in a new `.service-tile__header` container in `src/components/ServiceTile.tsx` so they render on the same row.
- Add `.service-tile__header` flexbox styles and set `.service-tile__icon { flex-shrink: 0 }` in `src/app/globals.css` to keep the icon size stable and provide spacing.
- Add a unit test in `src/__tests__/components/ServiceTile.test.tsx` that asserts the icon and name are grouped inside the header row.
- No other functional behavior of the tile was changed; status dot, widget badge, description and widget areas remain unaffected.

### Testing
- Ran `npm test -- --run src/__tests__/components/ServiceTile.test.tsx` and the component test file passed (33 tests passed).
- Ran the full test suite with `npm test` and all tests passed (100 test files, 1,411 tests passed).
- Ran `npm run type-check` which completed successfully.
- Ran `npm run lint` which completed with no errors and two pre-existing warnings, and attempted a Playwright browser download for a visual screenshot but the browser download failed (HTTP 403) so no screenshot was captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a658b800ebc83338b911411c20debb8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved service tile header layout, keeping icons at a consistent size while allowing service names to wrap correctly.
  * Aligned service icons and names more reliably across different tile layouts.

* **Tests**
  * Added coverage to verify that service icons and names are grouped correctly within the tile header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->