### PR TITLE
Reserve corner-control space in the service tile header

### DIFF
--- a/src/__tests__/components/ServiceTile.test.tsx
+++ b/src/__tests__/components/ServiceTile.test.tsx
@@ -60,6 +60,56 @@ describe("ServiceTile", () => {
     expect(header?.children[1]).toHaveClass("service-tile__name");
   });
 
+  // The header row sits under the absolutely-positioned top-right corner
+  // controls, so it has to declare which one is there for globals.css to
+  // reserve the matching inset (--tile-corner-reach). jsdom applies no
+  // stylesheet, so the flag itself is what's assertable here.
+  describe("header corner-control clearance", () => {
+    const cornerSlot = (container: HTMLElement) =>
+      container
+        .querySelector(".service-tile__header")
+        ?.getAttribute("data-corner-slot");
+
+    it("flags the status dot's slot on a tile with a URL", async () => {
+      let container!: HTMLElement;
+      await act(async () => {
+        ({ container } = render(
+          <ServiceTile name="Jellyfin" url="http://192.168.1.10:8096" />
+        ));
+      });
+      expect(container.querySelector(".status-dot")).not.toBeNull();
+      expect(cornerSlot(container)).toBe("dot");
+    });
+
+    it("flags the wider badge slot when the widget config is invalid", async () => {
+      const issues: WidgetConfigIssue[] = [
+        { path: "api_key", message: "Required" },
+      ];
+      let container!: HTMLElement;
+      await act(async () => {
+        ({ container } = render(
+          <ServiceTile
+            name="Sonarr"
+            url="http://sonarr.local"
+            widget={{ type: "sonarr-queue", invalid: issues }}
+          />
+        ));
+      });
+      expect(container.querySelector(".tile-widget-badge")).not.toBeNull();
+      expect(cornerSlot(container)).toBe("badge");
+    });
+
+    it("omits the flag when neither corner control renders", async () => {
+      let container!: HTMLElement;
+      await act(async () => {
+        ({ container } = render(<ServiceTile name="System Stats" />));
+      });
+      expect(container.querySelector(".status-dot")).toBeNull();
+      expect(container.querySelector(".tile-widget-badge")).toBeNull();
+      expect(cornerSlot(container)).toBeNull();
+    });
+  });
+
   it("links to the correct URL in a new tab", async () => {
     await act(async () => {
       render(<ServiceTile name="Jellyfin" url="http://192.168.1.10:8096" />);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -436,6 +436,42 @@ button {
   align-items: center;
   gap: 10px;
   min-width: 0;
+  /* The corner controls (.status-dot / .tile-widget-badge and the edit-mode
+     .tile-kebab) are absolutely positioned over the tile's top-right corner —
+     which is this row. Without a reserved inset a long name runs underneath
+     them, most visibly on a 1x1 tile where the header owns the full content
+     width. --tile-corner-reach is how far the right-most control extends in
+     from the tile's BORDER edge; the header lives inside the tile's padding,
+     so that padding comes back off, plus 6px of breathing room. Clamped at 0
+     so a larger --gap simply means no inset rather than negative padding. */
+  padding-right: max(0px, calc(var(--tile-corner-reach, 0px) + 6px - var(--gap)));
+}
+
+/* View mode: the shared slot holds either the dot (right: 10px + 8px wide) or
+   the badge (right: 6px + 20px wide). Keep these in sync with .status-dot and
+   .tile-widget-badge below. */
+.service-tile__header[data-corner-slot="dot"] {
+  --tile-corner-reach: 18px;
+}
+
+.service-tile__header[data-corner-slot="badge"] {
+  --tile-corner-reach: 26px;
+}
+
+/* Edit mode: .tile-kebab takes the corner (right: 6px + 20px wide) and pushes
+   the dot/badge out to right: 30px — see the `.service-tile--editable
+   .status-dot` shift in the B3 section. Ordered after the view-mode rules so
+   the kebab-only case wins on equal specificity. */
+.service-tile--editable .service-tile__header {
+  --tile-corner-reach: 26px;
+}
+
+.service-tile--editable .service-tile__header[data-corner-slot="dot"] {
+  --tile-corner-reach: 38px;
+}
+
+.service-tile--editable .service-tile__header[data-corner-slot="badge"] {
+  --tile-corner-reach: 50px;
 }
 
 .service-tile__letter-fallback {
@@ -3573,7 +3609,9 @@ button {
 
 /* Keep the edit-mode status dot clear of the kebab in the same corner. The
    badge shares the dot's slot (they're mutually exclusive), so it needs the
-   identical shift for the same reason. */
+   identical shift for the same reason. Changing this offset also changes how
+   much clearance the header row needs — update the --tile-corner-reach values
+   on .service-tile__header to match. */
 .service-tile--editable .status-dot,
 .service-tile--editable .tile-widget-badge {
   right: 30px;

--- a/src/components/ServiceTile.tsx
+++ b/src/components/ServiceTile.tsx
@@ -297,7 +297,20 @@ export default function ServiceTile({ name, url, icon, description, widget, size
       ) : (
         url && <StatusDot url={url} preview={preview} />
       )}
-      <div className="service-tile__header">
+      {/*
+       * The name shares the header row with the icon, and that row runs the
+       * full content width straight under the absolutely-positioned corner
+       * controls — so on a 1x1 tile a long name is overlaid by them. Which
+       * control occupies the shared slot decides how much clearance the row
+       * needs (the badge is 20px wide, the dot 8px), so report it to the
+       * stylesheet and let `.service-tile__header[data-corner-slot]` reserve
+       * the matching inset. The edit-mode kebab needs no flag: it is always
+       * present when `drag` is, which `.service-tile--editable` already says.
+       */}
+      <div
+        className="service-tile__header"
+        data-corner-slot={invalidIssues ? "badge" : url ? "dot" : undefined}
+      >
         <ServiceIcon icon={icon} url={url} name={name} />
         <span className="service-tile__name">{name}</span>
       </div>


### PR DESCRIPTION
Addresses the P2 review comment on #80 ([discussion_r3653525581](https://github.com/pmyszczynski/kokpit/pull/80#discussion_r3653525581)). Stacked on top of that branch, so merging this into `codex/linear-mention-kok-56-change-the-service-tile-to-have-the` updates #80 in place.

### Motivation

`.service-tile__header` puts the icon and name on one row that spans the tile's full content width — and that row sits directly under the corner controls, which are all absolutely positioned in the top-right: `.status-dot`, `.tile-widget-badge`, and the edit-mode `.tile-kebab`. Before the header existed, the name rendered on its own line *below* the icon and never reached that corner, so this is a regression introduced by #80.

The overlap is worst on a 1×1 tile, where the header owns the whole row and nothing else pushes the name away from the edge.

### Description

- `src/components/ServiceTile.tsx` — the header now carries `data-corner-slot="dot" | "badge"` (omitted when neither renders), naming which control occupies the shared top-right slot. The two are mutually exclusive, and their widths differ (dot 8px, badge 20px), so the clearance differs too. The kebab needs no flag: it is always present when `drag` is, which the existing `.service-tile--editable` class already signals.
- `src/app/globals.css` — `.service-tile__header` gains `padding-right: max(0px, calc(var(--tile-corner-reach, 0px) + 6px - var(--gap)))`. `--tile-corner-reach` is how far the right-most control extends in from the tile's border edge; the header lives inside the tile's padding, so that padding comes back off. Values mirror the control geometry already in the file — dot 18px, badge 26px, and in edit mode kebab 26px / dot 38px / badge 50px (the kebab takes the corner and pushes the others out to `right: 30px`). Clamped at 0 so a larger `--gap` means no inset rather than negative padding.
- A cross-reference comment on the existing `.service-tile--editable .status-dot` shift, since changing that offset changes the required clearance.
- `src/__tests__/components/ServiceTile.test.tsx` — three cases covering the flag: dot, badge, and neither. jsdom applies no stylesheet, so the flag itself is what is assertable at that layer.

### Testing

- Measured the real cascade in Chromium against a sweep of name lengths across all six states (view/edit × dot/badge/neither), comparing the rendered text rects to the control rects. Worst-case overlap went from **20px** (edit mode + widget badge) to **0px** in every state; computed `padding-right` came out 8/16/28/40/16/0px as intended.
- `npm test` — 100 files, 1,414 tests passed.
- `npm run type-check` — clean.
- `npm run lint` — 0 errors, the same 2 pre-existing warnings as on the base branch.
- E2E not run locally (Playwright suite only runs in CI).
