### PR TITLE
chore: release 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kokpit",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kokpit",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kokpit",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "engines": {
     "node": ">=22.19.0"


### PR DESCRIPTION
## Summary

- bump the Kokpit package version from `0.7.0` to `0.8.0`
- keep `package.json` and `package-lock.json` aligned for the release workflow version guard

## Why

`main` contains 22 commits since `v0.7.0`, including new Tautulli, Actual Budget, System Stats, and Tdarr widget functionality. This is a backward-compatible feature release.

## Validation

- `npm run lint` (passes with two existing warnings)
- `npm run type-check`
- `npm test` (111 files, 1,767 tests passed)
- audited `origin/main...HEAD`: only `package.json` and `package-lock.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to 0.8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->