### PR TITLE
fix: isolate E2E runtime config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ settings.yaml
 .worktrees/
 test-results/
 e2e/fixtures/auth-test-users.db*
+e2e/.runtime/
 
 # claude code local settings (per-developer, not shared)
 .claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,9 +76,6 @@ A self-hosted personal dashboard / homepage — a modern alternative to Homepage
 
 ## CI on Pull Requests
 
-**PR default:** Open pull requests as ready for review. Use a draft only when
-the user explicitly asks for one.
-
 `.github/workflows/ci.yml` (Lint, Type-check, Unit tests, E2E) triggers on
 `pull_request` with an explicit `types:` list: the three defaults (`opened`,
 `synchronize`, `reopened`) plus `ready_for_review`. What that means in practice:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,9 @@ A self-hosted personal dashboard / homepage — a modern alternative to Homepage
 
 ## CI on Pull Requests
 
+**PR default:** Open pull requests as ready for review. Use a draft only when
+the user explicitly asks for one.
+
 `.github/workflows/ci.yml` (Lint, Type-check, Unit tests, E2E) triggers on
 `pull_request` with an explicit `types:` list: the three defaults (`opened`,
 `synchronize`, `reopened`) plus `ready_for_review`. What that means in practice:

--- a/e2e/prepare-runtime-config.mjs
+++ b/e2e/prepare-runtime-config.mjs
@@ -1,0 +1,9 @@
+import { copyFile, mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const source = fileURLToPath(new URL("./fixtures/settings.yaml", import.meta.url));
+const runtimeConfig = fileURLToPath(new URL("./.runtime/settings.yaml", import.meta.url));
+
+await mkdir(dirname(runtimeConfig), { recursive: true });
+await copyFile(source, runtimeConfig);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -23,12 +23,16 @@ export default defineConfig({
   },
   use: { baseURL: "http://localhost:3000" },
   webServer: {
-    command: "npm run dev",
+    // The API persists settings changes, so never point E2E at the tracked
+    // fixture. Prepare a disposable copy before starting the test server.
+    command: "node ./e2e/prepare-runtime-config.mjs && npm run dev",
     env: {
       KOKPIT_AUTH_DISABLED: "true",
-      KOKPIT_CONFIG_PATH: "./e2e/fixtures/settings.yaml",
+      KOKPIT_CONFIG_PATH: "./e2e/.runtime/settings.yaml",
     },
     url: "http://localhost:3000",
-    reuseExistingServer: !process.env.CI,
+    // An already-running dev server may use a real or tracked config. Always
+    // launch this isolated server so E2E writes stay in the runtime copy.
+    reuseExistingServer: false,
   },
 });


### PR DESCRIPTION
## Summary

- Copy the tracked E2E settings fixture to an ignored runtime file before starting the test server.
- Point Playwright at the disposable runtime copy and always launch an isolated server.
- Ignore the generated runtime directory.

## Root cause

The E2E server used the tracked `e2e/fixtures/settings.yaml` directly. Tests update settings through `PATCH /api/settings`, which persisted those changes into the working tree.

## Impact

E2E runs no longer leave a modified tracked fixture, so they do not block pulls or create unrelated diffs.

## Validation

- `npm run type-check`
- `npm run test:e2e -- e2e/tests/widget-badge.spec.ts --reporter=list`
- Confirmed the tracked fixture was unchanged after the focused E2E run and the runtime copy is ignored.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - End-to-end tests now run with an isolated, disposable runtime configuration.
  - Test execution consistently prepares the required configuration before starting the application.
  - Existing application servers are no longer reused, improving test reliability and reducing configuration conflicts.

- **Chores**
  - Temporary end-to-end test files are excluded from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->