### PR TITLE
docs: align documentation with current architecture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ A self-hosted personal dashboard / homepage — a modern alternative to Homepage
 │   ├── test/               ← Vitest setup
 │   └── widgets/            ← widget plugin system (registry + shared widget types)
 └── public/
-    └── icons/              ← bundled icon sets
+    └── icons/              ← reserved local icon directory; icon sets are CDN-backed
 ```
 
 ---
@@ -135,7 +135,7 @@ If Docker publication fails, the tag and GitHub Release remain but the release r
 ## Key References
 
 - **Full roadmap & task list:** [`docs/Roadmap.md`](docs/Roadmap.md)
-- **Architecture decisions:** [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) *(not yet created)*
+- **Architecture:** [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
 - **Widget/integration specs:** documented per-widget in [`README.md § Widgets`](README.md#widgets) rather than a separate file — add new widgets there
 
 ---

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A self-hosted homelab dashboard built with Next.js. Kokpit gives you a single pl
 
 Kokpit is a personal dashboard for homelab and self-hosted setups. You define your services, widgets, and layout in a single `settings.yaml` file, and Kokpit renders a clean, themeable dashboard accessible from any browser.
 
-See `[docs/Roadmap.md](docs/Roadmap.md)` for full details on Roadmap and priority levels.
+See [docs/Roadmap.md](docs/Roadmap.md) for full details on roadmap and priority levels.
 
 ## Installation
 
@@ -14,7 +14,7 @@ See `[docs/Roadmap.md](docs/Roadmap.md)` for full details on Roadmap and priorit
 
 #### Quick start with pre-built image
 
-If you just want to run Kokpit, use the pre-built image from GitHub Container Registry (available from v0.2.0 onwards).
+If you just want to run Kokpit, use the pre-built image from GitHub Container Registry.
 
 **1. Create a working directory:**
 
@@ -32,9 +32,9 @@ services:
     ports:
       - "3000:3000"          # Change the left side to expose on a different host port
     environment:
-      # Required — must be a random string of at least 32 characters.
-      # Used to sign session tokens. Changing this invalidates all active sessions.
-      # Generate one with: openssl rand -hex 32
+      # Recommended — a stable random string for signing session tokens.
+      # Generate one with: openssl rand -hex 32. Changing it invalidates
+      # active sessions. If omitted, Kokpit creates and persists one in /data.
       KOKPIT_SESSION_SECRET: change-this-to-a-random-32-char-secret
 
       # Optional — set to "true" to skip authentication entirely.
@@ -70,10 +70,11 @@ docker compose up -d
 
 Kokpit will be available at `http://localhost:3000`. On first run, a setup wizard will prompt you to create the initial admin account.
 
-To pin to a specific version instead of `latest`:
+To pin to a specific version instead of `latest`, replace `<version>` with a
+published release version:
 
 ```yaml
-    image: ghcr.io/pmyszczynski/kokpit:0.2.0
+    image: ghcr.io/pmyszczynski/kokpit:<version>
 ```
 
 #### Building from source
@@ -94,7 +95,7 @@ cd kokpit
 docker compose up kokpit --build
 ```
 
-**For information about Docker image releases, versioning, and publishing to GHCR, see `[docs/DOCKER_RELEASES.md](docs/DOCKER_RELEASES.md)`.**
+**For Docker image releases, versioning, and GHCR publishing, see [docs/DOCKER_RELEASES.md](docs/DOCKER_RELEASES.md).**
 
 ### Local development
 
@@ -115,7 +116,22 @@ docker compose up kokpit-dev
 
 ## Usage
 
-All configuration lives in `settings.yaml` at the project root. The in-app settings panel (accessible via the ⚙ icon in the navbar, with Services, Groups, and Bookmarks tabs) reads from and writes back to this file — changes take effect immediately without a restart. You can also edit the YAML directly.
+Configuration is stored in `settings.yaml`. Source and local development default
+to `<project-root>/settings.yaml`; the published Docker image defaults to
+`/data/settings.yaml`, so the quick-start volume persists it on the host at
+`./data/settings.yaml`. Set `KOKPIT_CONFIG_PATH` to use another location.
+
+The in-app settings panel (accessible via the ⚙ icon in the navbar) has
+Appearance, Layout, Groups, Services, Bookmarks, and Authentication tabs. It
+reads from and writes back to the same file, and changes take effect without a
+restart. You can also edit the YAML directly.
+
+The Docker image also defaults `KOKPIT_DB_PATH` to `/data/users.db` and
+`KOKPIT_UPLOADS_PATH` to `/data/uploads`; override these only when you need a
+different persistent layout. `auth.session_ttl_hours` controls JWT and session
+cookie lifetime (default: `24`). `KOKPIT_INSECURE_COOKIE=true` disables the
+secure-cookie flag in production mode for local HTTP testing; do not use it on
+an internet-exposed deployment.
 
 On first load after the schema-v2 upgrade, Kokpit detects the legacy service shape even when the file has no `schema_version`, migrates it, and keeps the exact original as `settings.yaml.pre-v2.bak`. Configuration writes fail closed under an inter-process lock. If Kokpit is forcibly terminated and a later startup reports a settings-lock timeout, first verify that no Kokpit process or container is using the config volume, then remove only the `settings.yaml.lock` directory; an interrupted `settings.yaml.displaced` transaction is recovered automatically on the next start.
 
@@ -325,7 +341,9 @@ service_tiles:
       refresh_interval_ms: 30000  # optional, minimum 5000
 ```
 
-Credentials in `widget.config` are read server-side only and are never sent to the browser.
+Connection credentials belong in `services[].integration.config`; tile-specific
+display options belong in `service_tiles[].widget.config`. Credentials are read
+server-side only and are never sent to the browser.
 
 **Troubleshooting widget configuration:** If a widget's config fails validation (e.g., a missing required field like `token` or a malformed URL), the tile displays a small warning badge in its corner. Hover the badge to see the specific validation errors in a tooltip. Users with edit permission can click the badge to open the service editor with the widget section focused, then fix the configuration and save.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,157 @@
+# Architecture
+
+Kokpit is a Docker-first Next.js dashboard. `settings.yaml` is the source of
+truth for dashboard configuration; SQLite holds only account state. The server
+owns configuration I/O, credentials, and upstream integration requests. Client
+components receive safe projections and render the dashboard and editor.
+
+## System overview
+
+```text
+settings.yaml ──► config loader/schema ──► server-rendered dashboard
+     ▲                    │                         │
+     │                    ├──► client-safe settings ─┼──► settings/edit UI
+     │                    │                         │
+     └──── authenticated PATCH /api/settings ◄──────┘
+
+SQLite users.db ──► auth/session ──► protected routes and API guards
+
+service integration config + tile widget options
+        └──► /api/widget (server-side fetch) ──► browser widget polling
+```
+
+## Runtime and routing
+
+The application uses the Next.js App Router.
+
+- [`src/instrumentation.ts`](../src/instrumentation.ts) loads the Node-only
+  instrumentation module at startup. It validates configuration and starts the
+  file watcher.
+- [`src/app/layout.tsx`](../src/app/layout.tsx) loads the theme and global
+  appearance before rendering the application.
+- [`src/app/(protected)`](../src/app/(protected)) contains the dashboard and
+  settings experience. Its layout redirects unauthenticated visitors to login
+  and redirects to the setup wizard when authentication is enabled but no users
+  exist.
+- Public routes are deliberately limited to flows such as login, setup, password
+  recovery, and health checks. API routes enforce the same auth decision through
+  `isRequestAuthenticated()` when their data or operation is protected.
+
+Server components render the normal dashboard. Client components handle the
+settings panel, edit mode, drag-and-drop, and widget refresh UI. Keep Node-only
+configuration code out of client imports: shared config types and pure helpers
+live in `src/config/index.ts`, while filesystem and locking APIs are exported
+from `src/config/server.ts`.
+
+## Configuration and persistence
+
+`src/config/schema.ts` defines schema version 2. The core model separates
+reusable services from their dashboard placements:
+
+- `services[]` contains identity, launch metadata, and an optional integration
+  connection.
+- `service_tiles[]` references a service and owns group, size, widget type, and
+  per-tile widget options.
+- `groups[]`, `bookmarks[]`, `appearance`, `layout`, and `auth` complete the
+  dashboard configuration.
+
+The loader in `src/config/loader.ts` validates the YAML, migrates legacy service
+shapes to schema version 2, and writes configuration under an inter-process
+lock. Writes are installed atomically and use a revision value to reject an edit
+that would overwrite an external change. The watcher invalidates the cached
+configuration after on-disk edits.
+
+Persistence locations are environment-configurable:
+
+| Purpose | Environment variable | Source/local default | Production image default |
+| --- | --- | --- | --- |
+| Dashboard configuration | `KOKPIT_CONFIG_PATH` | `settings.yaml` | `/data/settings.yaml` |
+| Users and recovery state | `KOKPIT_DB_PATH` | `data/users.db` | `/data/users.db` |
+| Icon and background uploads | `KOKPIT_UPLOADS_PATH` | `data/uploads` | `/data/uploads` |
+
+The production image uses `/data` as its default persistent location; the
+quick-start Compose configuration mounts that directory from the host. Uploaded
+assets are hash-addressed below that directory; their upload routes validate
+file type and sanitize SVGs.
+
+## Authentication and authorization
+
+Users live in SQLite (`src/auth/db.ts`) with bcrypt password hashes, optional
+TOTP secrets, and recovery-code state. Sessions are HS256 JWTs in an `httpOnly`,
+same-site cookie. `auth.session_ttl_hours` sets both token and cookie lifetime.
+
+`KOKPIT_SESSION_SECRET` supplies the signing key. If it is absent, Kokpit
+creates a random key and stores it next to the database so sessions survive a
+restart. `KOKPIT_AUTH_DISABLED=true` is an explicit trusted-network bypass and
+overrides `auth.enabled`; it must not be used for an internet-exposed instance.
+`KOKPIT_INSECURE_COOKIE=true` is only for local HTTP testing: it removes the
+secure-cookie flag in production mode.
+
+There are no roles yet. An authenticated user can edit configuration, and the
+same is true for any visitor when authentication is disabled.
+
+## Widgets and integrations
+
+Widgets are registered by side effect when `src/integrations/index.ts` imports
+each integration module. The registry in `src/widgets/index.ts` defines:
+
+- an integration: connection schema, form fields, credential scope, and optional
+  connection test;
+- a widget: merged config schema, per-tile options, data fetcher, renderer,
+  refresh interval, and size hints.
+
+At runtime, `ServiceGrid` resolves a service tile to a widget without sending
+its configuration to the page. The browser polls `/api/widget` with the tile ID.
+That route retrieves the saved service connection and tile options, validates
+both against the registered schemas, combines them only on the server, applies a
+hard timeout, and calls the integration fetcher. This keeps API keys, tokens,
+and passwords out of browser network requests and component props.
+
+The settings API uses `src/widgets/configSecrets.ts` to make a client-safe
+projection. Registered password fields are replaced with signed references;
+unknown or unsafe config is represented by an opaque reference. On save, the
+server verifies those references before retaining an existing secret. This lets
+the editor preserve credentials without disclosing them.
+
+To add an integration, create its API client and widget renderer under
+`src/integrations/<name>/`, register its integration and widget definitions,
+import it from `src/integrations/index.ts`, add tests, and document its YAML
+fields in the README's Widgets section.
+
+## Dashboard rendering and editing
+
+`src/components/ServiceGrid.tsx` resolves group order, tile sizes, bookmark
+placement, and invalid widget configuration for the server-rendered dashboard.
+The edit-mode components under `src/components/edit/` stage changes locally.
+Save submits all changed top-level configuration sections through
+`PATCH /api/settings` with the revision header; discard leaves `settings.yaml`
+unchanged. Tile and group drag-and-drop therefore do not mutate persisted
+configuration until the user explicitly saves.
+
+Appearance is resolved server-side before the initial render. Custom CSS from
+`appearance.custom_css` is escaped to prevent a style-tag breakout and emitted
+in the `user-custom` cascade layer, which follows integration-specific layers.
+
+## Deployment and operations
+
+The Dockerfile builds Next.js standalone output, then runs it in a Node 22
+Alpine image as a non-root user. `docker-entrypoint.sh` creates `/data` and, when
+present, adds that user to the Docker socket's group for the Docker widget. The
+socket remains a high-privilege host interface despite a read-only mount; see
+the README before enabling it.
+
+`docker-compose.yml` provides `kokpit-dev` for hot reload and `kokpit` for the
+production runner. `/api/health` is unauthenticated so Docker and monitoring
+tools can use it for health checks.
+
+## Testing and delivery
+
+Unit tests live under `src/__tests__`. Playwright covers the normal dashboard,
+visual regressions, and authentication flows under `e2e/`. CI runs lint,
+type-check, and unit tests separately, while its E2E job runs standard E2E then
+production-auth E2E. Release automation first runs the full test gate, then
+creates a GitHub release and calls the reusable Docker publish workflow, which
+publishes and verifies the expected GHCR manifests.
+
+See [TESTING.md](TESTING.md) for test commands and visual-baseline guidance, and
+[DOCKER_RELEASES.md](DOCKER_RELEASES.md) for the release procedure.

--- a/docs/Roadmap.md
+++ b/docs/Roadmap.md
@@ -25,7 +25,7 @@ Mark tasks with `[x]` as you complete them. Claude Code will read this state.
   - Define `settings.yaml` schema: services, widgets, layout, auth, appearance
   - Parser that reads and writes YAML without destroying comments or formatting
   - Schema validator with clear error messages on startup
-  - Config watcher — hot-reload on file change in dev
+  - Config watcher — hot-reload on file change
 
 - [X] `P0` **Authentication system**
   - Username/password auth with bcrypt hashing
@@ -41,7 +41,7 @@ Mark tasks with `[x]` as you complete them. Claude Code will read this state.
   - App layout: top navbar, optional sidebar, main grid canvas
   - CSS variable system for full theme overridability
   - Default modern dark theme (ship at least 1 light + 1 dark built-in)
-  - Custom CSS injection slot (`appearance.customCss` in YAML)
+  - Custom CSS injection slot (`appearance.custom_css` in YAML)
 
 - [x] `P1` **Service tiles (app links)**
   - Clickable tiles: icon, label, URL, optional description
@@ -62,7 +62,8 @@ Mark tasks with `[x]` as you complete them. Claude Code will read this state.
 
 - [x] `P0` **Widget system architecture**
   - Plugin-like widget API: each widget has a config schema, async data fetcher, and render component
-  - Widgets declared in `settings.yaml` under `widgets:`
+  - Widgets attached to `service_tiles:` in `settings.yaml`; reusable
+    connections live on `services[].integration`
   - Error states, loading states, and refresh intervals per widget
 
 - [x] `P0` **Plex integration** — live stats on tile (active streams, transcodes)
@@ -100,7 +101,7 @@ Mark tasks with `[x]` as you complete them. Claude Code will read this state.
 
 - [x] `P2` **Bookmarks & groups**
   - [x] Bookmark links separate from service tiles
-  - [x] Grouped into named sections/tabs
+  - [x] Grouped into named collapsible sections
   - [x] Drag-to-reorder within groups — shipped with dashboard edit mode (Phase 3 `P0`, UX redesign Phase B)
 
 ---
@@ -155,7 +156,8 @@ Mark tasks with `[x]` as you complete them. Claude Code will read this state.
 - [ ] `P2` **Mobile-responsive layout**
   - [x] Responsive breakpoints for tablet and mobile (per-breakpoint column/row-height overrides; size presets collapse gracefully at 768px/480px since v0.5.0)
   - [ ] Optional separate mobile layout config — *partially done: tablet/mobile can override columns and row height; a full per-device layout (own order/sizes) remains open*
-  - [ ] PWA manifest for home screen installation
+  - [x] Web app manifest for home screen installation
+  - [ ] Offline support / service worker
 
 ---
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,10 +1,13 @@
 # Testing
 
-Three layers, run in this order in CI (`.github/workflows/ci.yml`):
+CI runs lint, type-check, and unit tests as separate jobs. The E2E job then runs
+the browser suites in this order (`.github/workflows/ci.yml`):
 
-1. **Unit tests** (Vitest + Testing Library + jsdom) — `npm test` / `npm run test:coverage`
-2. **E2E tests** (Playwright, real Next.js dev server + mocked upstream services) — `npm run test:e2e`
-3. **Auth E2E tests** (Playwright, production build) — `npm run test:e2e:auth`
+1. **E2E tests** (Playwright, real Next.js dev server + mocked upstream services) — `npm run test:e2e`
+2. **Auth E2E tests** (Playwright, production build) — `npm run test:e2e:auth`
+
+**Unit tests** use Vitest + Testing Library + jsdom and run as
+`npm test` / `npm run test:coverage`.
 
 ## Unit tests
 

--- a/settings.example.yaml
+++ b/settings.example.yaml
@@ -5,7 +5,7 @@
 # settings.yaml is gitignored — your credentials stay local.
 #
 # The in-app UI reads from and writes back to settings.yaml.
-# Changes take effect without restarting the server (dev mode).
+# Changes take effect without restarting the server.
 #
 # Schema version: 2
 # ═══════════════════════════════════════════════════════════════
@@ -13,7 +13,8 @@
 schema_version: 2
 
 # ─── Auth ────────────────────────────────────────────────────
-# When auth.enabled is true, all routes require a valid session.
+# When auth.enabled is true, the dashboard and protected APIs require a valid
+# session. Login, setup, recovery, and /api/health remain public.
 # ─────────────────────────────────────────────────────────────
 auth:
   enabled: true # Set false to disable auth (or use KOKPIT_AUTH_DISABLED=true env var)

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4151,8 +4151,8 @@ button {
   outline: none;
 }
 
-/* User-injected custom CSS from appearance.customCss in settings.yaml */
-/* This layer is loaded last and always wins without needing !important */
+/* User-injected custom CSS from appearance.custom_css in settings.yaml. */
+/* The layer follows integration-specific layers in the author layer order. */
 @layer tautulli-widget, user-custom;
 
 @layer tautulli-widget {


### PR DESCRIPTION
## What changed

- add a code-grounded architecture reference covering runtime boundaries, configuration, authentication, widgets, editing, Docker, and delivery
- align README, roadmap, testing, example configuration, and contributor guidance with the current schema-v2 implementation
- clarify the custom CSS cascade-layer behavior

## Why

The documentation had drifted from the current runtime and configuration model, particularly around Docker paths, session-secret persistence, service integrations versus tile widget configuration, CI job boundaries, and custom CSS layering.

## Impact

Documentation and comments only. There is no runtime behavior change.

## Validation

- `git diff --check origin/main...HEAD`
- audited `origin/main...HEAD` to confirm exactly seven documentation/comment paths


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a detailed architecture guide and updates README, Roadmap, Testing, settings.example.yaml, and CSS comments to match the current schema‑v2 and Docker-first runtime. Clarifies config and persistence paths, session-secret handling, service-integration vs tile-widget config, and the custom CSS cascade layer; docs-only, no runtime changes.

<sup>Written for commit a9f164ef843ba3331271e007ea35955298716094. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pmyszczynski/kokpit/pull/89?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

