### PR TITLE
chore: release v0.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kokpit",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kokpit",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kokpit",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "engines": {
     "node": ">=22.19.0"


### PR DESCRIPTION
## Summary

- bump package.json and package-lock.json from 0.8.0 to 0.9.0

## Why

This prepares the minor release containing schema-v2 service/tile decoupling and the fixed modular dashboard grid merged since v0.8.0.

## Impact

No runtime code changes are introduced by this PR. The release workflow will use this version to create v0.9.0 and publish the Docker image.

## Validation

- package and lockfile version fields verified as 0.9.0
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases `kokpit` v0.9.0 by bumping version fields from 0.8.0. This enables the release pipeline to tag v0.9.0 and publish the Docker image that includes the schema‑v2 service/tile decoupling and modular dashboard grid fix already merged since 0.8.0.

- Updates only the version in `package.json` and `package-lock.json`; no runtime code or behavior changes.
- Review: verify both files read 0.9.0.
- Rollout: run the release workflow; downstreams may update their image tag to v0.9.0.

<sup>Written for commit 987fada4d9f0f774dd0c0ed0995273878bb480a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pmyszczynski/kokpit/pull/90?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

