### PR TITLE
Use compact Immich widget size by default

### DIFF
--- a/src/__tests__/integrations/immich.test.ts
+++ b/src/__tests__/integrations/immich.test.ts
@@ -130,6 +130,21 @@ describe("immich-stats widget registration", () => {
     expect(getWidget("immich-stats")?.refreshInterval).toBe(60_000);
   });
 
+  it("defaults to the normal size", async () => {
+    await import("@/integrations/immich/statsWidget");
+    const { getWidget } = await import("@/widgets");
+    expect(getWidget("immich-stats")?.preferredSize).toBe("normal");
+  });
+
+  it("supports default and wide footprints in order", async () => {
+    await import("@/integrations/immich/statsWidget");
+    const { getWidget } = await import("@/widgets");
+    expect(getWidget("immich-stats")?.supportedFootprints).toEqual([
+      { label: "Default", columnSpan: 3, rowSpan: 2 },
+      { label: "Wide", columnSpan: 6, rowSpan: 2 },
+    ]);
+  });
+
   it("configSchema accepts valid config", async () => {
     await import("@/integrations/immich/statsWidget");
     const { getWidget } = await import("@/widgets");

--- a/src/integrations/immich/statsWidget.tsx
+++ b/src/integrations/immich/statsWidget.tsx
@@ -75,8 +75,11 @@ export function ImmichStatsWidget({
 registerWidget<ImmichConfig, ImmichStats>({
   id: "immich-stats",
   name: "Immich Stats",
-  preferredSize: "wide",
-  supportedFootprints: [{ label: "Default", columnSpan: 6, rowSpan: 2 }],
+  preferredSize: "normal",
+  supportedFootprints: [
+    { label: "Default", columnSpan: 3, rowSpan: 2 },
+    { label: "Wide", columnSpan: 6, rowSpan: 2 },
+  ],
   configSchema: ImmichConfigSchema,
   fetchData: fetchStats,
   refreshInterval: 60_000,


### PR DESCRIPTION
## Summary

- change the Immich stats widget default footprint from 6×2 to 3×2
- keep 6×2 available as the optional **Wide** footprint
- add registration coverage for the preferred size and supported footprint order

## Validation

- `npm test -- src/__tests__/integrations/immich.test.ts` — 16 tests passed
- `npm run type-check` — passed
- `git diff --check` — passed
- GitHub CI — Lint, Type-check, Unit tests, and E2E passed