### PR TITLE
fix(prowlarr): use 3x4 default widget size

### DIFF
--- a/e2e/tests/prowlarr-widget.spec.ts
+++ b/e2e/tests/prowlarr-widget.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect, type Page } from "@playwright/test";
+import { schemaV2Fixtures } from "../helpers/schema-v2";
+
+const PROWLARR_TILE_DATA = schemaV2Fixtures([
+  {
+    name: "Prowlarr",
+    url: "http://localhost:9696",
+    widget: {
+      type: "prowlarr-stats",
+      config: {
+        url: "http://localhost:9696",
+        api_key: "dummy",
+      },
+    },
+  },
+]);
+
+const TILE_ID = PROWLARR_TILE_DATA.service_tiles[0].id;
+const PROWLARR_SETTINGS = {
+  ...PROWLARR_TILE_DATA,
+  groups: [],
+  bookmarks: [],
+  appearance: { theme: "dark" as const, custom_css: undefined },
+};
+
+function prowlarrTile(page: Page) {
+  return page
+    .locator(".service-tile")
+    .filter({ has: page.locator('.service-tile__name:text-is("Prowlarr")') });
+}
+
+function prowlarrWidget(page: Page) {
+  return prowlarrTile(page).locator(".prowlarr-stats-widget");
+}
+
+test("prowlarr widget defaults to tall footprint and renders without clipping", async ({
+  page,
+  request,
+}) => {
+  const settingsResponse = await request.patch("/api/settings", {
+    data: PROWLARR_SETTINGS,
+  });
+  expect(settingsResponse.ok()).toBe(true);
+
+  await page.route("**/api/widget*", async (route) => {
+    const url = new URL(route.request().url());
+    const tileId = url.searchParams.get("tile_id");
+    if (tileId === TILE_ID) {
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          ok: true,
+          data: {
+            totalIndexers: 12,
+            enabledIndexers: 11,
+            failingIndexers: 1,
+            totalGrabs: 1_234,
+          },
+        }),
+      });
+      return;
+    }
+    await route.continue();
+  });
+
+  await page.goto("/");
+  const tile = prowlarrTile(page);
+  const widget = prowlarrWidget(page);
+  await expect(tile).toHaveCount(1);
+  await expect(tile.locator(".service-tile__name")).toHaveText("Prowlarr");
+  await expect(tile).toHaveClass(/service-tile--tall/);
+  await expect(widget).toBeVisible();
+  await expect(widget.locator(".prowlarr-stats-widget__stat")).toHaveCount(4);
+
+  const overflow = await widget.evaluate((element) => {
+    const widgetBounds = element.getBoundingClientRect();
+    const tileBounds = element.closest(".service-tile")!.getBoundingClientRect();
+    const statBounds = Array.from(
+      element.querySelectorAll(".prowlarr-stats-widget__stat")
+    ).map((stat) => {
+      const bounds = stat.getBoundingClientRect();
+      return { left: bounds.left, right: bounds.right, top: bounds.top, bottom: bounds.bottom };
+    });
+
+    return {
+      scrollHeight: element.scrollHeight,
+      clientHeight: element.clientHeight,
+      scrollWidth: element.scrollWidth,
+      clientWidth: element.clientWidth,
+      styleOverflowY: getComputedStyle(element).overflowY,
+      styleOverflowX: getComputedStyle(element).overflowX,
+      statsStayInside: statBounds.every(
+        (bounds) =>
+          bounds.left >= widgetBounds.left &&
+          bounds.right <= widgetBounds.right &&
+          bounds.top >= widgetBounds.top &&
+          bounds.bottom <= widgetBounds.bottom
+      ),
+      widgetStaysInsideTile:
+        widgetBounds.left >= tileBounds.left &&
+        widgetBounds.right <= tileBounds.right &&
+        widgetBounds.top >= tileBounds.top &&
+        widgetBounds.bottom <= tileBounds.bottom,
+      columns: new Set(statBounds.map((bounds) => Math.round(bounds.left))).size,
+      rows: new Set(statBounds.map((bounds) => Math.round(bounds.top))).size,
+    };
+  });
+  expect(overflow.scrollHeight).toBeLessThanOrEqual(overflow.clientHeight);
+  expect(overflow.scrollWidth).toBeLessThanOrEqual(overflow.clientWidth);
+  expect(overflow.styleOverflowY).toBe("hidden");
+  expect(overflow.styleOverflowX).toBe("hidden");
+  expect(overflow.statsStayInside).toBe(true);
+  expect(overflow.widgetStaysInsideTile).toBe(true);
+  expect(overflow.columns).toBe(2);
+  expect(overflow.rows).toBe(2);
+
+  await expect(page.locator(".service-tile--tall")).toBeVisible();
+});

--- a/src/__tests__/integrations/prowlarr.test.ts
+++ b/src/__tests__/integrations/prowlarr.test.ts
@@ -212,6 +212,16 @@ describe("prowlarr-stats widget registration", () => {
     expect(getWidget("prowlarr-stats")?.refreshInterval).toBe(60_000);
   });
 
+  it("defaults to a tall footprint (3x4)", async () => {
+    await import("@/integrations/prowlarr/statsWidget");
+    const { getWidget } = await import("@/widgets");
+    const definition = getWidget("prowlarr-stats");
+    expect(definition?.preferredSize).toBe("tall");
+    expect(definition?.supportedFootprints).toEqual([
+      { label: "Default", columnSpan: 3, rowSpan: 4 },
+    ]);
+  });
+
   it("configSchema accepts valid config", async () => {
     await import("@/integrations/prowlarr/statsWidget");
     const { getWidget } = await import("@/widgets");

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2571,6 +2571,10 @@ button {
 
 /* ── Prowlarr stats widget ───────────────────────────────────────────────── */
 
+.prowlarr-stats-widget {
+  overflow: hidden;
+}
+
 .prowlarr-stats-widget__value--alert {
   color: var(--color-error);
 }

--- a/src/integrations/prowlarr/statsWidget.tsx
+++ b/src/integrations/prowlarr/statsWidget.tsx
@@ -60,8 +60,8 @@ export function ProwlarrStatsWidget({
 registerWidget<ProwlarrConfig, ProwlarrStats>({
   id: "prowlarr-stats",
   name: "Prowlarr Stats",
-  preferredSize: "wide",
-  supportedFootprints: [{ label: "Default", columnSpan: 6, rowSpan: 2 }],
+  preferredSize: "tall",
+  supportedFootprints: [{ label: "Default", columnSpan: 3, rowSpan: 4 }],
   serviceEditorPreset: {
     defaultName: "Prowlarr",
     defaultIconUrl: "https://cdn.simpleicons.org/prowlarr",


### PR DESCRIPTION
## Summary

- change the Prowlarr stats widget default footprint from 6x2 to 3x4
- prevent Prowlarr stat content from showing scrollbars
- add unit and E2E regression coverage for the 2x2 pill layout and overflow bounds

## Validation

- `npm test` — 118 files, 1918 tests passed
- `npm run type-check` — passed
- `npm run lint` — passed with one pre-existing Netdata unused-type warning
- focused Playwright Prowlarr spec — passed
- in-app browser at 1440x1000: rendered tile 340x264, 2 columns x 2 rows, widget/tile scroll sizes equal client sizes, overflow hidden on both axes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sets the Prowlarr stats widget default footprint from wide 6x2 to tall 3x4 and hides widget overflow to remove scrollbars. This improves readability and prevents clipping; new widgets default to a 2x2 pill layout.

- Behavior change: preferredSize is now "tall" with a single supported footprint {3x4}; previously "wide" {6x2}.
- CSS sets `.prowlarr-stats-widget { overflow: hidden; }` to keep content within tile bounds.
- Tests: unit test asserts the new default footprint; Playwright E2E verifies a 2x2 pill grid, no scrollbars, and no overflow.

<sup>Written for commit a39f1bf358ebef1201b107eb7a780d9e7fda2d8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pmyszczynski/kokpit/pull/93?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

