### PR TITLE
chore: release v0.10.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kokpit",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "kokpit",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kokpit",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "engines": {
     "node": ">=22.19.0"


### PR DESCRIPTION
## Summary

- bump the application version from 0.9.0 to 0.10.0
- prepare the release containing the responsive Plex widget sizes and updated Immich/Prowlarr default footprints

## Validation

- version fields are consistent in package.json and package-lock.json
- release branch is based on the latest origin/main
- full PR diff contains only the two version files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Release v0.10.0 to ship responsive Plex widget sizes and updated default footprints for Immich and Prowlarr.

- Only changes are version bumps in `package.json` and `package-lock.json`; the features are already merged.
- Release branch is based on the latest `main`.
- No migrations or config changes required.

<sup>Written for commit 6309bc9281ae81d60c5fd01760a38b91c608103e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/pmyszczynski/kokpit/pull/95?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

